### PR TITLE
(#13163) Datadir should be configurable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,6 +10,7 @@
 #   [*service_name*]      - mysql service name.
 #   [*config_file*]       - my.cnf configuration file path.
 #   [*socket*]            - mysql socket.
+#   [*datadir*]           - path to datadir.
 #
 # Actions:
 #
@@ -32,7 +33,8 @@ class mysql::config(
   $etc_root_password = $mysql::params::etc_root_password,
   $service_name      = $mysql::params::service_name,
   $config_file       = $mysql::params::config_file,
-  $socket            = $mysql::params::socket
+  $socket            = $mysql::params::socket,
+  $datadir           = $mysql::params::datadir
 ) inherits mysql::params {
 
   File {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class mysql::params {
   $port                = 3306
   $server_package_name = 'mysql-server'
   $etc_root_password   = false
+  $datadir             = '/var/lib/mysql'
 
   case $::operatingsystem {
     "Ubuntu": {

--- a/spec/classes/mysql_config_spec.rb
+++ b/spec/classes/mysql_config_spec.rb
@@ -2,11 +2,14 @@ require 'spec_helper'
 describe 'mysql::config' do
 
   let :constant_parameter_defaults do
-    {:root_password     => 'UNSET',
+    {
+     :root_password     => 'UNSET',
      :old_root_password => '',
      :bind_address      => '127.0.0.1',
      :port              => '3306',
-     :etc_root_password => false}
+     :etc_root_password => false,
+     :datadir           => '/var/lib/mysql'
+    }
   end
 
   describe 'with osfamily specific defaults' do
@@ -72,7 +75,8 @@ describe 'mysql::config' do
             :service_name => 'dans_mysql',
             :socket       => '/home/dan/mysql.sock',
             :bind_address => '0.0.0.0',
-            :port         => '3306'
+            :port         => '3306',
+            :datadir      => '/path/to/datadir'
           }
         ].each do |passed_params|
 
@@ -125,6 +129,7 @@ describe 'mysql::config' do
               expected_lines = [
                 "port    = #{param_values[:port]}",
                 "socket    = #{param_values[:socket]}",
+                "datadir   = #{param_values[:datadir]}",
                 "bind-address    = #{param_values[:bind_address]}"
               ]
               (content.split("\n") & expected_lines).should == expected_lines

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -9,7 +9,7 @@ user    = mysql
 socket    = <%= socket %>
 port      = <%= port %>
 basedir   = /usr
-datadir   = /var/lib/mysql
+datadir   = <%= datadir %>
 tmpdir    = /tmp
 skip-external-locking
 bind-address    = <%= bind_address %>


### PR DESCRIPTION
Previously datadir was hardcoded to /var/lib/mysql.
This commit makes datadir configurable for MySQL
installations with custom datadir paths.
