### PR TITLE
Added mysql::server::account_security class.

### DIFF
--- a/manifests/server/account_security.pp
+++ b/manifests/server/account_security.pp
@@ -1,0 +1,13 @@
+class mysql::server::account_security {
+  # Some installations have some default users which are not required.
+  # We remove them here. You can subclass this class to overwrite this behavior.
+  database_user { [ "root@${::fqdn}", "root@${::hostname}", 'root@127.0.0.1',
+                    "@${::fqdn}", "@${::hostname}", '@localhost', '@%' ]:
+    ensure  => 'absent',
+    require => Class['mysql::config'],
+  }
+  database { 'test':
+    ensure  => 'absent',
+    require => Class['mysql::config'],
+  }
+}

--- a/spec/classes/mysql_server_account_security_spec.rb
+++ b/spec/classes/mysql_server_account_security_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'mysql::server::account_security' do
+
+  let :facts do {
+    :fqdn     => 'myhost.mydomain',
+    :hostname => 'myhost'
+  }
+  end
+
+  it 'should remove Database_User[root@myhost.mydomain]' do
+    should contain_database_user('root@myhost.mydomain').with_ensure('absent')
+  end
+  it 'should remove Database_User[root@myhost]' do
+    should contain_database_user('root@myhost').with_ensure('absent')
+  end
+  it 'should remove Database_User[root@127.0.0.1]' do
+    should contain_database_user('root@127.0.0.1').with_ensure('absent')
+  end
+  it 'should remove Database_User[@myhost.mydomain]' do
+    should contain_database_user('@myhost.mydomain').with_ensure('absent')
+  end
+  it 'should remove Database_User[@myhost]' do
+    should contain_database_user('@myhost').with_ensure('absent')
+  end
+  it 'should remove Database_User[@localhost]' do
+    should contain_database_user('@localhost').with_ensure('absent')
+  end
+  it 'should remove Database_User[@%]' do
+    should contain_database_user('@%').with_ensure('absent')
+  end
+
+  it 'should remove Database[test]' do
+    should contain_database('test').with_ensure('absent')
+  end
+
+end

--- a/tests/server/account_security.pp
+++ b/tests/server/account_security.pp
@@ -1,0 +1,4 @@
+class { 'mysql::server':
+  config_hash => { 'root_password' => 'password', },
+}
+class { 'mysql::server::account_security': }


### PR DESCRIPTION
Secures the MySQL installation by removing the test database and the default users that are created during the MySQL first-run (root@${fqdn}, @%, @localhost, etc.).  Includes rspec tests and updated documentation.
