### PR TITLE
(WIP) #20562: Minor fix for ordering

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,4 +122,6 @@ class mysql(
     name   => $client_package_name_real,
   }
 
+  Class['mysql::config'] -> Mysql::Db <| |>
+
 }


### PR DESCRIPTION
A very small fix for the case where the root password has been changed by hand and then you change your mysql::server entry to match.  If you also change any mysql::db entries at the same time this causes those to be attempted before your /root/.my.cnf is updated.

NOTE:

I can't add rspec testing for this until https://github.com/rodjek/rspec-puppet/pull/106 is merged.  I would prefer not to merge this until we add those ordering tests, but I wanted to at least get a PR up for the person with the issue.
