### PR TITLE
(#11963) Fix spec test due to path changes.

### DIFF
--- a/spec/classes/mysql_config_spec.rb
+++ b/spec/classes/mysql_config_spec.rb
@@ -92,7 +92,7 @@ describe 'mysql::config' do
 
             it { should contain_exec('mysqld-restart').with(
               :refreshonly => true,
-              :path        => '/sbin/:/usr/sbin/',
+              :path        => '/sbin/:/usr/sbin/:/usr/bin/:/bin/',
               :command     => "service #{param_values[:service_name]} restart"
             )}
 


### PR DESCRIPTION
Due to additional path in issue 11963 to mysql-restart, the config class
spec test have been updated to reflect these changes.
