### PR TITLE
Don't assign to hash after creation

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -25,8 +25,7 @@ class mysql::server (
 
   Class['mysql::server'] -> Class['mysql::config']
 
-  $config_class = {}
-  $config_class['mysql::config'] = $config_hash
+  $config_class = { 'mysql::config' => $config_hash }
 
   create_resources( 'class', $config_class )
 


### PR DESCRIPTION
We shouldn't modify a variable after creating it. It is just a bug that
it is possible at all.
