### PR TITLE
Clarify how to grant specific privileges with database_grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ The custom resources can be used in any other manifests:
 
     database_grant { 'user@localhost/database':
       privileges => ['all'] ,
+      # Or specify individual privileges with columns from the mysql.db table:
+      # privileges => ['Select_priv', 'Insert_priv', 'Update_priv', 'Delete_priv']
     }
 
 A resource default can be specified to handle dependency:


### PR DESCRIPTION
When I tried to use database_grant, I assumed the privilege 
names would match the SQL GRANT command, for example, SELECT
or CREATE TEMPORARY TABLES.  But in fact the privilege names
are taken from columns of the mysql.db table.  As a result,
a row was created in mysqld.db, but none of the privileges 
I intended to grant were actually granted.

Someone else filed a ticket with the same issue:
http://projects.puppetlabs.com/issues/15808

Document that how to specify individual privileges in
README.md.
