### PR TITLE
Remove Unneeded Dependency

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -51,7 +51,7 @@ define mysql::db (
     ensure   => $ensure,
     charset  => $charset,
     provider => 'mysql',
-    require  => [Class['mysql::server'],Package['mysql_client']],
+    require  => [Class['mysql::config'],Package['mysql_client']],
     before   => Database_user["${user}@${host}"],
   }
 


### PR DESCRIPTION
require  => [Class['mysql::server'],Package['mysql_client']],

The require above prevents users from leveraging other
mysql plugins such as galera:

  https://github.com/CiscoSystems/puppet-galera

I don't believe that the dependency on mysql::server
actually works.

If this is not acceptible, then an alternate solution could be:

Remove this:
require  => [Class['mysql::server'],Package['mysql_client']],

and replace with
Class<| 'mysql::server' |> ->Database [$name]
