### PR TITLE
Cover Fedora 19's move from mysql to mariadb packages

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,8 +46,14 @@ class mysql::params {
 
   case $::osfamily {
     'RedHat': {
+      if $::operatingsystem == 'Fedora' and $::operatinsystemrelease >= 19 {
+        $client_package_name = 'mariadb'
+        $server_package_name = 'mariadb-server'
+      } else {
+        $client_package_name = 'mysql'
+        $server_package_name = 'mysql-server'
+      }
       $basedir               = '/usr'
-      $client_package_name   = 'mysql'
       $config_file           = '/etc/my.cnf'
       $datadir               = '/var/lib/mysql'
       $tmpdir                = '/tmp'
@@ -61,7 +67,6 @@ class mysql::params {
       $ruby_package_name     = 'ruby-mysql'
       $ruby_package_provider = 'gem'
       $service_name          = 'mysqld'
-      $server_package_name   = 'mysql-server'
       $socket                = '/var/lib/mysql/mysql.sock'
       $ssl_ca                = '/etc/mysql/cacert.pem'
       $ssl_cert              = '/etc/mysql/server-cert.pem'


### PR DESCRIPTION
In their latest release, Fedora moved from mysql to mariadb. While the new packages "Provide" the old ones and Fedora's native tools handle this situation very well, Puppet's rpm provider unfortunately doesn't.

Therefore, if the OS is Fedora >= 19, the package names need to be s/mysql/mariadb/ now. Note that paths, etc. did not change.
