### PR TITLE
Allow wildcards in account host names

### DIFF
--- a/lib/puppet/type/database_user.rb
+++ b/lib/puppet/type/database_user.rb
@@ -7,7 +7,7 @@ Puppet::Type.newtype(:database_user) do
   newparam(:name) do
     desc "The name of the user. This uses the 'username@hostname' or username@hosname."
     validate do |value|
-      unless value =~ /\w+@\w+/
+      unless value =~ /\w+@[\w%]+/
         raise ArgumentError, "Invalid database user #{value}"
       end
       list = value.split('@')

--- a/tests/mysql_user.pp
+++ b/tests/mysql_user.pp
@@ -1,6 +1,8 @@
 $mysql_root_pw='password'
 class { 'mysql::server':
-  root_password => 'password',
+  config_hash => {
+    root_password => 'password',
+  }
 }
 #database_user{['test1@localhost', 'test2@localhost', 'test3@localhost']:
 database_user{'redmine@localhost':
@@ -13,4 +15,9 @@ database_user{'redmine@localhost':
 database_user{'dan@localhost':
   ensure => present,
   password_hash => mysql_password('blah')
+}
+
+database_user{'dan@%':
+  ensure => present,
+  password_hash => mysql_password('blah'),
 }


### PR DESCRIPTION
Allow wildcard in the host part of MySQL accounts:
http://dev.mysql.com/doc/refman/5.0/en/grant.html#grant-accounts-passwords

Add a database_user test that contains a wildcard in the host name part.

Also, pass root_password to mysql::server in config_hash.
