### PR TITLE
Update manifests/server.pp

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -23,7 +23,7 @@ class mysql::server (
   $enabled          = true
 ) inherits mysql::params {
 
-  Class['mysql::server'] -> Class['mysql::config']
+  Class['mysql::config'] -> Class['mysql::server']
 
   $config_class = {}
   $config_class['mysql::config'] = $config_hash


### PR DESCRIPTION
The dependency is being declared in the wrong direction.  Must configure first, then run.

The impact I'm experiencing is that a file in the conf.d directory cannot be set to notify the mysqld service.
