### PR TITLE
2013-01-09 - Version 0.6.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,20 @@
+2013-01-09 - Version 0.6.0
+* Add `mysql::server::config` define for specific config directives
+* Add `mysql::php` class for php support
+* Add `backupcompress` parameter to `mysql::backup`
+* Add `restart` parameter to `mysql::config`
+* Add `purge_conf_dir` parameter to `mysql::config`
+* Add `manage_service` parameter to `mysql::server`
+* Add syslog logging support via the `log_error` parameter
+* Add initial SuSE support
+* Fix remove non-localhost root user when fqdn != hostname
+* Fix dependency in `mysql::server::monitor`
+* Fix .my.cnf path for root user and root password
+* Fix ipv6 support for users
+* Fix / update various spec tests
+* Fix typos
+* Fix lint warnings
+
 2012-08-23 - Version 0.5.0
 * Add puppetlabs/stdlib as requirement
 * Add validation for mysql privs in provider

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'puppetlabs-mysql'
-version '0.5.0'
+version '0.6.0'
 source 'git://github.com/puppetlabs/puppetlabs-mysql.git'
 author 'Puppet Labs'
 license 'Apache 2.0'


### PR DESCRIPTION
- Add `mysql::server::config` define for specific config directives
- Add `mysql::php` class for php support
- Add `backupcompress` parameter to `mysql::backup`
- Add `restart` parameter to `mysql::config`
- Add `purge_conf_dir` parameter to `mysql::config`
- Add `manage_service` parameter to `mysql::server`
- Add syslog logging support via the `log_error` parameter
- Add initial SuSE support
- Fix remove non-localhost root user when fqdn != hostname
- Fix dependency in `mysql::server::monitor`
- Fix .my.cnf path for root user and root password
- Fix ipv6 support for users
- Fix / update various spec tests
- Fix typos
- Fix lint warnings
