### PR TITLE
fix variables in templates

### DIFF
--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -1,24 +1,24 @@
 [client]
-port    = <%= port %>
-socket    = <%= socket %>
+port    = <%= @port %>
+socket    = <%= @socket %>
 [mysqld_safe]
-socket    = <%= socket %>
+socket    = <%= @socket %>
 nice    = 0
-<% if log_error == 'syslog' -%>
+<% if @log_error == 'syslog' -%>
 syslog
 <% end -%>
 [mysqld]
 user    = mysql
-pid-file  = <%= pidfile %>
-socket    = <%= socket %>
-port      = <%= port %>
-basedir   = <%= basedir %>
-datadir   = <%= datadir %>
+pid-file  = <%= @pidfile %>
+socket    = <%= @socket %>
+port      = <%= @port %>
+basedir   = <%= @basedir %>
+datadir   = <%= @datadir %>
 tmpdir    = /tmp
 skip-external-locking
 
-<% if bind_address %>
-bind-address    = <%= bind_address %>
+<% if @bind_address %>
+bind-address    = <%= @bind_address %>
 <% end %> 
 
 key_buffer         = 16M
@@ -28,18 +28,18 @@ thread_cache_size  = 8
 myisam-recover     = BACKUP
 query_cache_limit  = 1M
 query_cache_size   = 16M
-<% if log_error != 'syslog' -%>
-log_error          = <%= log_error %>
+<% if @log_error != 'syslog' -%>
+log_error          = <%= @log_error %>
 <% end -%>
 expire_logs_days   = 10
 max_binlog_size    = 100M
 <% if default_engine != 'UNSET' %>
-default-storage-engine = <%= default_engine %>
+default-storage-engine = <%= @default_engine %>
 <% end %>
-<% if ssl == true %>
-ssl-ca    = <%= ssl_ca %>
-ssl-cert  = <%= ssl_cert %>
-ssl-key   = <%= ssl_key %>
+<% if @ssl == true %>
+ssl-ca    = <%= @ssl_ca %>
+ssl-cert  = <%= @ssl_cert %>
+ssl-key   = <%= @ssl_key %>
 <% end %>
 
 [mysqldump]

--- a/templates/my.cnf.pass.erb
+++ b/templates/my.cnf.pass.erb
@@ -1,6 +1,6 @@
 [client]
 user=root
 host=localhost
-<% unless root_password == 'UNSET' -%>
-password=<%= root_password %>
+<% unless @root_password == 'UNSET' -%>
+password=<%= @root_password %>
 <% end -%>

--- a/templates/my.conf.cnf.erb
+++ b/templates/my.conf.cnf.erb
@@ -1,5 +1,5 @@
 ### MANAGED BY PUPPET ###
-<% settings.sort.each do |section, content|      -%>
+<% @settings.sort.each do |section, content|      -%>
 [<%= section %>]
 <%   content.sort.each do |key, values|          -%>
 <%     [values].flatten.sort.each do |value|     -%>

--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -10,14 +10,14 @@
 #
 ##### START CONFIG ###################################################
 
-USER=<%= backupuser %>
-PASS=<%= backuppassword %>
-DIR=<%= backupdir %>
+USER=<%= @backupuser %>
+PASS=<%= @backuppassword %>
+DIR=<%= @backupdir %>
 
 ##### STOP CONFIG ####################################################
 PATH=/usr/bin:/usr/sbin:/bin:/sbin
 
 find $DIR -mtime +30 -exec rm -f {} \;
 mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \
- --all-databases <% if backupcompress %>| bzcat -zc <% end %>> ${DIR}/mysql_backup_`date +%Y%m%d-%H%M%S`.sql<% if backupcompress %>.bz2<% end  %>
+ --all-databases <% if @backupcompress %>| bzcat -zc <% end %>> ${DIR}/mysql_backup_`date +%Y%m%d-%H%M%S`.sql<% if @backupcompress %>.bz2<% end  %>
 


### PR DESCRIPTION
The use of variables in a template with out a '@' has been deprecated, and as of 3.2.x Puppet warns about it
