### PR TITLE
Update specs for current testing practices and GH publish

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,5 @@
 fixtures:
   repositories:
     "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib"
-    "create_resources": "git://github.com/puppetlabs/puppetlabs-create_resources.git"
   symlinks:
     "mysql": "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 pkg/
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,39 @@
+branches:
+  only:
+    - master
 language: ruby
 bundler_args: --without development
-before_script:
-  - "[ $PUPPET_GEM_VERSION ~> 2.6 ] && git clone git://github.com/puppetlabs/puppetlabs-create_resources.git spec/fixtures/modules/create_resources || true"
 script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
+after_success:
+  - git clone -q git://github.com/puppetlabs/ghpublisher.git .forge-release
+  - .forge-release/publish
 rvm:
   - 1.8.7
   - 1.9.3
-  - ruby-head
+  - 2.0.0
 env:
-  - PUPPET_GEM_VERSION="~> 2.6.0"
-  - PUPPET_GEM_VERSION="~> 2.7.0"
-  - PUPPET_GEM_VERSION="~> 3.0.0"
-  - PUPPET_GEM_VERSION="~> 3.1.0"
+  matrix:
+    - PUPPET_GEM_VERSION="~> 2.7.0"
+    - PUPPET_GEM_VERSION="~> 3.0.0"
+    - PUPPET_GEM_VERSION="~> 3.1.0"
+    - PUPPET_GEM_VERSION="~> 3.2.0"
+  global:
+    - PUBLISHER_LOGIN=puppetlabs
+    - secure: |-
+        Hc9OPm/kRTmjXSP3TbLir/y6Yy1LqmZS8zrqxdTbpo3Z04EYv1uKhaFDpECl
+        0a6bJRUWpLWIuDco08fHMeCTWoFGzE97EDelhHKSYiTNllzYKWPHy7ki/al6
+        wjz0gLtiDfmktHQOHatBy6EKLFjoyjGoE4cUUta4Ixq4tMBNzEA=
 matrix:
-  allow_failures:
-    - rvm: ruby-head
   exclude:
     - rvm: 1.9.3
       env: PUPPET_GEM_VERSION="~> 2.7.0"
-    - rvm: ruby-head
+    - rvm: 2.0.0
       env: PUPPET_GEM_VERSION="~> 2.7.0"
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 2.6.0"
-    - rvm: ruby-head
-      env: PUPPET_GEM_VERSION="~> 2.6.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.0.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
-source :rubygems
+source 'https://rubygems.org'
 
 group :development, :test do
+  gem 'rake',                   :require => false
+  gem 'rspec-puppet',           :require => false
   gem 'puppetlabs_spec_helper', :require => false
+  gem 'puppet-lint',            :require => false
 end
 
 if puppetversion = ENV['PUPPET_GEM_VERSION']


### PR DESCRIPTION
- Remove `create_resources` and other Puppet 2.6.x stuff
- Add Ruby 2.0.0 and Puppet 3.2.x
- Add missing bundler gems
- Add travis/forge autopublish
