### PR TITLE
add ft_min_word_len and ft_max_word_len config options

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -68,6 +68,8 @@
 #     specified database and table name patterns.
 #   [*replicate_wild_ignore_table]      - Tells the slave thread not to
 #     replicate a statement where any table matches the given wildcard pattern.
+#   [*ft_min_word_len*]     - minimum length of words to be indexed by mysql
+#   [*ft_max_word_len*]     - maximum length of words to be indexed by mysql
 #
 # Actions:
 #
@@ -125,7 +127,9 @@ class mysql::config(
   $log_bin_trust_function_creators  = 'UNSET',
   $replicate_ignore_table           = 'UNSET',
   $replicate_wild_do_table          = 'UNSET',
-  $replicate_wild_ignore_table      = 'UNSET'
+  $replicate_wild_ignore_table      = 'UNSET',
+  $ft_min_word_len                  = 'UNSET',
+  $ft_max_word_len                  = 'UNSET'
 ) inherits mysql {
 
   File {

--- a/spec/classes/mysql_config_spec.rb
+++ b/spec/classes/mysql_config_spec.rb
@@ -33,7 +33,9 @@ describe 'mysql::config' do
      :log_bin_trust_function_creators => 'UNSET',
      :replicate_ignore_table          => 'UNSET',
      :replicate_wild_do_table         => 'UNSET',
-     :replicate_wild_ignore_table     => 'UNSET'
+     :replicate_wild_ignore_table     => 'UNSET',
+     :ft_min_word_len                 => 'UNSET',
+     :ft_max_word_len                 => 'UNSET'
     }
   end
 
@@ -153,7 +155,9 @@ describe 'mysql::config' do
             :tmp_table_size       => '4096M',
             :max_heap_table_size  => '4096M',
             :table_open_cache     => 2048,
-            :long_query_time      => 0.5
+            :long_query_time      => 0.5,
+            :ft_min_word_len      => 3,
+            :ft_max_word_len      => 10
           }
         ].each do |passed_params|
 
@@ -231,6 +235,12 @@ describe 'mysql::config' do
               end
               if param_values[:long_query_time] != 'UNSET'
                 expected_lines = expected_lines | [ "long_query_time     = #{param_values[:long_query_time]}" ]
+              end
+              if param_values[:ft_min_word_len] != 'UNSET'
+                expected_lines = expected_lines | [ "ft_min_word_len = #{param_values[:ft_min_word_len]}" ]
+              end
+              if param_values[:ft_max_word_len] != 'UNSET'
+                expected_lines = expected_lines | [ "ft_max_word_len = #{param_values[:ft_max_word_len]}" ]
               end
               if param_values[:default_engine] != 'UNSET'
                 expected_lines = expected_lines | [ "default-storage-engine = #{param_values[:default_engine]}" ]

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -74,6 +74,12 @@ replicate-wild-do-table         = <%= @replicate_wild_do_table %>
 <% if @replicate_wild_ignore_table != 'UNSET' -%>
 replicate-wild-ignore-table     = <%= @replicate_wild_ignore_table %>
 <% end -%>
+<% if @ft_min_word_len != 'UNSET' -%>
+ft_min_word_len = <%= @ft_min_word_len %>
+<% end -%>
+<% if @ft_max_word_len != 'UNSET' -%>
+ft_max_word_len = <%= @ft_max_word_len %>
+<% end -%>
 
 <% if @log_error != 'syslog' -%>
 log_error           = <%= @log_error %>


### PR DESCRIPTION
add options to set the minimun and maximum length of words indexed by the MySql full-text search engine
