### PR TITLE
Release 0.7.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+2013-07-26 - Version 0.7.1
+Bugfixes:
+- Single-quote password for special characters
+- Update travis testing for puppet 3.2.x and missing Bundler gems
+
 2013-06-25 - Version 0.7.0
 This is a maintenance release for community bugfixes and exposing
 configuration variables.

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'puppetlabs-mysql'
-version '0.7.0'
+version '0.7.1'
 source 'git://github.com/puppetlabs/puppetlabs-mysql.git'
 author 'Puppet Labs'
 license 'Apache 2.0'


### PR DESCRIPTION
Bugfixes:
- Single-quote password for special characters
- Update travis testing for puppet 3.2.x and missing Bundler gems
