### PR TITLE
Solve an edge-case of syntax highlighting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This module uses the fact osfamily which is supported by Facter 1.6.1+. If you d
       }
     }
 
-This module depends on creates_resources function which is introduced in Puppet 2.7. Users on puppet 2.6 can use the following module which provides this functionality:
+This module depends on the `creates_resources` function which is introduced in Puppet 2.7. Users on puppet 2.6 can use the following module which provides this functionality:
 
 [http://github.com/puppetlabs/puppetlabs-create_resources](http://github.com/puppetlabs/puppetlabs-create_resources)
 


### PR DESCRIPTION
In my vim-setup, the underscore in `create_resources` leads to
rendering everything in italics after that. Wrapping it in backticks
solves this in the editor and also looks better when rendered as HTML.
