### PR TITLE
Fully qualify $operatingsystem

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@
 #
 class mysql::params{
   $socket                   = '/var/run/mysqld/mysqld.sock'
-  case $operatingsystem {
+  case $::operatingsystem {
     'centos', 'redhat', 'fedora': {
       $service_name         = 'mysqld'
       $client_package_name  = 'mysql'


### PR DESCRIPTION
Fully qualify $operatingsystem from root scope as $::operatingsystem.
