### PR TITLE
Add show view privilege for backup user

### DIFF
--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -36,7 +36,7 @@ class mysql::backup (
   }
 
   database_grant { "${backupuser}@localhost":
-    privileges => [ 'Select_priv', 'Reload_priv', 'Lock_tables_priv' ],
+    privileges => [ 'Select_priv', 'Reload_priv', 'Lock_tables_priv', 'Show_view_priv' ],
     require    => Database_user["${backupuser}@localhost"],
   }
 


### PR DESCRIPTION
It is seems like mysqldump requires view privileges.

Before patch I get that failure:

```
mysqldump: Couldn't execute 'show create table `o53ko_jf_languages`': SHOW VIEW command denied to user 'mysql-backup'@'localhost' for table 'o53ko_jf_languages' (1142)
```
