### PR TITLE
Added slow_query_log and slow_query_log_file variables.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -43,6 +43,8 @@
 #   [*table_open_cache]     - The number of open tables for all threads.
 #   [*long_query_time]      - If a query takes longer than this many seconds,
 #     the server increments the Slow_queries status variable.
+#   [*slow_query_log]
+#   [*slow_query_log_file]
 #   [*server_id]            - The server ID, used in replication to give each
 #     master and slave a unique identity.
 #   [*sql_log_bin]          - This variable controls whether logging to the
@@ -119,6 +121,8 @@ class mysql::config(
   $max_heap_table_size              = 'UNSET',
   $table_open_cache                 = 'UNSET',
   $long_query_time                  = 'UNSET',
+  $slow_query_log                   = 'UNSET',
+  $slow_query_log_file              = 'UNSET',
   $character_set                    = 'UNSET',
   $server_id                        = 'UNSET',
   $sql_log_bin                      = 'UNSET',

--- a/spec/classes/mysql_config_spec.rb
+++ b/spec/classes/mysql_config_spec.rb
@@ -26,6 +26,8 @@ describe 'mysql::config' do
      :max_heap_table_size             => 'UNSET',
      :table_open_cache                => 'UNSET',
      :long_query_time                 => 'UNSET',
+     :slow_query_log                  => 'UNSET',
+     :slow_query_log_file             => 'UNSET',
      :server_id                       => 'UNSET',
      :sql_log_bin                     => 'UNSET',
      :log_bin                         => 'UNSET',
@@ -155,6 +157,8 @@ describe 'mysql::config' do
             :max_heap_table_size  => '4096M',
             :table_open_cache     => 2048,
             :long_query_time      => 0.5,
+            :slow_query_log       => 1,
+            :slow_query_log_file  => '/tmp/slow.log',
             :ft_min_word_len      => 3,
             :ft_max_word_len      => 10
           }
@@ -234,6 +238,12 @@ describe 'mysql::config' do
               end
               if param_values[:long_query_time] != 'UNSET'
                 expected_lines = expected_lines | [ "long_query_time     = #{param_values[:long_query_time]}" ]
+              end
+              if param_values[:slow_query_log] != 'UNSET'
+                expected_lines = expected_lines | [ "slow_query_log      = #{param_values[:slow_query_log]}" ]
+              end
+              if param_values[:slow_query_log_file] != 'UNSET'
+                expected_lines = expected_lines | [ "slow_query_log_file = #{param_values[:slow_query_log_file]}" ]
               end
               if param_values[:ft_min_word_len] != 'UNSET'
                 expected_lines = expected_lines | [ "ft_min_word_len = #{param_values[:ft_min_word_len]}" ]

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -50,6 +50,12 @@ table_open_cache    = <%= @table_open_cache %>
 <% if @long_query_time != 'UNSET' -%>
 long_query_time     = <%= @long_query_time %>
 <% end -%>
+<% if @slow_query_log != 'UNSET' -%>
+slow_query_log      = <%= @slow_query_log %>
+<% end -%>
+<% if @slow_query_log_file != 'UNSET' -%>
+slow_query_log_file = <%= @slow_query_log_file %>
+<% end -%>
 <% if @server_id != 'UNSET' -%>
 server-id           = <%= @server_id %>
 <% end -%>


### PR DESCRIPTION
This pull request adds the variables slow_query_log and slow_query_log_file to the mysql::config class.

MySQL 5.1:
- [slow_query_log](https://dev.mysql.com/doc/refman/5.1/en/server-system-variables.html#sysvar_slow_query_log)
- [slow_query_log_file](https://dev.mysql.com/doc/refman/5.1/en/server-system-variables.html#sysvar_slow_query_log_file)

MySQL 5.5:
- [slow_query_log](https://dev.mysql.com/doc/refman/5.5/en/server-system-variables.html#sysvar_slow_query_log)
- [slow_query_log_file](https://dev.mysql.com/doc/refman/5.5/en/server-system-variables.html#sysvar_slow_query_log_file)

MySQL 5.6:
- [slow_query_log](https://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_slow_query_log)
- [slow_query_log_file](https://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_slow_query_log_file)

Tests are green:

```
$ bundle exec rake spec
...
Finished in 8.58 seconds
162 examples, 0 failures
```
