### PR TITLE
Create /root/.my.cnf even when root passwd is not managed

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -116,6 +116,11 @@ class mysql::config(
         require => Exec['set_mysql_rootpw'],
       }
     }
+  } else {
+    file { '/root/.my.cnf':
+      ensure  => present,
+      require => Exec['set_mysql_rootpw'],
+    }
   }
 
   file { '/etc/mysql':

--- a/spec/classes/mysql_config_spec.rb
+++ b/spec/classes/mysql_config_spec.rb
@@ -130,7 +130,7 @@ describe 'mysql::config' do
 
             it { should_not contain_exec('set_mysql_rootpw') }
 
-            it { should_not contain_file('/root/.my.cnf')}
+            it { should contain_file('/root/.my.cnf')}
 
             it { should contain_file('/etc/mysql').with(
               'owner'  => 'root',


### PR DESCRIPTION
When the root password is not managed, it causes mysql to
fail b/c it does not create the /root/.my.cnf file (which causes
all mysql commands from the provider to fail)
