### PR TITLE
I noticed the following message whilst provisioning using this module:

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -75,7 +75,8 @@ class mysql::config(
       logoutput => true,
       unless    => "mysqladmin -u root -p${root_password} status > /dev/null",
       path      => '/usr/local/sbin:/usr/bin',
-      notify    => Exec['mysqld-restart']
+      notify    => Exec['mysqld-restart'],
+      require   => File['/etc/mysql/conf.d'],
     }
 
     file { '/root/.my.cnf':


### PR DESCRIPTION
notice: /Stage[main]/Mysql::Config/Exec[set_mysql_rootpw]/returns: mysqladmin: Can't read dir of '/etc/mysql/conf.d/' (Errcode: 2)

Even though it's not fatal, it's cleaner for Exec['set_mysql_rootpw'] to require File['/etc/mysql/conf.d'].
