### PR TITLE
Database should set charset on create.

### DIFF
--- a/lib/puppet/provider/database/mysql.rb
+++ b/lib/puppet/provider/database/mysql.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:database).provide(:mysql) do
   commands :mysqlshow  => 'mysqlshow'
 	
   def create
-    mysqladmin("--default-character-set=#{resource[:charset]}", 'create', @resource[:name])
+    mysql('-NBe', "CREATE DATABASE #{@resource[:name]} CHARACTER SET #{resource[:charset]}")
   end
 
   def destroy


### PR DESCRIPTION
Previously, the charset of the database was not
being set on create, causing puppet to have to
potentially run twice to update it.
