### PR TITLE
include mysql_client package as a requirement for the db creation

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -43,10 +43,6 @@ define mysql::db (
   $enforce_sql = false,
   $ensure      = 'present'
 ) {
-  #prereqs
-  include mysql
-
-  $client_package_name = $mysql::client_package_name
   #input validation
   validate_re($ensure, '^(present|absent)$',
   "${ensure} is not supported for ensure. Allowed values are 'present' and 'absent'.")
@@ -55,7 +51,7 @@ define mysql::db (
     ensure   => $ensure,
     charset  => $charset,
     provider => 'mysql',
-    require  => [Class['mysql::server'],Package[$client_package_name]],
+    require  => [Class['mysql::server'],Package['mysql_client']],
     before   => Database_user["${user}@${host}"],
   }
 


### PR DESCRIPTION
Update the mysql::db defined type for issue #221, adding a requirement that the mysql client package be installed before trying to create a database
