### PR TITLE
(#11543 ) Make the user in mysql::db to database, not global

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -52,7 +52,7 @@ define mysql::db (
     }
   }
 
-  database_user{"${user}@${host}":
+  database_user{"${user}@${host}/${name}":
     ensure        => present,
     password_hash => mysql_password($password),
     provider      => 'mysql',

--- a/spec/defines/mysql_db_spec.rb
+++ b/spec/defines/mysql_db_spec.rb
@@ -6,6 +6,7 @@ describe 'mysql::db', :type => :define do
   let(:params) {
     { 'user'     => 'testuser',
       'password' => 'testpass',
+      'host'     => 'fake_host',
     }
   }
 
@@ -18,6 +19,10 @@ describe 'mysql::db', :type => :define do
     should contain_database('test_db').with_notify('Exec[test_db-import-import]')
   end
 
+  it 'should assign the user to the database' do
+    should contain_database_user('testuser@fake_host/test_db')
+  end
+
   it 'should only import sql script on creation if not enforcing' do
     params.merge!({'sql' => 'test_sql', 'enforce_sql' => false})
     should contain_exec('test_db-import-import').with_refreshonly(true)
@@ -26,5 +31,20 @@ describe 'mysql::db', :type => :define do
   it 'should import sql script on creation if enforcing' do
     params.merge!({'sql' => 'test_sql', 'enforce_sql' => true})
     should contain_exec('test_db-import-import').with_refreshonly(false)
+  end
+end
+
+describe 'mysql::db', :type => :define do
+  let(:title) { 'test_db_2' }
+
+  let(:params) {
+    { 'user'     => 'testuser',
+      'password' => 'testpass',
+      'host'     => 'fake_host',
+    }
+  }
+
+  it 'should allow for two resource with the same user' do
+    should contain_database_user('testuser@fake_host/test_db_2')
   end
 end


### PR DESCRIPTION
Previous to this commit, the mysql::db defined type managed a resource
of type database_user using the value of the user parameter passed in to
mysql::db.  This was problematic since if two different mysql::db
resources were declared with the same user, a duplicate resource error
would occur.

This commit resolves this by assigning the database_user resource to the
database being managed. Note this changes existing behavior and will
likely be cause for a major version release.
