### PR TITLE
Refactor ruby package provider

### DIFF
--- a/manifests/ruby.pp
+++ b/manifests/ruby.pp
@@ -15,7 +15,8 @@
 #
 class mysql::ruby(
   $ensure = installed,
-  $package_name = $mysql::params::ruby_package_name 
+  $package_name = $mysql::params::ruby_package_name,
+  $package_provider = 'gem'
 ) inherits mysql::params {
   # I am not making the mysql package a dep for this
   # the only dep is the package which yum will resolve for me.
@@ -27,7 +28,7 @@ class mysql::ruby(
   package{'ruby-mysql':
   #  name => $ruby_mysql_name,
     name => $package_name, 
-    provider => 'gem',
+    provider => $package_provider,
     ensure   => $ensure,
   }
 }


### PR DESCRIPTION
Allow a parameter for the ruby-mysql package provider.  This
will allow you to use providers other than gem.
