### PR TITLE
Support Fedora's rolling development "release", Rawhide

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,7 +53,7 @@ class mysql::params {
 
   case $::osfamily {
     'RedHat': {
-      if $::operatingsystem == 'Fedora' and $::operatingsystemrelease >= 19 {
+      if $::operatingsystem == 'Fedora' and (is_integer($::operatingsystemrelease) and $::operatingsystemrelease >= 19 or $::operatingsystemrelease == "Rawhide") {
         $client_package_name = 'mariadb'
         $server_package_name = 'mariadb-server'
       } else {


### PR DESCRIPTION
Since Rawhide is a rolling kind of release with no version numbers,
the operatingsystemrelease will actually return "Rawhide" instead
of any Integer. So we better check whether operatingsystemrelease
is an Integer before comparing numbers and cover Rawhide, too.
