### PR TITLE
Allow for the subclassing of the mysql::config class

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class mysql::params {
   $etc_root_password   = false
   $ssl                 = false
   $restart             = true
+  $config_type         = 'mysql::config'
 
   case $::operatingsystem {
     'Ubuntu': {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -20,12 +20,13 @@ class mysql::server (
   $service_name     = $mysql::params::service_name,
   $service_provider = $mysql::params::service_provider,
   $config_hash      = {},
-  $enabled          = true
+  $enabled          = true,
+  $config_type      = $mysql::params::config_type
 ) inherits mysql::params {
 
-  Class['mysql::server'] -> Class['mysql::config']
+  Class['mysql::server'] -> Class[$config_type]
 
-  $config_class = { 'mysql::config' => $config_hash }
+  $config_class = { "$config_type" => $config_hash }
 
   create_resources( 'class', $config_class )
 


### PR DESCRIPTION
For many MySQL users, the default configuration templates for MySQL may not be sufficient.  MySQL has a plethora of config options and it would be extremely useful to be able to manipulate these as desired.

The current logic for the server class does not lend itself well to subclassing the config class as it hard-codes 'mysql::confg' when calling create_resources().  In our use case we have subclassed mysql::config such that we provide our own erb template - one with all of the configuration items that we require.

Now, when declaring a mysql::server resource we can do so in the following manner:

``` ruby
class our-mysql::config (
  $root_password     = 'UNSET',
  $old_root_password = '',
  $bind_address      = $mysql::params::bind_address,
  $port              = $mysql::params::port,
  $etc_root_password = $mysql::params::etc_root_password,
  $service_name      = $mysql::params::service_name,
  $config_file       = $mysql::params::config_file,
  $socket            = $mysql::params::socket,
  $pidfile           = $mysql::params::pidfile,
  $datadir           = $mysql::params::datadir,
  $ssl               = $mysql::params::ssl,
  $ssl_ca            = $mysql::params::ssl_ca,
  $ssl_cert          = $mysql::params::ssl_cert,
  $ssl_key           = $mysql::params::ssl_key,
  $log_error         = $mysql::params::log_error,
  $default_engine    = 'UNSET',
  $root_group        = $mysql::params::root_group,
  $restart           = $mysql::params::restart
  $our_other_settings
  ...

) inherits mysql::config {

        File [ "/etc/my.cnf" ] {
                content => template('our-mysql/my.cnf.erb'),
                mode    => '0644',
        }
}

class our-mysql {

        class { 'mysql::server':
                package_name => "mysql55-server",
                config_type => "our-mysql::config",
                config_hash => {
                        'socket'         => "/opt/mysql/dbprod/$our_mysql_data_instance.sock",
                        'datadir'        => "/opt/mysql/dbdata1/$our_mysql_data_instance",
                        'pidfile'        => "/opt/mysql/dbprod/$our_mysql_data_instance.pid",
                        'default_engine' => "innodb",
                        'log_error'      => "/opt/mysql/error",
                }
        }
}
```
