### PR TITLE
15 - Fix resource names in monitor.pp

### DIFF
--- a/manifests/server/monitor.pp
+++ b/manifests/server/monitor.pp
@@ -5,13 +5,13 @@ class mysql::server::monitor (
   $mysql_monitor_hostname
 ) {
 
-  mysql_user{ 
+  database_user{ 
     "${mysql_monitor_username}@${mysql_monitor_hostname}":
       password_hash => mysql_password($mysql_monitor_password),
       ensure        => present,
       require       => Service['mysqld'],
   }
-  mysql_grant { "${mysql_monitor_username}@${mysql_monitor_hostname}":
+  database_grant { "${mysql_monitor_username}@${mysql_monitor_hostname}":
     privileges    => [ 'process_priv', 'super_priv' ],
     require       => [ Mysql_user["${mysql_monitor_username}@${mysql_monitor_hostname}"], Service['mysqld']],
   }


### PR DESCRIPTION
This should fix issue #15. There was a minor syntax error in the file where we were referencing mysql_user and mysql_grant.
