### PR TITLE
Add HOME environment variable for .my.cnf to mysqladmin command

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -172,11 +172,12 @@ class mysql::config(
     }
 
     exec { 'set_mysql_rootpw':
-      command   => "mysqladmin -u root ${old_pw} password '${root_password}'",
-      logoutput => true,
-      unless    => "mysqladmin -u root -p'${root_password}' status > /dev/null",
-      path      => '/usr/local/sbin:/usr/bin:/usr/local/bin',
-      notify    => $restart ? {
+      command     => "mysqladmin -u root ${old_pw} password '${root_password}'",
+      logoutput   => true,
+      environment => "HOME=${root_home}",
+      unless      => "mysqladmin -u root -p'${root_password}' status > /dev/null",
+      path        => '/usr/local/sbin:/usr/bin:/usr/local/bin',
+      notify      => $restart ? {
         true  => Exec['mysqld-restart'],
         false => undef,
       },


### PR DESCRIPTION
In Puppet 3, the 'mysqladmin' command needs a HOME environment variable setting, in order to find the password stored in ~/.my.conf.  Pull request #243 fixed this issue for the 'mysql' command; this one fixes it for 'mysqladmin'.
