### PR TITLE
(#11508) Only load sql_scripts on DB creation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,47 @@
+require 'rake'
+require 'fileutils'
+
+begin
+  require 'rspec/core/rake_task'
+  HAVE_RSPEC = true
+rescue LoadError
+  HAVE_RSPEC = false
+end
+
+task :default => [:build]
+
+def update_module_version
+  gitdesc = %x{git describe}.chomp
+  semver = gitdesc.gsub(/v?(\d+\.\d+\.\d+)-?(.*)/) do
+    newver = "#{$1}"
+    newver << "git-#{$2}" unless $2.empty?
+    newver
+  end
+  modulefile = File.read("Modulefile")
+  modulefile.gsub!(/^\s*version\s+'.*?'/, "version '#{semver}'")
+  File.open("Modulefile", 'w') do |f|
+    f.write(modulefile)
+  end
+  semver
+end
+
+desc "Build Puppet Module Package"
+task :build do
+  system("gimli README*.markdown")
+  FileUtils.cp "Modulefile", "Modulefile.bak"
+  update_module_version
+  system("puppet-module build")
+  FileUtils.mv "Modulefile.bak", "Modulefile"
+end
+
+desc "Clean the package directory"
+task :clean do
+  FileUtils.rm_rf("pkg/")
+end
+
+if HAVE_RSPEC then
+  desc 'Run all module spec tests (Requires rspec-puppet gem)'
+  task :spec do
+    system 'rspec --format d spec/'
+  end
+end

--- a/spec/classes/mysql_init_spec.rb
+++ b/spec/classes/mysql_init_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe 'mysql' do
+
+  it { should contain_class 'mysql' }
+end

--- a/spec/defines/mysql_db_spec.rb
+++ b/spec/defines/mysql_db_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'mysql::db', :type => :define do
+  let(:title) { 'test_db' }
+  let(:params) {
+    {'user'        => 'testuser',
+     'password'    => 'testpass',
+     'enforce_sql' => false,
+     'sql'         => 'test_sql',
+    }
+  }
+
+  it 'should set load of sql script to refreshonly' do
+    should create_resource('exec', 'test_db-import-import').with_param('refreshonly', true)
+  end
+end

--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,0 +1,6 @@
+--format
+s
+--colour
+--loadby
+mtime
+--backtrace

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'puppet'
+require 'rubygems'
+require 'rspec-puppet'
+
+RSpec.configure do |c|
+  c.module_path = File.join(File.dirname(__FILE__), '../../')
+end


### PR DESCRIPTION
Previous to this commit, if the sql parameter was provided to a
declaration of the mysql::db defined type, the defined type would always
load the sql script on every catalog run. This changes the exec that
loads that sql script to be refreshonly unless the enforce_sql parameter
is set to true.
