### PR TITLE
Permissions too restrictive on /etc/mysql/my.cnf

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,19 +25,18 @@ class mysql::config(
     }
     file{'/root/.my.cnf':
       content => template('mysql/my.cnf.pass.erb'),
-      mode  => '0400',
     }
     if $etc_root_password {
        file{'/etc/my.cnf':
           content => template('mysql/my.cnf.pass.erb'),
           require => Exec['set_mysql_rootpw'],
-          mode  => '0400',
        }
     }
   }
   File {
     owner => 'root',
     group => 'root',
+    mode  => '0400',
     notify  => Exec['mysqld-restart'],
     require => Package['mysql-server']
   }
@@ -52,5 +51,6 @@ class mysql::config(
 
   file { '/etc/mysql/my.cnf':
     content => template('mysql/my.cnf.erb'),
+    mode    => '0644'
   }
 }


### PR DESCRIPTION
Since /etc/mysql/my.cnf contains the [client] section, normal
users need to be able to read that file.  We should set 0644
on /etc/mysql/my.cnf, but use 0400 on /etc/my.cnf and
/root/.my.cnf because they contain passwords in plaintext.

I gotta run, and won't be back until Tues Jan 3rd.  Let me know if I need to file a bug report -- if anyone wants to save me the trouble, I'd appreciate it :)
