### PR TITLE
Add documentation related to osfamily fact.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@ This module manages mysql on Linux (RedHat/Debian) distros. A native mysql provi
 
 ## Description
 
+This module uses the fact osfamily which is supported by Facter 1.6.1+. If you do not have facter 1.6.1 in your environment, the following manifests will provide the same functionality in site.pp (before declaring any node):
+
+    if ! $::osfamily {
+      case $::operatingsystem {
+        'RedHat', 'Fedora', 'CentOS', 'Scientific', 'SLC', 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS', 'OEL': {
+          $osfamily = 'RedHat'
+        }
+        'ubuntu', 'debian': {
+          $osfamily = 'Debian'
+        }
+        'SLES', 'SLED', 'OpenSuSE', 'SuSE': {
+          $osfamily = 'Suse'
+        }
+        'Solaris', 'Nexenta': {
+          $osfamily = 'Solaris'
+        }
+        default: {
+          $osfamily = $::operatingsystem
+        }
+      }
+    }
+
 This module is based on work by David Schmitt. The following contributor have contributed patches to this module (beyond Puppet Labs):
 
 * Christian G. Warden


### PR DESCRIPTION
In the refacter, osfamily requires facter 1.6.1+ so the readme is
updated with more information related to this change.
