### PR TITLE
Fixed PID file location for SLES 11 SP2.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -90,7 +90,10 @@ class mysql::params {
         /OpenSuSE/           => '/var/run/mysql/mysql.sock',
         /(SLES|SLED)/        => '/var/lib/mysql/mysql.sock',
         }
-      $pidfile               = '/var/run/mysql/mysqld.pid'
+      $pidfile               = $::operatingsystem ? {
+        /OpenSuSE/           => '/var/run/mysql/mysqld.pid',
+        /(SLES|SLED)/        => '/var/lib/mysql/mysqld.pid',
+        }
       $config_file           = '/etc/my.cnf'
       $log_error             = $::operatingsystem ? {
         /OpenSuSE/           => '/var/log/mysql/mysqld.log',


### PR DESCRIPTION
In mysql/manifests/params.pp the location of the PID file is set to /var/run/mysql/mysqld.pid:

```
...
'Suse': {
  $socket                = $::operatingsystem ? {
    /OpenSuSE/           => '/var/run/mysql/mysql.sock',
    /(SLES|SLED)/        => '/var/lib/mysql/mysql.sock',
    }
  $pidfile               = '/var/run/mysql/mysqld.pid'
  $config_file           = '/etc/my.cnf'
  ...
}
...
```

But if you install MySQL under SLES 11 SP2 then there is no /var/run/mysql directory and the PID file is saved at /var/lib/mysql/mysqld.pid:

```
$ cat /etc/SuSE-release 
SUSE Linux Enterprise Server 11 (x86_64)
VERSION = 11
PATCHLEVEL = 2

$ zypper install mysql
...
Installing: mysql-5.0.94-0.2.4.1 [done]
...

$ /etc/init.d/mysql start
...
Starting service MySQL

$ ls /var/run/mysql
ls: cannot access /var/run/mysql: No such file or directory

$ ls /var/lib/mysql/mysqld.pid
/var/lib/mysql/mysqld.pid

$ cat /var/lib/mysql/mysqld.pid
3809

$ ps -p 3809
  PID TTY          TIME CMD
 3809 ?        00:00:00 mysqld
```

With the current mysql/manifests/params.pp the following snippet works only for the first run:

```
include mysql

class { "mysql::server": }

mysql::db { "test_db":
  user => "test_user",
  password => "D26WryKZwBL2mgaf3I9R",
  host => "localhost",
  grant => ["all"]
}
```

On the second run, the following error happens:

```
Notice: /Stage[main]/Mysql::Server/Service[mysqld]/ensure: ensure changed 'stopped' to 'running'
Error: Execution of '/usr/bin/mysql --defaults-file=/root/.my.cnf -NBe create database `test_db` character set utf8' returned 1: ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/lib/mysql/mysql.sock' (2)

Error: /Stage[main]/.../Mysql::Db[test_db]/Database[test_db]/ensure: change from absent to present failed: Execution of '/usr/bin/mysql --defaults-file=/root/.my.cnf -NBe create database `test_db` character set utf8' returned 1: ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/lib/mysql/mysql.sock' (2)

Notice: /Stage[main]/.../Mysql::Db[test_db]/Database_user[test_user@localhost]: Dependency Database[test_db] has failures: true
Warning: /Stage[main]/.../Mysql::Db[test_db]/Database_user[test_user@localhost]: Skipping because of failed dependencies
Error: Could not prefetch database_grant provider 'mysql': Execution of '/usr/bin/mysql --defaults-file=/root/.my.cnf mysql -Be describe user' returned 1: ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/lib/mysql/mysql.sock' (2)

Notice: /Stage[main]/.../Mysql::Db[test_db]/Database_grant[test_user@localhost/test_db]: Dependency Database[test_db] has failures: true
Warning: /Stage[main]/.../Mysql::Db[test_db]/Database_grant[test_user@localhost/test_db]: Skipping because of failed dependencies
...
```

This pull request corrects the location of the PID file for SLES 11 SP2 and fixes the above problem.
