### PR TITLE
(#12417) my.cnf baseline improvement

### DIFF
--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -1,33 +1,191 @@
+# =================================================================
+# Base configuration courtesy of Open Query (http://openquery.com/)
+# For production use, case-specific preparation is still required.
+# 2012-02-04
+#
+# This is *not* an optimised config, merely a more sane baseline:
+# - binary and slow log enabled, with enhancements
+# - InnoDB default (e.g., ACID out-of-the-box, same as on Windows)
+# - strict mode (for proper input checks, same as on Windows)
+# - various other useful settings
+#
+# For tuning assistance, please see http://openquery.com/services
+# =================================================================
+#
+# You can copy this file to one of:
+# - "/etc/mysql/my.cnf" to set global options,
+# - "~/.my.cnf" to set user-specific options.
+# 
+# One can use all long options that the program supports.
+# Run program with --help to get a list of available options and with
+# --print-defaults to see which it would actually understand and use.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+# This will be passed to all mysql clients
+# It has been reported that passwords should be enclosed with ticks/quotes
+# escpecially if they contain "#" chars...
+# Remember to edit /etc/mysql/debian.cnf when changing the socket location.
 [client]
-port    = <%= port %>
-socket    = /var/run/mysqld/mysqld.sock
+port		= <%= port %>
+socket		= /var/run/mysqld/mysqld.sock
+# Default is Latin1, if you need UTF-8 set this (also in server section)
+#default-character-set  = utf8 
+
+# Here is entries for some specific programs
+# The following values assume you have at least 32M ram
+
+# This was formally known as [safe_mysqld]. Both versions are currently parsed.
 [mysqld_safe]
-socket    = /var/run/mysqld/mysqld.sock
-nice    = 0
-[mysqld]
-user    = mysql
-socket    = /var/run/mysqld/mysqld.sock
-port      = <%= port %>
-basedir   = /usr
-datadir   = /var/lib/mysql
-tmpdir    = /tmp
+socket		= /var/run/mysqld/mysqld.sock
+nice		= 0
+
+[server]
+#
+# * Basic Settings
+#
+user		= mysql
+pid-file	= /var/run/mysqld/mysqld.pid
+socket		= /var/run/mysqld/mysqld.sock
+bind-address		= <%= bind_address %>
+port		= <%= port %>
+basedir		= /usr
+datadir		= /var/lib/mysql
+tmpdir		= /tmp
 skip-external-locking
-bind-address    = <%= bind_address %>
-key_buffer         = 16M
-max_allowed_packet = 16M
-thread_stack       = 192K
-thread_cache_size  = 8
-myisam-recover     = BACKUP
-query_cache_limit  = 1M
-query_cache_size   = 16M
-log_error          = /var/log/mysql/error.log
-expire_logs_days   = 10
-max_binlog_size    = 100M
+#
+# * Character sets
+# 
+# Default is Latin1, if you need UTF-8 set all this (also in client section)
+#
+#default-character-set  = utf8 
+#default-collation      = utf8_general_ci 
+#character_set_server   = utf8 
+#collation_server       = utf8_general_ci 
+#
+
+#
+# * Fine Tuning
+#
+max_connections		= 500
+connect_timeout		= 5
+wait_timeout		= 600
+max_allowed_packet	= 16M
+thread_cache_size       = 128
+sort_buffer_size	= 4M
+bulk_insert_buffer_size	= 16M
+tmp_table_size		= 32M
+max_heap_table_size	= 256M
+#
+# * MyISAM
+#
+# This replaces the startup script and checks MyISAM tables if needed
+# the first time they are touched. On error, make copy and try a repair.
+myisam_recover          = BACKUP
+key_buffer_size		= 128M
+open-files-limit	= 2000
+table_cache             = 400
+myisam_sort_buffer_size	= 512M
+concurrent_insert	= 2
+read_buffer_size	= 2M
+read_rnd_buffer_size	= 1M
+#
+# * Query Cache Configuration
+#
+# Cache only tiny result sets, so we can fit more in the query cache.
+query_cache_limit		= 128K
+query_cache_size		= 64M
+# for more write intensive setups, set to DEMAND or OFF
+#query_cache_type		= DEMAND
+#
+# * Logging and Replication
+#
+# Both location gets rotated by the cronjob.
+# Be aware that this log type is a performance killer.
+# As of 5.1 you can enable the log at runtime!
+#general_log_file        = /var/log/mysql/mysql.log
+#general_log             = 1
+#
+# Error logging goes to syslog due to /etc/mysql/conf.d/mysqld_safe_syslog.cnf.
+#
+# we do want to know about network errors and such
+log_warnings		= 2
+#
+# Here you can see queries with especially long duration
+log_slow_queries = 1
+#slow_query_log_file		= /var/log/mysql/mysql-slow.log
+long_query_time = 10
+#log_slow_rate_limit	= 1000
+#log_slow_verbosity	= query_plan
+
+# enable the two below if using MySQL-5.1 or later
+#log-queries-not-using-indexes = 1
+#min-examined-row-limit = 5000
+log_slow_admin_statements
+#
+# The following can be used as easy to replay backup logs or for replication.
+# note: if you are setting up a replication slave, see README.Debian about
+#       other settings you may need to change.
+#server-id		= 1
+#report_host		= master1
+#auto_increment_increment = 2
+#auto_increment_offset	= 1
+log_bin			= /var/log/mysql/mysql-bin
+log_bin_index		= /var/log/mysql/mysql-bin.index
+# not fab for performance, but safer
+#sync_binlog		= 1
+expire_logs_days	= 10
+max_binlog_size         = 100M
+# slaves
+#relay_log		= /var/log/mysql/relay-bin
+#relay_log_index	= /var/log/mysql/relay-bin.index
+#relay_log_info_file	= /var/log/mysql/relay-bin.info
+#log_slave_updates
+#read_only
+#
+#
+# * InnoDB
+#
+# InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
+# Read the manual for more InnoDB related options. There are many!
+default_storage_engine	= InnoDB
+sql_mode		= NO_ENGINE_SUBSTITUTION,TRADITIONAL
+# you can't just change log file size, requires special procedure
+#innodb_log_file_size	= 50M
+innodb_buffer_pool_size	= 512M
+innodb_log_buffer_size	= 8M
+innodb_file_per_table	= 1
+innodb_open_files	= 400
+innodb_io_capacity	= 400
+innodb_flush_method	= O_DIRECT
+#
+# * Security Features
+#
+# Read the manual, too, if you want chroot!
+# chroot = /var/lib/mysql/
+#
+# For generating SSL certificates I recommend the OpenSSL GUI "tinyca".
+#
+# ssl-ca=/etc/mysql/cacert.pem
+# ssl-cert=/etc/mysql/server-cert.pem
+# ssl-key=/etc/mysql/server-key.pem
+
+
+
 [mysqldump]
 quick
 quote-names
-max_allowed_packet = 16M
+max_allowed_packet	= 16M
+
 [mysql]
+#no-auto-rehash	# faster start of mysql but no tab completition
+
 [isamchk]
-key_buffer    = 16M
+key_buffer		= 16M
+
+#
+# * IMPORTANT: Additional settings that can override those from this file!
+#   The files must end with '.cnf', otherwise they'll be ignored.
+#
 !includedir /etc/mysql/conf.d/


### PR DESCRIPTION
Based off:
http://bazaar.launchpad.net/~ourdelta-core/ourdelta/trunk/view/head:/bakery/debian-5.1/additions/my.cnf

Removed a few mysql-5.0 incompatible things. Increased a few buffers
since RAM is more common and puppet users use production dbs and not
local test environments.
