### PR TITLE
Fix puppet error when setting etc_root_password in mysql.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -54,6 +54,7 @@ class mysql::config(
   $ssl_cert          = $mysql::ssl_cert,
   $ssl_key           = $mysql::ssl_key
 ) inherits mysql {
+  validate_bool($etc_root_password)
 
   File {
     owner  => 'root',
@@ -104,18 +105,12 @@ class mysql::config(
         false => undef,
       },
       require   => File['/etc/mysql/conf.d'],
+      before    => File[$config_file],
     }
 
     file { '/root/.my.cnf':
       content => template('mysql/my.cnf.pass.erb'),
       require => Exec['set_mysql_rootpw'],
-    }
-
-    if $etc_root_password {
-      file{ '/etc/my.cnf':
-        content => template('mysql/my.cnf.pass.erb'),
-        require => Exec['set_mysql_rootpw'],
-      }
     }
   } else {
     file { '/root/.my.cnf':

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -1,6 +1,9 @@
 [client]
 port    = <%= @port %>
 socket    = <%= @socket %>
+<%- if @etc_root_password -%>
+password  = '<%= @root_password %>'
+<%- end -%>
 [mysqld_safe]
 socket    = <%= @socket %>
 nice    = 0


### PR DESCRIPTION
Puppet agent fails with duplicate definition errors if I enable `etc_root_password`. 

This patch avoids the error by omitting the standard definition.
