### PR TITLE
One variable without an @ in the front was missed.

### DIFF
--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -33,7 +33,7 @@ log_error          = <%= @log_error %>
 <% end -%>
 expire_logs_days   = 10
 max_binlog_size    = 100M
-<% if default_engine != 'UNSET' %>
+<% if @default_engine != 'UNSET' %>
 default-storage-engine = <%= @default_engine %>
 <% end %>
 <% if @ssl == true %>


### PR DESCRIPTION
...3.2.x complains about such things
