### PR TITLE
Add max_allowed_packet to my.cnf template

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,23 +1,24 @@
 # Class: mysql::config
 #
 # Parameters:
-#   [*bind_address*]      - address to bind service.
-#   [*config_file*]       - my.cnf configuration file path.
-#   [*datadir*]           - path to datadir.
-#   [*default_engine]     - configure a default table engine
-#   [*etc_root_password*] - whether to save /etc/my.cnf.
-#   [*log_error]          - path to mysql error log
-#   [*old_root_password*] - previous root user password,
-#   [*port*]              - port to bind service.
-#   [*restart]            - whether to restart mysqld (true/false)
-#   [*root_group]         - use specified group for root-owned files
-#   [*root_password*]     - root user password.
-#   [*service_name*]      - mysql service name.
-#   [*socket*]            - mysql socket.
-#   [*ssl]                - enable ssl
-#   [*ssl_ca]             - path to ssl-ca
-#   [*ssl_cert]           - path to ssl-cert
-#   [*ssl_key]            - path to ssl-key
+#   [*bind_address*]       - address to bind service.
+#   [*config_file*]        - my.cnf configuration file path.
+#   [*datadir*]            - path to datadir.
+#   [*default_engine]      - configure a default table engine
+#   [*etc_root_password*]  - whether to save /etc/my.cnf.
+#   [*log_error]           - path to mysql error log
+#   [*max_allowed_packet*] - maximum allowed packet size in mysqld and mysqldump
+#   [*old_root_password*]  - previous root user password,
+#   [*port*]               - port to bind service.
+#   [*restart]             - whether to restart mysqld (true/false)
+#   [*root_group]          - use specified group for root-owned files
+#   [*root_password*]      - root user password.
+#   [*service_name*]       - mysql service name.
+#   [*socket*]             - mysql socket.
+#   [*ssl]                 - enable ssl
+#   [*ssl_ca]              - path to ssl-ca
+#   [*ssl_cert]            - path to ssl-cert
+#   [*ssl_key]             - path to ssl-key
 #
 #
 # Actions:
@@ -34,25 +35,26 @@
 #   }
 #
 class mysql::config(
-  $bind_address      = $mysql::bind_address,
-  $config_file       = $mysql::config_file,
-  $datadir           = $mysql::datadir,
-  $default_engine    = $mysql::default_engine,
-  $etc_root_password = $mysql::etc_root_password,
-  $log_error         = $mysql::log_error,
-  $pidfile           = $mysql::pidfile,
-  $port              = $mysql::port,
-  $purge_conf_dir    = $mysql::purge_conf_dir,
-  $restart           = $mysql::restart,
-  $root_group        = $mysql::root_group,
-  $root_password     = $mysql::root_password,
-  $old_root_password = $mysql::old_root_password,
-  $service_name      = $mysql::service_name,
-  $socket            = $mysql::socket,
-  $ssl               = $mysql::ssl,
-  $ssl_ca            = $mysql::ssl_ca,
-  $ssl_cert          = $mysql::ssl_cert,
-  $ssl_key           = $mysql::ssl_key
+  $bind_address       = $mysql::bind_address,
+  $config_file        = $mysql::config_file,
+  $datadir            = $mysql::datadir,
+  $default_engine     = $mysql::default_engine,
+  $etc_root_password  = $mysql::etc_root_password,
+  $log_error          = $mysql::log_error,
+  $max_allowed_packet = $mysql::max_allowed_packet,
+  $pidfile            = $mysql::pidfile,
+  $port               = $mysql::port,
+  $purge_conf_dir     = $mysql::purge_conf_dir,
+  $restart            = $mysql::restart,
+  $root_group         = $mysql::root_group,
+  $root_password      = $mysql::root_password,
+  $old_root_password  = $mysql::old_root_password,
+  $service_name       = $mysql::service_name,
+  $socket             = $mysql::socket,
+  $ssl                = $mysql::ssl,
+  $ssl_ca             = $mysql::ssl_ca,
+  $ssl_cert           = $mysql::ssl_cert,
+  $ssl_key            = $mysql::ssl_key,
 ) inherits mysql {
 
   File {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,8 @@
 #
 # [*manage_service*]        - Boolean dictating if mysql::server should manage the service
 #
+# [*max_allowed_packet*]    - Maximum packet size permitted in mysql and mysqldump
+#
 # [*old_root_password*]     - Previous root user password,
 #
 # [*package_ensure*]        - ensure value for packages.
@@ -89,6 +91,7 @@ class mysql(
   $java_package_name     = $mysql::params::java_package_name,
   $log_error             = $mysql::params::log_error,
   $manage_service        = $mysql::params::manage_service,
+  $max_allowed_packet    = $mysql::params::max_allowed_packet,
   $old_root_password     = $mysql::params::old_root_password,
   $package_ensure        = $mysql::params::package_ensure,
   $package_name          = undef,
@@ -109,7 +112,7 @@ class mysql(
   $ssl                   = $mysql::params::ssl,
   $ssl_ca                = $mysql::params::ssl_ca,
   $ssl_cert              = $mysql::params::ssl_cert,
-  $ssl_key               = $mysql::params::ssl_key
+  $ssl_key               = $mysql::params::ssl_key,
 ) inherits mysql::params{
   if $package_name {
     warning('Using $package_name has been deprecated in favor of $client_package_name and will be removed.')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class mysql::params {
   $default_engine      = 'UNSET'
   $etc_root_password   = false
   $manage_service      = true
+  $max_allowed_packet  = '16M'
   $old_root_password   = ''
   $package_ensure      = 'present'
   $purge_conf_dir      = false

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -22,7 +22,7 @@ bind-address    = <%= bind_address %>
 <% end %> 
 
 key_buffer         = 16M
-max_allowed_packet = 16M
+max_allowed_packet = <%= max_allowed_packet %>
 thread_stack       = 192K
 thread_cache_size  = 8
 myisam-recover     = BACKUP
@@ -45,7 +45,7 @@ ssl-key   = <%= ssl_key %>
 [mysqldump]
 quick
 quote-names
-max_allowed_packet = 16M
+max_allowed_packet = <%= max_allowed_packet %>
 [mysql]
 [isamchk]
 key_buffer    = 16M


### PR DESCRIPTION
Previously, max_allowed_packet was hardcoded to '16M', which is a fine
default, but we needed to change it and weren't able to.  Added it (with
that 16M default) to the params file, and as a parameter to init and
config.

We tested this without passing anything in (no changes) and via a data binding to change it to '64M'.
