### PR TITLE
Support the use of mysql rpm packages from IUScommunity.org

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,0 +1,26 @@
+class mysql::client (
+) inherits mysql {
+  case $software_package {
+    ius: {
+      if $::osfamily == 'RedHat' {
+        # Use yum shell to remove various distro packages, install IUS packages in a single yum transaction so as to avoid problems with dependencies/conflicts
+        $installs = $mysql::params::ius_client_packages
+        $excludes = $mysql::params::ius_client_package_excludes
+      } else {
+        fail("IUScommunity packaging is only for RedHat-family systems")
+      }
+    }
+    default,distro,vendor: {
+      $installs = [$mysql::params::client_package_name]
+      $excludes = [$ius_client_packages]
+    }
+  }
+  exec { 'yum-shell-mysql':
+    command => "yum -y shell /tmp/yum-shell-mysql",
+  }
+  file { '/tmp/yum-shell-mysql':
+    content => template("mysql/yum-shell-mysql.erb")
+  }
+  File['/tmp/yum-shell-mysql'] -> Exec['yum-shell-mysql']
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@
 #
 # Parameters:
 #   [*client_package_name*]  - The name of the mysql client package.
+#   [*software_package*]  - to allow alternative packages; specify "distro" for distro defaults, "ius" to use mysql55 packages on RedHat familiy (from iuscommunity.org) 
 #
 # Actions:
 #
@@ -12,13 +13,7 @@
 # Sample Usage:
 #
 class mysql (
-  $package_name   = $mysql::params::client_package_name,
-  $package_ensure = 'present'
+  $package_ensure = 'present',
+  $software_package = 'distro'
 ) inherits mysql::params {
-
-  package { 'mysql_client':
-    ensure => $package_ensure,
-    name   => $package_name,
-  }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class mysql::params {
   $restart             = true
 
   case $::operatingsystem {
-    'Ubuntu': {
+    "Ubuntu": {
       $service_provider = upstart
     }
     default: {
@@ -34,6 +34,9 @@ class mysql::params {
       $service_name          = 'mysqld'
       $client_package_name   = 'mysql'
       $server_package_name   = 'mysql-server'
+      $ius_client_packages   = ['mysql55','mysqlclient16','mysql55-libs']
+      $ius_client_package_excludes = ['mysql','mysql-libs','mysql-server','mysql-devel','mysql-test','mysql-embedded','mysql-embedded-devel']
+      $ius_server_packages   = ['mysql55-server',$ius_client_packages]
       $socket                = '/var/lib/mysql/mysql.sock'
       $pidfile               = '/var/run/mysqld/mysqld.pid'
       $config_file           = '/etc/my.cnf'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -22,16 +22,26 @@ class mysql::server (
   $config_hash      = {},
   $enabled          = true
 ) inherits mysql::params {
-
+  include mysql
+  include mysql::client
   Class['mysql::server'] -> Class['mysql::config']
 
   $config_class = { 'mysql::config' => $config_hash }
 
   create_resources( 'class', $config_class )
 
-  package { 'mysql-server':
-    ensure => $package_ensure,
-    name   => $package_name,
+  case $mysql::software_package {
+    ius: {
+      $mysqlserver = 'mysql55-server'
+    }
+    default,distro,vendor: {
+      $mysqlserver = $package_name
+    }
+  }
+  package { $mysqlserver:
+    ensure  => $package_ensure,
+    alias   => 'mysql-server',
+    require => Class['mysql::client']
   }
 
   if $enabled {

--- a/templates/yum-shell-mysql.erb
+++ b/templates/yum-shell-mysql.erb
@@ -1,0 +1,4 @@
+install <%= installs.join(' ') %>
+remove <%= excludes.join(' ') %>
+install cronie-anacron cronie crontabs postfix sysstat
+run


### PR DESCRIPTION
IUScommunity.org publishes updated packages for RHEL/CentOS including mysql. This commit enables the puppet admin to use the IUS packages for mysql instead of stock distro packages.
