### PR TITLE
handling of my.cnf config file is now optional

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,6 +8,7 @@
 #   [*default_engine]      - configure a default table engine
 #   [*etc_root_password*]  - whether to save /etc/my.cnf.
 #   [*log_error]           - path to mysql error log
+#   [*manage_config_file*] - if the config file should be managed (default: true)
 #   [*max_allowed_packet*] - Maximum network packet size mysqld will accept
 #   [*old_root_password*]  - previous root user password,
 #   [*port*]               - port to bind service.
@@ -42,6 +43,7 @@ class mysql::config(
   $tmpdir             = $mysql::tmpdir,
   $default_engine     = $mysql::default_engine,
   $etc_root_password  = $mysql::etc_root_password,
+  $manage_config_file = $mysql::manage_config_file,
   $max_allowed_packet = $mysql::max_allowed_packet,
   $log_error          = $mysql::log_error,
   $pidfile            = $mysql::pidfile,
@@ -131,15 +133,18 @@ class mysql::config(
     ensure => directory,
     mode   => '0755',
   }
+
   file { '/etc/mysql/conf.d':
     ensure  => directory,
     mode    => '0755',
     recurse => $purge_conf_dir,
     purge   => $purge_conf_dir,
   }
-  file { $config_file:
-    content => template('mysql/my.cnf.erb'),
-    mode    => '0644',
-  }
 
+  if $manage_config_file  {
+    file { $config_file:
+      content => template('mysql/my.cnf.erb'),
+      mode    => '0644',
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,8 @@
 #
 # [*log_error*]             - Where to log errors
 #
+# [*manage_config_file*]    - if the config file should be managed (default: true)
+#
 # [*manage_service*]        - Boolean dictating if mysql::server should manage the service
 #
 # [*max_allowed_packet*]    - Maximum network packet size mysqld will accept
@@ -93,6 +95,7 @@ class mysql(
   $etc_root_password     = $mysql::params::etc_root_password,
   $java_package_name     = $mysql::params::java_package_name,
   $log_error             = $mysql::params::log_error,
+  $manage_config_file    = true,
   $manage_service        = $mysql::params::manage_service,
   $max_allowed_packet    = $mysql::params::max_allowed_packet,
   $old_root_password     = $mysql::params::old_root_password,

--- a/spec/classes/mysql_config_spec.rb
+++ b/spec/classes/mysql_config_spec.rb
@@ -56,6 +56,22 @@ describe 'mysql::config' do
           {:osfamily => osfamily}
         end
 
+        describe 'when config file should be managed' do
+          let :params do
+            {:manage_config_file => true}
+          end
+
+          it { should contain_file(osparams[:config_file]) }
+        end
+
+        describe 'when config file should not be managed' do
+          let :params do
+            {:manage_config_file => false}
+          end
+
+          it { should_not contain_file(osparams[:config_file]) }
+        end
+
         describe 'when root password is set' do
 
           let :params do


### PR DESCRIPTION
This adds a parameter (default value is like old behavior) so that the
my.cnf file isn't managed (created/updated) by the mysql module at all
which is necessary for our environment. We need to set all parameters by
ourself. If we don't set a parameter then the default from the mysqld
binary should be used instead of any default parameter the mysql module
provides us.
