### PR TITLE
#11963 In the mysql module the Exec[mysqld-restart] should have more in path

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,7 +32,7 @@ class mysql::config(
   $etc_root_password = $mysql::params::etc_root_password,
   $service_name      = $mysql::params::service_name,
   $config_file       = $mysql::params::config_file,
-  $socket            = $mysql::params::socket,
+  $socket            = $mysql::params::socket
 ) inherits mysql::params {
 
   Class['mysql::server'] -> Class['mysql::config']

--- a/spec/classes/mysql_server_spec.rb
+++ b/spec/classes/mysql_server_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'mysql::server' do
+  let (:facts) do
+    { :osfamily => 'Debian' }
+  end
+
+  it { should contain_package('mysql-server').with_ensure('present') }
+  it do should contain_service('mysqld').with(
+    'name'   => 'mysql',
+    'ensure' => 'running',
+    'enable' => 'true'
+  ) end
+
+  it { should contain_class 'mysql::config' }
+  it do should contain_exec('mysqld-restart').with(
+    'command'     => 'service mysql restart',
+    'logoutput'   => 'on_failure',
+    'path'        => '/sbin/:/usr/sbin/:/usr/bin/:/bin/',
+    'refreshonly' => 'true'
+  ) end
+end


### PR DESCRIPTION
As seen in the issue (https://projects.puppetlabs.com/issues/11963), there's already a fix waiting in another stalled pull-request containing other fixes.

Maybe this issue can be resolved separately ?
