### PR TITLE
Debian should not manage root password

### DIFF
--- a/manifests/server/redhat.pp
+++ b/manifests/server/redhat.pp
@@ -1,0 +1,27 @@
+class mysql::server::redhat(
+  $root_password,
+  $old_root_password = ''
+) {
+  case $old_root_password {
+    '': {$old_pw=''}
+    default: {$old_pw="-p${old_root_password}"}
+  }
+  exec{ 'set_mysql_rootpw':
+    command   => "mysqladmin -u root ${old_pw} password ${root_password}",
+    #logoutput => on_failure,
+    logoutput => true,
+    unless   => "mysqladmin -u root -p${root_password} status > /dev/null",
+    path      => '/usr/local/sbin:/usr/bin',
+    require   => [Package['mysql-server'], Service['mysqld']],
+    before    => File['/root/.my.cnf'],
+    notify    => Exec['mysqld-restart'],
+  }
+  file{['/root/.my.cnf', '/etc/my.cnf']:
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0400',
+    content => template('mysql/my.cnf.erb'),
+    notify  => Exec['mysqld-restart'],
+    require => Package['mysql-server'],
+  }
+}


### PR DESCRIPTION
- previously setting the root password failed on 
  Debian b/c a root password was already set
  during package installation
- Debian already installs mysql with a 
  maintainance user capable of performing any
  required database actions.
- this patch splits setting of root password to
  be redhat specific.
- as a consequence, users will not be able to 
  specify a root password on Debian (which 
  needs to be opened as a seperate ticket)
