### PR TITLE
Allow for the inclusion of arbitrary settings in mysqld config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,23 +1,24 @@
 # Class: mysql::config
 #
 # Parameters:
-#   [*bind_address*]      - address to bind service.
-#   [*config_file*]       - my.cnf configuration file path.
-#   [*datadir*]           - path to datadir.
-#   [*default_engine]     - configure a default table engine
-#   [*etc_root_password*] - whether to save /etc/my.cnf.
-#   [*log_error]          - path to mysql error log
-#   [*old_root_password*] - previous root user password,
-#   [*port*]              - port to bind service.
-#   [*restart]            - whether to restart mysqld (true/false)
-#   [*root_group]         - use specified group for root-owned files
-#   [*root_password*]     - root user password.
-#   [*service_name*]      - mysql service name.
-#   [*socket*]            - mysql socket.
-#   [*ssl]                - enable ssl
-#   [*ssl_ca]             - path to ssl-ca
-#   [*ssl_cert]           - path to ssl-cert
-#   [*ssl_key]            - path to ssl-key
+#   [*bind_address*]        - address to bind service.
+#   [*config_file*]         - my.cnf configuration file path.
+#   [*datadir*]             - path to datadir.
+#   [*default_engine]       - configure a default table engine
+#   [*etc_root_password*]   - whether to save /etc/my.cnf.
+#   [*log_error]            - path to mysql error log
+#   [*old_root_password*]   - previous root user password,
+#   [*port*]                - port to bind service.
+#   [*restart]              - whether to restart mysqld (true/false)
+#   [*root_group]           - use specified group for root-owned files
+#   [*root_password*]       - root user password.
+#   [*service_name*]        - mysql service name.
+#   [*socket*]              - mysql socket.
+#   [*ssl]                  - enable ssl
+#   [*ssl_ca]               - path to ssl-ca
+#   [*ssl_cert]             - path to ssl-cert
+#   [*ssl_key]              - path to ssl-key
+#   [*mysqld_misc_settings] - extra settings for mysqld
 #
 #
 # Actions:
