### PR TITLE
Use $root_home for .my.cnf

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -109,6 +109,7 @@ class mysql::config(
     file { "${root_home}/.my.cnf":
       content => template('mysql/my.cnf.pass.erb'),
       require => Exec['set_mysql_rootpw'],
+      mode => '0600',
     }
 
     if $etc_root_password {
@@ -120,6 +121,7 @@ class mysql::config(
   } else {
     file { "${root_home}/.my.cnf":
       ensure  => present,
+      mode => '0600',
     }
   }
 


### PR DESCRIPTION
File .my.cnf should not use hardcoded /root path
