### PR TITLE
account security should not fail if hostname == fqdn

### DIFF
--- a/manifests/server/account_security.pp
+++ b/manifests/server/account_security.pp
@@ -1,10 +1,16 @@
 class mysql::server::account_security {
   # Some installations have some default users which are not required.
   # We remove them here. You can subclass this class to overwrite this behavior.
-  database_user { [ "root@${::fqdn}", "root@${::hostname}", 'root@127.0.0.1', 'root@::1',
-                    "@${::fqdn}", "@${::hostname}", '@localhost', '@%' ]:
+  database_user { [ "root@${::fqdn}", 'root@127.0.0.1', 'root@::1',
+                    "@${::fqdn}", '@localhost', '@%' ]:
     ensure  => 'absent',
     require => Class['mysql::config'],
+  }
+  if ($::fqdn != $::hostname) {
+    database_user { ["root@${::hostname}", "@${::hostname}"]:
+      ensure  => 'absent',
+      require => Class['mysql::config'],
+    }
   }
   database { 'test':
     ensure  => 'absent',


### PR DESCRIPTION
This commit checks that hostaname and fqdn are not
equal before trying to remove both.
