### PR TITLE
Specify the defaults file to use when executing the mysql command

### DIFF
--- a/lib/puppet/provider/database/mysql.rb
+++ b/lib/puppet/provider/database/mysql.rb
@@ -8,13 +8,13 @@ Puppet::Type.type(:database).provide(:mysql) do
   optional_commands :mysqladmin => 'mysqladmin'
 
   def self.instances
-    mysql('-NBe', "show databases").split("\n").collect do |name|
+    mysql('--defaults-file=~root/.my.cnf', '-NBe', "show databases").split("\n").collect do |name|
       new(:name => name)
     end
   end
 
   def create
-    mysql('-NBe', "create database #{@resource[:name]} character set #{resource[:charset]}")
+    mysql('--defaults-file=~root/.my.cnf', '-NBe', "create database #{@resource[:name]} character set #{resource[:charset]}")
   end
 
   def destroy
@@ -22,16 +22,16 @@ Puppet::Type.type(:database).provide(:mysql) do
   end
 
   def charset
-    mysql('-NBe', "show create database #{resource[:name]}").match(/.*?(\S+)\s\*\//)[1]
+    mysql('--defaults-file=~root/.my.cnf', '-NBe', "show create database #{resource[:name]}").match(/.*?(\S+)\s\*\//)[1]
   end
 
   def charset=(value)
-    mysql('-NBe', "alter database #{resource[:name]} CHARACTER SET #{value}")
+    mysql('--defaults-file=~root/.my.cnf', '-NBe', "alter database #{resource[:name]} CHARACTER SET #{value}")
   end
 
   def exists?
     begin
-      mysql('-NBe', "show databases").match(/^#{@resource[:name]}$/)
+      mysql('--defaults-file=~root/.my.cnf', '-NBe', "show databases").match(/^#{@resource[:name]}$/)
     rescue => e
       debug(e.message)
       return nil

--- a/lib/puppet/provider/database_grant/mysql.rb
+++ b/lib/puppet/provider/database_grant/mysql.rb
@@ -74,11 +74,11 @@ Puppet::Type.type(:database_grant).provide(:mysql) do
       name = split_name(@resource[:name])
       case name[:type]
       when :user
-        mysql "mysql", "-e", "INSERT INTO user (host, user) VALUES ('%s', '%s')" % [
+        mysql '--defaults-file=~root/.my.cnf', "-e", "INSERT INTO user (host, user) VALUES ('%s', '%s')" % [
           name[:host], name[:user],
         ]
       when :db
-        mysql "mysql", "-e", "INSERT INTO db (host, user, db) VALUES ('%s', '%s', '%s')" % [
+        mysql '--defaults-file=~root/.my.cnf', "-e", "INSERT INTO db (host, user, db) VALUES ('%s', '%s', '%s')" % [
           name[:host], name[:user], name[:db],
         ]
       end
@@ -87,7 +87,7 @@ Puppet::Type.type(:database_grant).provide(:mysql) do
   end
 
   def destroy
-    mysql "mysql", "-e", "REVOKE ALL ON '%s'.* FROM '%s@%s'" % [ @resource[:privileges], @resource[:database], @resource[:name], @resource[:host] ]
+    mysql '--defaults-file=~root/.my.cnf', "-e", "REVOKE ALL ON '%s'.* FROM '%s@%s'" % [ @resource[:privileges], @resource[:database], @resource[:name], @resource[:host] ]
   end
 
   def row_exists?
@@ -96,7 +96,7 @@ Puppet::Type.type(:database_grant).provide(:mysql) do
     if name[:type] == :db
       fields << :db
     end
-    not mysql( "mysql", "-NBe", 'SELECT "1" FROM %s WHERE %s' % [ name[:type], fields.map do |f| "%s = '%s'" % [f, name[f]] end.join(' AND ')]).empty?
+    not mysql( '--defaults-file=~root/.my.cnf', "-NBe", 'SELECT "1" FROM %s WHERE %s' % [ name[:type], fields.map do |f| "%s = '%s'" % [f, name[f]] end.join(' AND ')]).empty?
   end
 
   def all_privs_set?
@@ -118,9 +118,9 @@ Puppet::Type.type(:database_grant).provide(:mysql) do
 
     case name[:type]
     when :user
-      privs = mysql "mysql", "-Be", 'select * from user where user="%s" and host="%s"' % [ name[:user], name[:host] ]
+      privs = mysql '--defaults-file=~root/.my.cnf', "-Be", 'select * from mysql.user where user="%s" and host="%s"' % [ name[:user], name[:host] ]
     when :db
-      privs = mysql "mysql", "-Be", 'select * from db where user="%s" and host="%s" and db="%s"' % [ name[:user], name[:host], name[:db] ]
+      privs = mysql '--defaults-file=~root/.my.cnf', "-Be", 'select * from mysql.db where user="%s" and host="%s" and db="%s"' % [ name[:user], name[:host], name[:db] ]
     end
 
     if privs.match(/^$/)
@@ -166,7 +166,7 @@ Puppet::Type.type(:database_grant).provide(:mysql) do
     # puts "set:", set
     stmt = stmt << set << where
 
-    mysql "mysql", "-Be", stmt
+    mysql '--defaults-file=~root/.my.cnf', "-Be", stmt
     mysql_flush
   end
 end

--- a/lib/puppet/provider/database_user/mysql.rb
+++ b/lib/puppet/provider/database_user/mysql.rb
@@ -8,30 +8,30 @@ Puppet::Type.type(:database_user).provide(:mysql) do
   optional_commands :mysqladmin => 'mysqladmin'
 
   def self.instances
-    users = mysql("mysql", '-BNe' "select concat(User, '@',Host) as User from mysql.user").split("\n")
+    users = mysql('--defaults-file=~root/.my.cnf', '-BNe' "select concat(User, '@',Host) as User from mysql.user").split("\n")
     users.select{ |user| user =~ /.+@/ }.collect do |name|
       new(:name => name)
     end
   end
 
   def create
-    mysql("mysql", "-e", "create user '%s' identified by PASSWORD '%s'" % [ @resource[:name].sub("@", "'@'"), @resource.value(:password_hash) ])
+    mysql('--defaults-file=~root/.my.cnf', "-e", "create user '%s' identified by PASSWORD '%s'" % [ @resource[:name].sub("@", "'@'"), @resource.value(:password_hash) ])
   end
 
   def destroy
-    mysql("mysql", "-e", "drop user '%s'" % @resource.value(:name).sub("@", "'@'") )
+    mysql('--defaults-file=~root/.my.cnf', "-e", "drop user '%s'" % @resource.value(:name).sub("@", "'@'") )
   end
 
   def password_hash
-    mysql("mysql", "-NBe", "select password from user where CONCAT(user, '@', host) = '%s'" % @resource.value(:name)).chomp
+    mysql('--defaults-file=~root/.my.cnf', "-NBe", "select password from mysql.user where CONCAT(user, '@', host) = '%s'" % @resource.value(:name)).chomp
   end
 
   def password_hash=(string)
-    mysql("mysql", "-e", "SET PASSWORD FOR '%s' = '%s'" % [ @resource[:name].sub("@", "'@'"), string ] )
+    mysql('--defaults-file=~root/.my.cnf', "-e", "SET PASSWORD FOR '%s' = '%s'" % [ @resource[:name].sub("@", "'@'"), string ] )
   end
 
   def exists?
-    not mysql("mysql", "-NBe", "select '1' from user where CONCAT(user, '@', host) = '%s'" % @resource.value(:name)).empty?
+    not mysql('--defaults-file=~root/.my.cnf', "-NBe", "select '1' from mysql.user where CONCAT(user, '@', host) = '%s'" % @resource.value(:name)).empty?
   end
 
   def flush


### PR DESCRIPTION
I ran into a problem with the mysql providers when running 'sudo puppet agent -t'.  The mysql command did not look in root's home directory for the defaults file as expected, but rather in the home directory of the user running the sudo command, because puppet had not been run in a root login session.  The simple fix for this is to specify the defaults file.
