### PR TITLE
Fix: database_user type being declared twice with mysql::db

### DIFF
--- a/lib/puppet/provider/database_user/mysql.rb
+++ b/lib/puppet/provider/database_user/mysql.rb
@@ -10,28 +10,28 @@ Puppet::Type.type(:database_user).provide(:mysql) do
   def self.instances
     users = mysql([defaults_file, "mysql", '-BNe' "select concat(User, '@',Host) as User from mysql.user"].compact).split("\n")
     users.select{ |user| user =~ /.+@/ }.collect do |name|
-      new(:name => name)
+      new(:user => name)
     end
   end
 
   def create
-    mysql([defaults_file, "mysql", "-e", "create user '%s' identified by PASSWORD '%s'" % [ @resource[:name].sub("@", "'@'"), @resource.value(:password_hash) ]].compact)
+    mysql([defaults_file, "mysql", "-e", "create user '%s' identified by PASSWORD '%s'" % [ @resource[:user].sub("@", "'@'"), @resource.value(:password_hash) ]].compact)
   end
 
   def destroy
-    mysql([defaults_file, "mysql", "-e", "drop user '%s'" % @resource.value(:name).sub("@", "'@'") ].compact)
+    mysql([defaults_file, "mysql", "-e", "drop user '%s'" % @resource.value(:user).sub("@", "'@'") ].compact)
   end
 
   def password_hash
-    mysql([defaults_file, "mysql", "-NBe", "select password from mysql.user where CONCAT(user, '@', host) = '%s'" % @resource.value(:name)].compact).chomp
+    mysql([defaults_file, "mysql", "-NBe", "select password from mysql.user where CONCAT(user, '@', host) = '%s'" % @resource.value(:user)].compact).chomp
   end
 
   def password_hash=(string)
-    mysql([defaults_file, "mysql", "-e", "SET PASSWORD FOR '%s' = '%s'" % [ @resource[:name].sub("@", "'@'"), string ] ].compact)
+    mysql([defaults_file, "mysql", "-e", "SET PASSWORD FOR '%s' = '%s'" % [ @resource[:user].sub("@", "'@'"), string ] ].compact)
   end
 
   def exists?
-    not mysql([defaults_file, "mysql", "-NBe", "select '1' from mysql.user where CONCAT(user, '@', host) = '%s'" % @resource.value(:name)].compact).empty?
+    not mysql([defaults_file, "mysql", "-NBe", "select '1' from mysql.user where CONCAT(user, '@', host) = '%s'" % @resource.value(:user)].compact).empty?
   end
 
   def flush

--- a/lib/puppet/type/database_user.rb
+++ b/lib/puppet/type/database_user.rb
@@ -4,7 +4,8 @@ Puppet::Type.newtype(:database_user) do
 
   ensurable
 
-  newparam(:name, :namevar=>true) do
+  newparam(:name, :namevar=>true)
+  newparam(:user) do
     desc "The name of the user. This uses the 'username@hostname' or username@hostname."
     validate do |value|
       # https://dev.mysql.com/doc/refman/5.1/en/account-names.html

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -54,8 +54,9 @@ define mysql::db (
     require  => Class['mysql::server'],
   }
 
-  database_user { "${user}@${host}":
+  database_user { "${user}@${host}/${name}":
     ensure        => $ensure,
+    user          => "${user}@${host}",
     password_hash => mysql_password($password),
     provider      => 'mysql',
     require       => Database[$name],
@@ -65,7 +66,7 @@ define mysql::db (
     database_grant { "${user}@${host}/${name}":
       privileges => $grant,
       provider   => 'mysql',
-      require    => Database_user["${user}@${host}"],
+      require    => Database_user["${user}@${host}/${name}"],
     }
 
     $refresh = ! $enforce_sql


### PR DESCRIPTION
Fixes database_user type being declared twice when adding the same user to
different databases with mysql::db, by adding a :user parameter instead of using
:name in the type and provider definitions.
