### PR TITLE
Fix spec test issues related to error message.

### DIFF
--- a/spec/classes/mysql_config_spec.rb
+++ b/spec/classes/mysql_config_spec.rb
@@ -171,7 +171,7 @@ describe 'mysql::config' do
     it 'should fail' do
       expect do
         subject
-      end.should raise_error(Puppet::Error, /Duplicate declaration/)
+      end.should raise_error(Puppet::Error, /Duplicate (declaration|definition)/)
     end
 
   end


### PR DESCRIPTION
The current spec tests was testing for an error message duplicate
declaration instead of duplicate definition. This change was introduced
by puppet issue #11451, so we test for both errors instead.
