### PR TITLE
set platform dependent error logfile location

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -42,7 +42,8 @@ class mysql::config(
   $ssl               = $mysql::params::ssl,
   $ssl_ca            = $mysql::params::ssl_ca,
   $ssl_cert          = $mysql::params::ssl_cert,
-  $ssl_key           = $mysql::params::ssl_key
+  $ssl_key           = $mysql::params::ssl_key,
+  $log_error         = $mysql::params::log_error
 ) inherits mysql::params {
 
   File {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,6 +37,7 @@ class mysql::params {
       $client_package_name   = 'mysql'
       $socket                = '/var/lib/mysql/mysql.sock'
       $config_file           = '/etc/my.cnf'
+      $log_error             = '/var/log/mysqld.log'
       $ruby_package_name     = 'ruby-mysql'
       $ruby_package_provider = 'gem'
       $python_package_name   = 'MySQL-python'
@@ -47,6 +48,7 @@ class mysql::params {
       $client_package_name  = 'mysql-client'
       $socket               = '/var/run/mysqld/mysqld.sock'
       $config_file          = '/etc/mysql/my.cnf'
+      $log_error            = '/var/log/mysql/error.log'
       $ruby_package_name    = 'libmysql-ruby'
       $python_package_name  = 'python-mysqldb'
     }

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -20,7 +20,7 @@ thread_cache_size  = 8
 myisam-recover     = BACKUP
 query_cache_limit  = 1M
 query_cache_size   = 16M
-log_error          = /var/log/mysql/error.log
+log_error          = <%= log_error %>
 expire_logs_days   = 10
 max_binlog_size    = 100M
 


### PR DESCRIPTION
The default location for log-error is /var/log/mysqld.log
on Fedora and RHEL
