### PR TITLE
Remove redundant hard coded replication parameters

### DIFF
--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -84,8 +84,6 @@ ft_max_word_len = <%= @ft_max_word_len %>
 <% if @log_error != 'syslog' -%>
 log_error           = <%= @log_error %>
 <% end -%>
-expire_logs_days    = 10
-max_binlog_size     = 100M
 <% if @default_engine != 'UNSET' %>
 default-storage-engine = <%= @default_engine %>
 <% end -%>


### PR DESCRIPTION
The following new `mysql` class replication parameters were added in 0.8.0, however the existing hard coded parameters were not removed from the my.conf.erb template:
- `expire_logs_days`
- `max_binlog_size`

Sorry about the noise with the previous pull request, I saw it failed the tests because I moved the parameters. I didn't see any test for these lines which would be removed so this should be OK. This is my first ever pull request so I was always bound to make a mistake!
