### PR TITLE
Load old root password from /root/.my.cnf when changing password

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -94,7 +94,7 @@ class mysql::config(
     }
 
     exec { 'set_mysql_rootpw':
-      command   => "mysqladmin -u root ${old_pw} password '${root_password}'",
+      command   => "mysqladmin --defaults-file=$root_home/.my.cnf -u root ${old_pw} password '${root_password}'",
       logoutput => true,
       unless    => "mysqladmin -u root -p'${root_password}' status > /dev/null",
       path      => '/usr/local/sbin:/usr/bin:/usr/local/bin',

--- a/spec/classes/mysql_config_spec.rb
+++ b/spec/classes/mysql_config_spec.rb
@@ -62,7 +62,7 @@ describe 'mysql::config' do
           end
 
           it { should contain_exec('set_mysql_rootpw').with(
-            'command'   => 'mysqladmin -u root  password \'foo\'',
+            'command'   => 'mysqladmin --defaults-file=/root/.my.cnf -u root  password \'foo\'',
             'logoutput' => true,
             'unless'    => "mysqladmin -u root -p\'foo\' status > /dev/null",
             'path'      => '/usr/local/sbin:/usr/bin:/usr/local/bin'


### PR DESCRIPTION
Given there is no installed mysql server
When I run class { 'mysql::server': config_hash => { 'root_password' => 'foo' } }
And after that I run class { 'mysql::server': config_hash => { 'root_password' => 'bar' } }
Then mysql root password should be "bar"

Instead of it error produced: access denied for root@localhost using password: NO

Because when mysqladmin is called, $HOME is undefined and /root/.my.cnf file not loaded. So we
load it explicitly
