### PR TITLE
(#13203) Add ssl support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,10 @@
 #   [*config_file*]       - my.cnf configuration file path.
 #   [*socket*]            - mysql socket.
 #   [*datadir*]           - path to datadir.
+#   [*ssl]                - enable ssl
+#   [*ssl_ca]             - path to ssl-ca
+#   [*ssl_cert]           - path to ssl-cert
+#   [*ssl_key]            - path to ssl-key
 #
 # Actions:
 #
@@ -34,7 +38,11 @@ class mysql::config(
   $service_name      = $mysql::params::service_name,
   $config_file       = $mysql::params::config_file,
   $socket            = $mysql::params::socket,
-  $datadir           = $mysql::params::datadir
+  $datadir           = $mysql::params::datadir,
+  $ssl               = $mysql::params::ssl,
+  $ssl_ca            = $mysql::params::ssl_ca,
+  $ssl_cert          = $mysql::params::ssl_cert,
+  $ssl_key           = $mysql::params::ssl_key
 ) inherits mysql::params {
 
   File {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,10 @@ class mysql::params {
   $server_package_name = 'mysql-server'
   $etc_root_password   = false
   $datadir             = '/var/lib/mysql'
+  $ssl                 = false
+  $ssl_ca              = '/etc/mysql/cacert.pem'
+  $ssl_cert            = '/etc/mysql/server-cert.pem'
+  $ssl_key             = '/etc/mysql/server-key.pem'
 
   case $::operatingsystem {
     "Ubuntu": {

--- a/spec/classes/mysql_config_spec.rb
+++ b/spec/classes/mysql_config_spec.rb
@@ -8,7 +8,11 @@ describe 'mysql::config' do
      :bind_address      => '127.0.0.1',
      :port              => '3306',
      :etc_root_password => false,
-     :datadir           => '/var/lib/mysql'
+     :datadir           => '/var/lib/mysql',
+     :ssl               => false,
+     :ssl_ca            => '/etc/mysql/cacert.pem',
+     :ssl_cert          => '/etc/mysql/server-cert.pem',
+     :ssl_key           => '/etc/mysql/server-key.pem'
     }
   end
 
@@ -76,7 +80,11 @@ describe 'mysql::config' do
             :socket       => '/home/dan/mysql.sock',
             :bind_address => '0.0.0.0',
             :port         => '3306',
-            :datadir      => '/path/to/datadir'
+            :datadir      => '/path/to/datadir',
+            :ssl          => true,
+            :ssl_ca       => '/path/to/cacert.pem',
+            :ssl_cert     => '/path/to/server-cert.pem',
+            :ssl_key      => '/path/to/server-key.pem'
           }
         ].each do |passed_params|
 
@@ -132,6 +140,14 @@ describe 'mysql::config' do
                 "datadir   = #{param_values[:datadir]}",
                 "bind-address    = #{param_values[:bind_address]}"
               ]
+              if param_values[:ssl]
+                expected_lines = expected_lines |
+                  [
+                    "ssl-ca    = #{param_values[:ssl_ca]}",
+                    "ssl-cert  = #{param_values[:ssl_cert]}",
+                    "ssl-key   = #{param_values[:ssl_key]}"
+                  ]
+              end
               (content.split("\n") & expected_lines).should == expected_lines
             end
           end

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -23,6 +23,13 @@ query_cache_size   = 16M
 log_error          = /var/log/mysql/error.log
 expire_logs_days   = 10
 max_binlog_size    = 100M
+
+<% if ssl == true %>
+ssl-ca    = <%= ssl_ca %>
+ssl-cert  = <%= ssl_cert %>
+ssl-key   = <%= ssl_key %>
+<% end %>
+
 [mysqldump]
 quick
 quote-names


### PR DESCRIPTION
This commit adds a ssl parameter to the mysql::config class.
Setting ssl to true adds the following parameters to the template.

   ssl_ca             - path to ssl-ca
   ssl_cert           - path to ssl-cert
   ssl_key            - path to ssl-key
