### PR TITLE
added support to manage grants per table

### DIFF
--- a/lib/puppet/provider/database_grant/mysql.rb
+++ b/lib/puppet/provider/database_grant/mysql.rb
@@ -1,7 +1,8 @@
-# A grant is either global or per-db. This can be distinguished by the syntax
+# A grant is either global, per-db or per table. This can be distinguished by the syntax
 # of the name:
 #   user@host => global
 #   user@host/db => per-db
+#   user@host/db.table => per-table
 
 Puppet::Type.type(:database_grant).provide(:mysql) do
 


### PR DESCRIPTION
I need to manage a couple of grants on tables and the module only supports global and database level.

The syntax for the grants per table is:

``` ruby
 database_grant  { "user@hostname/mysql.proc":
    privileges => ['select'],
    require    => Database_user['user@hostname'],
  }
```

The privileges format for the tables_priv table is different from the db table. The valid privileges are:
**'Select','Insert','Update','Delete','Create','Drop','Grant','References','Index','Alter','Create View','Show view','Trigger'**

It's very likely that this code has bugs, but at least, it seems to work.
I don't know ruby to well, so I hacked my way through this code. It might help someone to make a proper job with it.
