### PR TITLE
mysql::dev installs developement libraries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ Creates a database with a user and assign some privileges.
       grant    => ['all'],
     }
 
+### mysql::dev
+Installes mysql development libraries, each library is represented by a parameter which is passed a valid `ensure` statement, i.e. `present`,`absent`, or a version string.
+
+    class { 'mysql::dev':
+      mysqlclient   => present,
+    }
+
+#### Current development librarires supported:
+* `mysqlclient` with the Debian OS family
+
 ### mysql::backup
 Installs a mysql backup script, cronjob, and privileged backup user.
 

--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -1,0 +1,34 @@
+# Class: mysql::dev
+#
+# installs mysql development libraries
+#
+# For all parameters, the value given will be passed to each package as the
+# ensure statement, i.e. present, absent or a version string are vaild
+#
+# Parameters:
+#   [*mysqlclient*] installs the mysqlclient-dev libraries
+#
+# Actions:
+#
+# Requires:
+#
+# Sample Usage:
+# class { 'mysql::dev': mysqlclient => present}
+class mysql::dev(
+  $mysqlclient = undef,
+) inherits mysql::params {
+
+# This structure might seem contrived, but for each package and OS
+# all that's required is an appropriate package name to be set up
+# in mysql::params
+  if $mysqlclient {
+    if $mysql::params::myslqclient_dev_package {
+      package {$mysql::params::myslqclient_dev_package:
+        ensure => $mysqlclient,
+      }
+    } else {
+      warning ("The mysqlclient development library not configured for ${::osfamily} on ${::fqdn}")
+    }
+  }
+
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -142,6 +142,7 @@ class mysql::params {
       $perl_package_name    = 'libdbd-mysql-perl'
       $python_package_name  = 'python-mysqldb'
       $ruby_package_name    = 'libmysql-ruby'
+      $myslqclient_dev_package = 'libmysqlclient-dev'
     }
 
     'FreeBSD': {


### PR DESCRIPTION
 Currently just has myslqclient set up as an example with the Debian OS family.

This is a proposed pattern for installing mysql development libraries.

`mysql::dev` has a parameter for each library configured, and an `ensure` statement is passed to that parameter, i.e. `absent`, `present`, or a version string. This is checked to see if an appropriate package variable has been set in `mysql::params` by OS or OS Family. The ensure statement is then passed to the package.
