### PR TITLE
(#14316) Make privileges case-insensitive

### DIFF
--- a/lib/puppet/provider/database_grant/mysql.rb
+++ b/lib/puppet/provider/database_grant/mysql.rb
@@ -36,13 +36,13 @@ Puppet::Type.type(:database_grant).provide(:mysql) do
   def self.query_user_privs
     results = mysql("mysql", "-Be", "describe user")
     column_names = results.split(/\n/).map { |l| l.chomp.split(/\t/)[0] }
-    @user_privs = column_names.delete_if { |e| !( e =~/_priv$/) }.map! { |p| p.intern }
+    @user_privs = column_names.delete_if { |e| !( e =~/_priv$/) }
   end
 
   def self.query_db_privs
     results = mysql("mysql", "-Be", "describe db")
     column_names = results.split(/\n/).map { |l| l.chomp.split(/\t/)[0] }
-    @db_privs = column_names.delete_if { |e| !(e =~/_priv$/) }.map! { |p| p.intern }
+    @db_privs = column_names.delete_if { |e| !(e =~/_priv$/) }
   end
 
   def mysql_flush
@@ -106,8 +106,8 @@ Puppet::Type.type(:database_grant).provide(:mysql) do
                 when :db
                   db_privs
                 end
-    all_privs = all_privs.collect do |p| p.to_s end.sort.join("|")
-    privs = privileges.collect do |p| p.to_s end.sort.join("|")
+    all_privs = all_privs.collect do |p| p.downcase end.sort.join("|")
+    privs = privileges.collect do |p| p.downcase end.sort.join("|")
 
     all_privs == privs
   end
@@ -133,7 +133,7 @@ Puppet::Type.type(:database_grant).provide(:mysql) do
       privs = privs.select do |p| p[0].match(/_priv$/) and p[1] == 'Y' end
     end
 
-    privs.collect do |p| symbolize(p[0]) end
+    privs.collect do |p| p[0] end
   end
 
   def privileges=(privs)
@@ -157,12 +157,17 @@ Puppet::Type.type(:database_grant).provide(:mysql) do
       all_privs = db_privs
     end
 
-    if privs[0] == :all
+    if privs[0].downcase == 'all'
       privs = all_privs
     end
 
+    # Downcase the requested priviliges for case-insensitive selection
+    # we don't map! here because the all_privs object has to remain in
+    # the same case the DB gave it to us in
+    privs = privs.map { |p| p.downcase }
+
     # puts "stmt:", stmt
-    set = all_privs.collect do |p| "%s = '%s'" % [p, privs.include?(p) ? 'Y' : 'N'] end.join(', ')
+    set = all_privs.collect do |p| "%s = '%s'" % [p, privs.include?(p.downcase) ? 'Y' : 'N'] end.join(', ')
     # puts "set:", set
     stmt = stmt << set << where
 

--- a/lib/puppet/type/database_grant.rb
+++ b/lib/puppet/type/database_grant.rb
@@ -31,16 +31,13 @@ Puppet::Type.newtype(:database_grant) do
 
   newproperty(:privileges, :array_matching => :all) do
     desc "The privileges the user should have. The possible values are implementation dependent."
-    munge do |v|
-      symbolize(v)
-    end
 
     def should_to_s(newvalue = @should)
       if newvalue
         unless newvalue.is_a?(Array)
           newvalue = [ newvalue ]
         end
-        newvalue.collect do |v| v.to_s end.sort.join ", "
+        newvalue.collect do |v| v.downcase end.sort.join ", "
       else
         nil
       end
@@ -51,7 +48,7 @@ Puppet::Type.newtype(:database_grant) do
         unless currentvalue.is_a?(Array)
           currentvalue = [ currentvalue ]
         end
-        currentvalue.collect do |v| v.to_s end.sort.join ", "
+        currentvalue.collect do |v| v.downcase end.sort.join ", "
       else
         nil
       end


### PR DESCRIPTION
Before #65, privileges were not case sensitive. This patch restores that behavior.
