### PR TITLE
(#10390) Manage /etc/mysql directory.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,6 +40,10 @@ class mysql::config(
     notify  => Exec['mysqld-restart'],
     require => Package['mysql-server']
   }
+  file { '/etc/mysql':
+    ensure => directory,
+    mode => '755',
+  }
 
   file { '/etc/mysql/my.cnf':
     content => template('mysql/my.cnf.erb'),


### PR DESCRIPTION
/etc/mysql/my.cnf was being managed and /etc/mysql was not.
This was causing failures if the directory was not created
by the package.

This commit manages it in case it was not created by the package.
