### PR TITLE
Variables are incorrectly set in the default section of the case in params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,10 +22,8 @@ class mysql::params{
       $service_name         = 'mysql'
       $client_package_name  = 'mysql-client'
     }
-    default: {
-      $python_package_name  = 'python-mysqldb'
-      $ruby_package_name    = 'ruby-mysql'
-      $client_package_name  = 'mysql'
-    }
   }
+  $python_package_name  = 'python-mysqldb'
+  $ruby_package_name    = 'ruby-mysql'
+  $client_package_name  = 'mysql'
 }


### PR DESCRIPTION
99% of installations won't ever hit the default.

Moving the variables to just after the case statement will set
them, removing the default part of the case will cause this class
to fail on unsupported distros.
