### PR TITLE
err: /Stage[main]/Mysql::Server/Service[mysql]: Could not evaluate: undefined method `read_script_from' for #<Puppet::Type::Service::ProviderUpstart:0xb7411b50>

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -34,19 +34,4 @@ class mysql::server (
     name   => $package_name,
     ensure => $package_ensure,
   }
-
-  if $enabled {
-    $service_ensure = 'running'
-  } else {
-    $service_ensure = 'stopped'
-  }
-
-  service { 'mysqld':
-    name     => $service_name,
-    ensure   => $service_ensure,
-    enable   => $enabled,
-    require  => Package['mysql-server'],
-    provider => $service_provider,
-  }
-
 }


### PR DESCRIPTION
Fixes: https://projects.puppetlabs.com/issues/15553

In my nodes.pp files I have this setup

<pre>
class { 'mysql::server':
    config_hash => { root_password => $mysql_root_password }
}
</pre>

When I run the agent, I get this error:

<pre>
debug: /Stage[main]/Pe_mcollective::Plugins/File[/opt/puppet/libexec/mcollective/mcollective/agent/service.ddl]: Autorequiring File[/opt/puppet/libexec/mcollective/mcollective/agent]
debug: /Schedule[daily]: Skipping device resources because running on a host
debug: /Schedule[monthly]: Skipping device resources because running on a host
debug: /Schedule[hourly]: Skipping device resources because running on a host
debug: Prefetching apt resources for package
debug: Executing '/usr/bin/dpkg-query -W --showformat '${Status} ${Package} ${Version}\n''
debug: Puppet::Type::Package::ProviderApt: Executing '/usr/bin/dpkg-query -W --showformat '${Status} ${Package} ${Version}\n''
debug: Puppet::Type::Service::ProviderUpstart: Executing '/sbin/status mysql'
err: /Stage[main]/Mysql::Server/Service[mysql]: Could not evaluate: undefined method `read_script_from' for #
debug: /Schedule[never]: Skipping device resources because running on a host
debug: Prefetching crontab resources for cron
debug: file_metadata supports formats: b64_zlib_yaml pson raw yaml; using pson
debug: file_metadata supports formats: b64_zlib_yaml pson raw yaml; using pson
</pre>

It appears that there might be a problem with the mysqld service in server.pp

<pre>
service { 'mysqld':
    name     => $service_name,
    ensure   => $service_ensure,
    enable   => $enabled,
    require  => Package['mysql-server'],
    provider => $service_provider,
}
</pre>

When I comment out the service like this (in server.pp)

<pre>
#service { 'mysqld':
#    name     => $service_name,
#    ensure   => $service_ensure,
#    enable   => $enabled,
#    require  => Package['mysql-server'],
#    provider => $service_provider,
#}
</pre>

Puppet does not fail. I haven’t changed any of my puppet scripts in the last week. It appears that this broke with the release of Puppet Enterprise 2.5.2.
