### PR TITLE
Only notify Exec to import sql if sql is given

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -46,7 +46,10 @@ define mysql::db (
     charset  => $charset,
     provider => 'mysql',
     require  => Class['mysql::server'],
-    notify   => Exec["${name}-import-import"],
+    notify   => $sql ? {
+      ''      => undef,
+      default => Exec["${name}-import-import"],
+    }
   }
 
   database_user{"${user}@${host}":
@@ -68,7 +71,7 @@ define mysql::db (
       command     => "/usr/bin/mysql -u ${user} -p${password} -h ${host} ${name} < ${sql}",
       logoutput   => true,
       refreshonly => $enforce_sql ? {
-        true => false,
+        true  => false,
         false => true,
       },
     }

--- a/spec/defines/mysql_db_spec.rb
+++ b/spec/defines/mysql_db_spec.rb
@@ -2,15 +2,29 @@ require 'spec_helper'
 
 describe 'mysql::db', :type => :define do
   let(:title) { 'test_db' }
+
   let(:params) {
-    {'user'        => 'testuser',
-     'password'    => 'testpass',
-     'enforce_sql' => false,
-     'sql'         => 'test_sql',
+    { 'user'     => 'testuser',
+      'password' => 'testpass',
     }
   }
 
-  it 'should set load of sql script to refreshonly' do
-    should create_resource('exec', 'test_db-import-import').with_param('refreshonly', true)
+  it 'should not notify the import sql exec if no sql script was provided' do
+    should contain_database('test_db').without_notify
+  end
+
+  it 'should notify exec to import sql if sql script is given' do
+    params.merge!({'sql' => 'test_sql'})
+    should contain_database('test_db').with_notify('Exec[test_db-import-import]')
+  end
+
+  it 'should only import sql script on creation if not enforcing' do
+    params.merge!({'sql' => 'test_sql', 'enforce_sql' => false})
+    should contain_exec('test_db-import-import').with_refreshonly(true)
+  end
+
+  it 'should import sql script on creation if enforcing' do
+    params.merge!({'sql' => 'test_sql', 'enforce_sql' => true})
+    should contain_exec('test_db-import-import').with_refreshonly(false)
   end
 end


### PR DESCRIPTION
Commit e3b9fd broke the mysql::db defined type by always notifying the
Exec[${name}-import-import] resource even though the resource may not be
declared if the $sql parameter was not given. This commit adds an
in-selector to only notify the Exec resource if the $sql parameter has a
value.  More extensive rspec-puppet tests have been provided to protect
against this in the future.
