### PR TITLE
fixed character-set detection regex

### DIFF
--- a/lib/puppet/provider/database/mysql.rb
+++ b/lib/puppet/provider/database/mysql.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:database).provide(:mysql) do
   end
 
   def charset
-    mysql("--defaults-file=#{Facter.value(:root_home)}/.my.cnf", '-NBe', "show create database `#{resource[:name]}`").match(/.*?(\S+)\s\*\//)[1]
+    mysql("--defaults-file=#{Facter.value(:root_home)}/.my.cnf", '-NBe', "show create database `#{resource[:name]}`").match(/.*?(\S+)\s(?:COLLATE.*)?\*\//)[1]
   end
 
   def charset=(value)


### PR DESCRIPTION
Previous regex matched COLLATE value instead of CHARACTER SET. For example:

```
CREATE DATABASE `test` /*!40100 DEFAULT CHARACTER SET utf8 COLLATE utf8_bin */
```

Returned `utf8_bin` instead of `utf8` causing an unfortunate database refresh in my configuration. Fixed the regex by adding the optional presence of the COLLATE keyword.

Tested to make sure that it worked on both cases (w/ and w/o COLLATE).
