### PR TITLE
Fix 2.6 support for mysql module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 bundler_args: --without development
 before_script:
-  - "[ $PUPPET_GEM_VERSION ~> 2.6 ] && git clone git://github.com/puppetlabs/puppetlabs-create_resources.git spec/fixtures/modules/create_resources || true"
+  - echo $PUPPET_GEM_VERSION | grep '2.6' && git clone git://github.com/puppetlabs/puppetlabs-create_resources.git spec/fixtures/modules/create_resources || true
 script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
 rvm:
   - 1.8.7

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -55,10 +55,12 @@ define mysql::db (
     before   => Database_user["${user}@${host}"],
   }
 
-  ensure_resource('database_user', "${user}@${host}", { ensure        => $ensure,
-                                                        password_hash => mysql_password($password),
-                                                        provider      => 'mysql'
-                                                      })
+  $database_user_hash = { 'ensure'        => $ensure,
+                          'password_hash' => mysql_password($password),
+                          'provider'      => 'mysql'
+                        }
+
+  ensure_resource('database_user', "${user}@${host}", $database_user_hash)
 
   if $ensure == 'present' {
     database_grant { "${user}@${host}/${name}":


### PR DESCRIPTION
The mysql module support for 2.6 is currently broken
b/c 2.6 does not support ananonymous hashes.

this commit refactors the code so that it should work with 2.6.