@@ -34,25 +35,26 @@
 #   }
 #
 class mysql::config(
-  $bind_address      = $mysql::bind_address,
-  $config_file       = $mysql::config_file,
-  $datadir           = $mysql::datadir,
-  $default_engine    = $mysql::default_engine,
-  $etc_root_password = $mysql::etc_root_password,
-  $log_error         = $mysql::log_error,
-  $pidfile           = $mysql::pidfile,
-  $port              = $mysql::port,
-  $purge_conf_dir    = $mysql::purge_conf_dir,
-  $restart           = $mysql::restart,
-  $root_group        = $mysql::root_group,
-  $root_password     = $mysql::root_password,
-  $old_root_password = $mysql::old_root_password,
-  $service_name      = $mysql::service_name,
-  $socket            = $mysql::socket,
-  $ssl               = $mysql::ssl,
-  $ssl_ca            = $mysql::ssl_ca,
-  $ssl_cert          = $mysql::ssl_cert,
-  $ssl_key           = $mysql::ssl_key
+  $bind_address         = $mysql::bind_address,
+  $config_file          = $mysql::config_file,
+  $datadir              = $mysql::datadir,
+  $default_engine       = $mysql::default_engine,
+  $etc_root_password    = $mysql::etc_root_password,
+  $log_error            = $mysql::log_error,
+  $pidfile              = $mysql::pidfile,
+  $port                 = $mysql::port,
+  $purge_conf_dir       = $mysql::purge_conf_dir,
+  $restart              = $mysql::restart,
+  $root_group           = $mysql::root_group,
+  $root_password        = $mysql::root_password,
+  $old_root_password    = $mysql::old_root_password,
+  $service_name         = $mysql::service_name,
+  $socket               = $mysql::socket,
+  $ssl                  = $mysql::ssl,
+  $ssl_ca               = $mysql::ssl_ca,
+  $ssl_cert             = $mysql::ssl_cert,
+  $ssl_key              = $mysql::ssl_key,
+  $mysqld_misc_settings = $mysql::mysqld_misc_settings
 ) inherits mysql {
 
   File {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,6 +71,8 @@
 #
 # [*ssl_key*]               - The SSL key to use
 #
+# [*mysqld_misc_settings]   - Add misc settings to mysqld in my.cnf
+#
 # Actions:
 #
 # Requires:
@@ -109,7 +111,8 @@ class mysql(
   $ssl                   = $mysql::params::ssl,
   $ssl_ca                = $mysql::params::ssl_ca,
   $ssl_cert              = $mysql::params::ssl_cert,
-  $ssl_key               = $mysql::params::ssl_key
+  $ssl_key               = $mysql::params::ssl_key,
+  $mysqld_misc_settings  = $mysql::params::mysqld_misc_settings
 ) inherits mysql::params{
   if $package_name {
     warning('Using $package_name has been deprecated in favor of $client_package_name and will be removed.')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,18 +12,19 @@
 #
 class mysql::params {
 
-  $bind_address        = '127.0.0.1'
-  $config_template     = 'mysql/my.cnf.erb'
-  $default_engine      = 'UNSET'
-  $etc_root_password   = false
-  $manage_service      = true
-  $old_root_password   = ''
-  $package_ensure      = 'present'
-  $purge_conf_dir      = false
-  $port                = 3306
-  $root_password       = 'UNSET'
-  $restart             = true
-  $ssl                 = false
+  $bind_address         = '127.0.0.1'
+  $config_template      = 'mysql/my.cnf.erb'
+  $default_engine       = 'UNSET'
+  $etc_root_password    = false
+  $manage_service       = true
+  $old_root_password    = ''
+  $package_ensure       = 'present'
+  $purge_conf_dir       = false
+  $port                 = 3306
+  $root_password        = 'UNSET'
+  $restart              = true
+  $ssl                  = false
+  $mysqld_misc_settings = {}
 
   case $::operatingsystem {
     'Ubuntu': {

--- a/spec/classes/mysql_config_spec.rb
+++ b/spec/classes/mysql_config_spec.rb
@@ -92,19 +92,20 @@ describe 'mysql::config' do
         [
           {},
           {
-            :service_name   => 'dans_service',
-            :config_file    => '/home/dan/mysql.conf',
-            :service_name   => 'dans_mysql',
-            :pidfile        => '/home/dan/mysql.pid',
-            :socket         => '/home/dan/mysql.sock',
-            :bind_address   => '0.0.0.0',
-            :port           => '3306',
-            :datadir        => '/path/to/datadir',
-            :default_engine => 'InnoDB',
-            :ssl            => true,
-            :ssl_ca         => '/path/to/cacert.pem',
-            :ssl_cert       => '/path/to/server-cert.pem',
-            :ssl_key        => '/path/to/server-key.pem'
+            :service_name         => 'dans_service',
+            :config_file          => '/home/dan/mysql.conf',
+            :service_name         => 'dans_mysql',
+            :pidfile              => '/home/dan/mysql.pid',
+            :socket               => '/home/dan/mysql.sock',
+            :bind_address         => '0.0.0.0',
+            :port                 => '3306',
+            :datadir              => '/path/to/datadir',
+            :default_engine       => 'InnoDB',
+            :ssl                  => true,
+            :ssl_ca               => '/path/to/cacert.pem',
+            :ssl_cert             => '/path/to/server-cert.pem',
+            :ssl_key              => '/path/to/server-key.pem',
+            :mysqld_misc_settings => { 'collation-server' => 'utf8_bin' }
           }
         ].each do |passed_params|
 
@@ -172,6 +173,12 @@ describe 'mysql::config' do
                     "ssl-ca    = #{param_values[:ssl_ca]}",
                     "ssl-cert  = #{param_values[:ssl_cert]}",
                     "ssl-key   = #{param_values[:ssl_key]}"
+                  ]
+              end
+              if param_values[:mysqld_misc_setttings]
+                expected_lines = expected_lines |
+                  [
+                    "collation-server = utf8_bin"
                   ]
               end
               (content.split("\n") & expected_lines).should == expected_lines

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -42,6 +42,10 @@ ssl-cert  = <%= ssl_cert %>
 ssl-key   = <%= ssl_key %>
 <% end %>
 
+<% mysqld_misc_settings.each do |key, value| -%>
+<%= key %> = <%= value %>
+<% end -%>
+
 [mysqldump]
 quick
 quote-names


### PR DESCRIPTION
I added a mysqld_misc_settings paramter which allows the inclusion of
arbitrary settings in to the mysqld section of my.cnf.  The
mysqld_misc_settings paramter expects a hash of key value pairs which
correspond to the mysql setting as the key and the value of that
setting as the value.
