### PR TITLE
fix puppet warning default_engine

### DIFF
--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -33,7 +33,7 @@ log_error          = <%= @log_error %>
 <% end -%>
 expire_logs_days   = 10
 max_binlog_size    = 100M
-<% if default_engine != 'UNSET' %>
+<% if @default_engine != 'UNSET' %>
 default-storage-engine = <%= @default_engine %>
 <% end %>
 <% if @ssl == true %>


### PR DESCRIPTION
fix default_engine warning

```
Warning: Variable access via 'default_engine' is deprecated. Use '@default_engine' instead. template[/tmp/vagrant-puppet/modules-0/mysql/templates/my.cnf.erb]:36
   (at /tmp/vagrant-puppet/modules-0/mysql/templates/my.cnf.erb:36:in `result')
```
