### PR TITLE
Fix mysql service on Ubuntu.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -80,7 +80,6 @@ class mysql::config(
     }
   }
 
-
   file { '/etc/mysql':
     ensure => directory,
     mode   => '0755',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,15 @@ class mysql::params {
   $server_package_name = 'mysql-server'
   $etc_root_password   = false
 
+  case $::operatingsystem {
+    "Ubuntu": {
+      $service_provider = upstart
+    }
+    default: {
+      $service_provider = undef
+    }
+  }
+
   case $::osfamily {
     'RedHat': {
       $service_name          = 'mysqld'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -15,10 +15,11 @@
 # Sample Usage:
 #
 class mysql::server (
-  $package_name   = $mysql::params::server_package_name,
-  $package_ensure = 'present',
-  $service_name   = $mysql::params::service_name,
-  $config_hash    = {}
+  $package_name     = $mysql::params::server_package_name,
+  $package_ensure   = 'present',
+  $service_name     = $mysql::params::service_name,
+  $service_provider = $mysql::params::service_provider,
+  $config_hash      = {}
 ) inherits mysql::params {
 
   Class['mysql::server'] -> Class['mysql::config']
@@ -31,10 +32,11 @@ class mysql::server (
   }
 
   service { 'mysqld':
-    name    => $service_name,
-    ensure  => running,
-    enable  => true,
-    require => Package['mysql-server'],
+    name     => $service_name,
+    ensure   => running,
+    enable   => true,
+    require  => Package['mysql-server'],
+    provider => $service_provider,
   }
 
 }

--- a/spec/classes/mysql_server_spec.rb
+++ b/spec/classes/mysql_server_spec.rb
@@ -8,20 +8,36 @@ describe 'mysql::server' do
     }
   end
 
+  describe 'when ubuntu use upstart' do
+    let :facts do
+      { :osfamily => 'Debian',
+        :operatingsystem => 'Ubuntu',
+      }
+    end
+
+    it { should contain_service('mysqld').with(
+      :name     => 'mysql',
+      :ensure   => 'running',
+      :enable   => 'true',
+      :provider => 'upstart',
+      :require  => 'Package[mysql-server]'
+    )}
+  end
+
   describe 'with osfamily specific defaults' do
     {
       'Debian' => {
-         :service_name => 'mysql'
+        :service_name => 'mysql'
       },
       'Redhat' => {
-         :service_name => 'mysqld'
+        :service_name => 'mysqld'
       }
     }.each do |osfamily, osparams|
 
       describe "when osfamily is #{osfamily}" do
 
         let :facts do
-          {:osfamily => osfamily}
+          { :osfamily => osfamily }
         end
 
         [
@@ -39,7 +55,6 @@ describe 'mysql::server' do
             let :parameter_defaults do
               constant_parameter_defaults.merge(osparams)
             end
-
 
             let :params do
               passed_params
@@ -60,6 +75,8 @@ describe 'mysql::server' do
               :enable  => 'true',
               :require => 'Package[mysql-server]'
             )}
+
+            it { should contain_service('mysqld').without_provider }
           end
         end
       end


### PR DESCRIPTION
On Ubuntu, mysql should use upstart provider instead of init.d. This
change overrides the init provider until the issue with init provider
can be addressed.
