### PR TITLE
Add bind address unset

### DIFF
--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -14,7 +14,7 @@ datadir   = <%= datadir %>
 tmpdir    = /tmp
 skip-external-locking
 
-<% if bind_address != 'UNSET' %>
+<% if bind_address %>
 bind-address    = <%= bind_address %>
 <% end %> 
 


### PR DESCRIPTION
This allows the user to pass `false` for the `bind_address` parameter to disable the value in the config.

Closes #86
