### PR TITLE
Escape $root_password during execs.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -81,13 +81,13 @@ class mysql::config(
   if $root_password != 'UNSET' {
     case $old_root_password {
       '':      { $old_pw='' }
-      default: { $old_pw="-p${old_root_password}" }
+      default: { $old_pw="-p'${old_root_password}'" }
     }
 
     exec { 'set_mysql_rootpw':
-      command   => "mysqladmin -u root ${old_pw} password ${root_password}",
+      command   => "mysqladmin -u root ${old_pw} password '${root_password}'",
       logoutput => true,
-      unless    => "mysqladmin -u root -p${root_password} status > /dev/null",
+      unless    => "mysqladmin -u root -p'${root_password}' status > /dev/null",
       path      => '/usr/local/sbin:/usr/bin:/usr/local/bin',
       notify    => Exec['mysqld-restart'],
       require   => File['/etc/mysql/conf.d'],

--- a/spec/classes/mysql_config_spec.rb
+++ b/spec/classes/mysql_config_spec.rb
@@ -59,9 +59,9 @@ describe 'mysql::config' do
           end
 
           it { should contain_exec('set_mysql_rootpw').with(
-            'command'   => 'mysqladmin -u root  password foo',
+            'command'   => 'mysqladmin -u root  password \'foo\'',
             'logoutput' => true,
-            'unless'    => "mysqladmin -u root -pfoo status > /dev/null",
+            'unless'    => "mysqladmin -u root -p\'foo\' status > /dev/null",
             'path'      => '/usr/local/sbin:/usr/bin:/usr/local/bin'
           )}
 
@@ -78,9 +78,9 @@ describe 'mysql::config' do
           end
 
           it { should contain_exec('set_mysql_rootpw').with(
-            'command'   => 'mysqladmin -u root -pbar password foo',
+            'command'   => 'mysqladmin -u root -p\'bar\' password \'foo\'',
             'logoutput' => true,
-            'unless'    => "mysqladmin -u root -pfoo status > /dev/null",
+            'unless'    => "mysqladmin -u root -p\'foo\' status > /dev/null",
             'path'      => '/usr/local/sbin:/usr/bin:/usr/local/bin'
           )}
 
@@ -186,9 +186,9 @@ describe 'mysql::config' do
     end
 
     it { should contain_exec('set_mysql_rootpw').with(
-      'command'   => 'mysqladmin -u root -pbar password foo',
+      'command'   => 'mysqladmin -u root -p\'bar\' password \'foo\'',
       'logoutput' => true,
-      'unless'    => "mysqladmin -u root -pfoo status > /dev/null",
+      'unless'    => "mysqladmin -u root -p\'foo\' status > /dev/null",
       'path'      => '/usr/local/sbin:/usr/bin:/usr/local/bin'
     )}
 


### PR DESCRIPTION
Some characters used in a password can cause the shell in an exec to do
unexpected things unless the password is enclosed in single quotes.

Try putting ';' in the middle of your password to test how interestingly it fails.
