### PR TITLE
fix mocha deprecation warnings

### DIFF
--- a/spec/unit/puppet/provider/database_grant/mysql_spec.rb
+++ b/spec/unit/puppet/provider/database_grant/mysql_spec.rb
@@ -1,5 +1,5 @@
 require 'puppet'
-require 'mocha'
+require 'mocha/api'
 require 'spec_helper'
 RSpec.configure do |config|
   config.mock_with :mocha


### PR DESCRIPTION
A new clone and bundle with puppetlabs-mysql installs mocha 0.13.2. This version of Mocha has deprecated the use of `require 'mocha'` and instead recommends using `require 'mocha/api'` for test frameworks that are not Test::Unit or MiniTest.

This pull request fixes those deprecation warnings.
