### PR TITLE
Ticket 15490/myqlbackup improvements

### DIFF
--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -19,5 +19,5 @@ PATH=/usr/bin:/usr/sbin:/bin:/sbin
 
 nice -n 10 find $DIR -mtime +30 -exec rm -f {} \;
 nice -n 10 mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \
- --all-databases | nice -n 10 bzcat -zc > ${DIR}/mysql_backup_`date +%Y%m%d-%H%M%S`.sql.bz2
+ --all-databases --master-data=2 | nice -n 10 bzcat -zc > ${DIR}/mysql_backup_`date +%Y%m%d-%H%M%S`.sql.bz2
 


### PR DESCRIPTION
nice to reduce cpu and io.

second commit could be problematic. When bin logging isn't enabled it errors with:
mysqldump: Error: Binlogging on server not active

acceptable?
