### PR TITLE
Add event_priv and trigger_priv to db_privs

### DIFF
--- a/lib/puppet/provider/database_grant/mysql.rb
+++ b/lib/puppet/provider/database_grant/mysql.rb
@@ -15,7 +15,8 @@ MYSQL_USER_PRIVS = [ :select_priv, :insert_priv, :update_priv, :delete_priv,
 MYSQL_DB_PRIVS = [ :select_priv, :insert_priv, :update_priv, :delete_priv,
   :create_priv, :drop_priv, :grant_priv, :references_priv, :index_priv,
   :alter_priv, :create_tmp_table_priv, :lock_tables_priv, :create_view_priv,
-  :show_view_priv, :create_routine_priv, :alter_routine_priv, :execute_priv
+  :show_view_priv, :create_routine_priv, :alter_routine_priv, :execute_priv,
+  :event_priv, :trigger_priv
 ]
 
 Puppet::Type.type(:database_grant).provide(:mysql) do


### PR DESCRIPTION
Two new priveleges were added in 5.1.6 (event_priv,
trigger_priv) This commit adds these new privs to the
db privs.

Previously, these privs were only added to the list of
privs for the users table and not the db table.
