### PR TITLE
change default_engine from undef to UNSET

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@ class mysql::params {
 
   $bind_address        = '127.0.0.1'
   $config_template     = 'mysql/my.cnf.erb'
-  $default_engine      = undef
+  $default_engine      = 'UNSET'
   $etc_root_password   = false
   $manage_service      = true
   $old_root_password   = ''


### PR DESCRIPTION
The templates/my.cnf.erb expects the default value for
default_engine to be UNSET (instead of undef).

Setting the default value to undef causes the value of the param
to literally default to undef which causes mysql to fail.
