### PR TITLE
Change list passed into validate_re to a stringe

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -44,7 +44,7 @@ define mysql::db (
   $ensure      = 'present'
 ) {
 
-  validate_re($ensure, [ '^present$', '^absent$' ],
+  validate_re($ensure, '^(present|absent)$',
   "${ensure} is not supported for ensure. Allowed values are 'present' and 'absent'.")
 
   database { $name:


### PR DESCRIPTION
The list was causing a syntax error on puppet 2.6.17

Syntax error at '['; expected ']' at /etc/puppet/modules/mysql/manifests/db.pp:47 on node rhel63
