### PR TITLE
(#10391) Update docs to reflect config_hash.

### DIFF
--- a/README
+++ b/README
@@ -17,7 +17,7 @@ class { 'mysql::ruby': } - installs mysql bindings for ruby
 mysql::server - installs mysql-server, starts service, sets root_pw, and sets root
 
 class { 'mysql::server': 
-  root_password => 'foo'
+  config_hash => { 'root_password' => 'foo' }
 }
 
 login information in /etc/.my.cnf and /root/.my.cnf

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -4,8 +4,7 @@
 #   manages the package, service, my.cnf
 #
 # Parameters:
-#   [*root_password*]     - root password for database
-#   [*old_root_password*] - previous root password if being changed
+#   [*config_hash*]       - hash of config parameters that need to be set.
 #   [*service_name*]      - name of service
 #   [*package_name*]      - name of package
 #

--- a/tests/mysql_database.pp
+++ b/tests/mysql_database.pp
@@ -1,5 +1,5 @@
 class { 'mysql::server':
-  root_password => 'password',
+  config_hash => {'root_password' => 'password'}
 }
 database{['test1', 'test2', 'test3']:
   ensure => present,

--- a/tests/server.pp
+++ b/tests/server.pp
@@ -1,5 +1,6 @@
-#$mysql_old_pw='password2'
 class { 'mysql::server':
-  root_password => 'password',
-  #old_root_password => 'foo'
+  config_hash =>  {
+      'root_password' => 'password',
+      #'old_root_password' => 'puppet'
+    }
 }


### PR DESCRIPTION
Configuration was moved to config hash param of the mysql::server class.

This was done so that additional parameters can be
added in the future and not have to be added to
both mysql::config and mysql::server as class params

This patch updates the README, docs, and examples to
correctly use the parameter.
