### PR TITLE
Add enabled parameter to mysql::server

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -19,7 +19,8 @@ class mysql::server (
   $package_ensure   = 'present',
   $service_name     = $mysql::params::service_name,
   $service_provider = $mysql::params::service_provider,
-  $config_hash      = {}
+  $config_hash      = {},
+  $enabled          = true
 ) inherits mysql::params {
 
   Class['mysql::server'] -> Class['mysql::config']
@@ -34,10 +35,16 @@ class mysql::server (
     ensure => $package_ensure,
   }
 
+  if $enabled {
+    $service_ensure = 'running'
+  } else {
+    $service_ensure = 'stopped'
+  }
+
   service { 'mysqld':
     name     => $service_name,
-    ensure   => running,
-    enable   => true,
+    ensure   => $service_ensure,
+    enable   => $enabled,
     require  => Package['mysql-server'],
     provider => $service_provider,
   }

--- a/spec/classes/mysql_server_spec.rb
+++ b/spec/classes/mysql_server_spec.rb
@@ -4,6 +4,7 @@ describe 'mysql::server' do
   let :constant_parameter_defaults do
     {:config_hash    => {},
      :package_ensure => 'present',
+     :enabled        => true
     }
   end
 
@@ -51,7 +52,8 @@ describe 'mysql::server' do
             :package_name   => 'dans_package',
             :package_ensure => 'latest',
             :service_name   => 'dans_service',
-            :config_hash    => {'root_password' => 'foo'}
+            :config_hash    => {'root_password' => 'foo'},
+            :enabled        => false
           }
         ].each do |passed_params|
 
@@ -76,8 +78,8 @@ describe 'mysql::server' do
 
             it { should contain_service('mysqld').with(
               :name    => param_values[:service_name],
-              :ensure  => 'running',
-              :enable  => 'true',
+              :ensure  => param_values[:enabled] ? 'running' : 'stopped',
+              :enable  => param_values[:enabled],
               :require => 'Package[mysql-server]'
             )}
 


### PR DESCRIPTION
This parameter can be used to specify whether the service
should be running.

It has been implemented to allow installations of mysql::server to
be in passive mode for HA.
