### PR TITLE
Mysql::backup Compression Optional

### DIFF
--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -6,6 +6,7 @@
 #   [*backupuser*]     - The name of the mysql backup user.
 #   [*backuppassword*] - The password of the mysql backup user.
 #   [*backupdir*]      - The target directory of the mysqldump.
+#   [*backupcompress*] - Boolean to compress backup with bzip2.
 #
 # Actions:
 #   GRANT SELECT, RELOAD, LOCK TABLES ON *.* TO 'user'@'localhost'
@@ -19,12 +20,14 @@
 #     backupuser     => 'myuser',
 #     backuppassword => 'mypassword',
 #     backupdir      => '/tmp/backups',
+#     backupcompress => true,
 #   }
 #
 class mysql::backup (
   $backupuser,
   $backuppassword,
   $backupdir,
+  $backupcompress = true,
   $ensure = 'present'
 ) {
 

--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -19,5 +19,5 @@ PATH=/usr/bin:/usr/sbin:/bin:/sbin
 
 find $DIR -mtime +30 -exec rm -f {} \;
 mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \
- --all-databases | bzcat -zc > ${DIR}/mysql_backup_`date +%Y%m%d-%H%M%S`.sql.bz2
+ --all-databases <% if backupcompress %> | bzcat -zc <% end %> > ${DIR}/mysql_backup_`date +%Y%m%d-%H%M%S`.sql<% if backupcompress %>.bz2<% end  %>
 


### PR DESCRIPTION
Added a parameter to mysql::backup to make bzip2 compression
optional. Compression is enabled by default, so current behavior
is not affected.

Rationale:
We are storing our MySQL backups on a system with deduplication.
Compression and dedup do not play well together, so it's advantagous
to be able to disable it.
