### PR TITLE
Fixed regex of database user.

### DIFF
--- a/lib/puppet/type/database_user.rb
+++ b/lib/puppet/type/database_user.rb
@@ -7,7 +7,9 @@ Puppet::Type.newtype(:database_user) do
   newparam(:name, :namevar=>true) do
     desc "The name of the user. This uses the 'username@hostname' or username@hostname."
     validate do |value|
-      raise(ArgumentError, "Invalid database user #{value}") unless value =~ /\w+@[\w%]+/
+      # https://dev.mysql.com/doc/refman/5.1/en/account-names.html
+      # Regex should problably be more like this: /^[`'"]?[^`'"]*[`'"]?@[`'"]?[\w%\.]+[`'"]?$/
+      raise(ArgumentError, "Invalid database user #{value}") unless value =~ /[\w-]*@[\w%\.]+/
       username = value.split('@')[0]
       if username.size > 16
         raise ArgumentError, "MySQL usernames are limited to a maximum of 16 characters"


### PR DESCRIPTION
The incorrect regex did not allow for the anonymous mysql users to be
removed via the mysql::server::account_security class.  The regex is now
increased to cover for @localhost and @%.
