### PR TITLE
Mention pluginsync in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This module manages mysql on Linux (RedHat/Debian) distros. A native mysql provider implements database resource type to handle database, database user, and database permission.
 
+Pluginsync needs to be enabled for this module to function properly.
+Read more about pluginsync in our [docs](http://docs.puppetlabs.com/guides/plugins_in_modules.html#enabling-pluginsync)
+
 ## Description
 
 This module uses the fact osfamily which is supported by Facter 1.6.1+. If you do not have facter 1.6.1 in your environment, the following manifests will provide the same functionality in site.pp (before declaring any node):


### PR DESCRIPTION
Pluginsync is required for this module to function properly. This
commit mentions that requirement and points at documentation on
how to enable pluginsync.
