### PR TITLE
Add support for Amazon Linux.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -84,7 +84,29 @@ class mysql::params {
     }
 
     default: {
-      fail("Unsupported osfamily: ${::osfamily} operatingsystem: ${::operatingsystem}, module ${module_name} only support osfamily RedHat Debian and FreeBSD")
+      case $::operatingsystem {
+        'Amazon': {
+          $basedir               = '/usr'
+          $datadir               = '/var/lib/mysql'
+          $service_name          = 'mysqld'
+          $client_package_name   = 'mysql'
+          $server_package_name   = 'mysql-server'
+          $socket                = '/var/lib/mysql/mysql.sock'
+          $config_file           = '/etc/my.cnf'
+          $log_error             = '/var/log/mysqld.log'
+          $ruby_package_name     = 'ruby-mysql'
+          $ruby_package_provider = 'gem'
+          $python_package_name   = 'MySQL-python'
+          $java_package_name     = 'mysql-connector-java'
+          $root_group            = 'root'
+          $ssl_ca                = '/etc/mysql/cacert.pem'
+          $ssl_cert              = '/etc/mysql/server-cert.pem'
+          $ssl_key               = '/etc/mysql/server-key.pem'
+        }
+
+      default: {
+        fail("Unsupported osfamily: ${::osfamily} operatingsystem: ${::operatingsystem}, module ${module_name} only support osfamily RedHat, Debian, and FreeBSD, or operatingsystem Amazon")
+      }
     }
   }
 


### PR DESCRIPTION
This mirrors the parameters of the RedHat osfamily for Amazon Linux which is not recognized by Facter.

This is a rebase and closes #55
