### PR TITLE
Add option so mysql::backup to dump each database to its own file

### DIFF
--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -9,6 +9,7 @@
 #   [*backupcompress*]     - Boolean to compress backup with bzip2.
 #   [*backuprotate*]       - Number of backups to keep. Default 30
 #   [*backupdatabases*]    - Specify databases to back up as array (default all)
+#   [*file_per_database*]  - Boolean to dump each database to its own file.
 #   [*delete_before_dump*] - Clean existing backups before creating new
 #
 # Actions:
@@ -34,6 +35,7 @@ class mysql::backup (
   $backuprotate = 30,
   $delete_before_dump = false,
   $backupdatabases = [],
+  $file_per_database = false,
   $ensure = 'present'
 ) {
 

--- a/spec/system/mysql_backup_spec.rb
+++ b/spec/system/mysql_backup_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper_system'
+
+describe 'mysql::backup class' do
+  context 'should work with no errors' do
+    pp = <<-EOS
+      class { 'mysql::server': config_hash => { 'root_password' => 'foo' } }
+      mysql::db { 'backup1':
+        user     => 'backup',
+        password => 'secret',
+      }
+      
+      class { 'mysql::backup':
+        backupuser     => 'myuser',
+        backuppassword => 'mypassword',
+        backupdir      => '/tmp/backups',
+        backupcompress => true,
+      }
+    EOS
+
+    context puppet_apply(pp) do
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should_not == 1 }
+      its(:refresh) { should be_nil }
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should be_zero }
+    end
+
+    context 'should run mysqlbackup.sh with no errors' do
+      context shell("/usr/local/sbin/mysqlbackup.sh") do
+        its(:exit_code) { should be_zero }
+      end
+    end
+  
+    context 'should dump all databases to single file' do
+      describe command('ls /tmp/backups/ | grep -c "mysql_backup_[0-9][0-9]*-[0-9][0-9]*.sql.bz2"') do
+        it { should return_stdout /1/ }
+        it { should return_exit_status 0 }
+      end
+    end
+  end
+
+
+  context 'should create one file per database' do
+    pp = <<-EOS
+      class { 'mysql::server': config_hash => { 'root_password' => 'foo' } }
+      mysql::db { 'backup1':
+        user     => 'backup',
+        password => 'secret',
+      }
+      
+      class { 'mysql::backup':
+        backupuser        => 'myuser',
+        backuppassword    => 'mypassword',
+        backupdir         => '/tmp/backups',
+        backupcompress    => true,
+        file_per_database => true,
+      }
+    EOS
+
+    context puppet_apply(pp) do
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should_not == 1 }
+      its(:refresh) { should be_nil }
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should be_zero }
+    end
+
+    context shell("/usr/local/sbin/mysqlbackup.sh") do
+      its(:exit_code) { should be_zero }
+    end
+    
+    describe command('ls /tmp/backups/ | grep -c "mysql_backup_backup1_[0-9][0-9]*-[0-9][0-9]*.sql.bz2"') do
+      it { should return_stdout /1/ }
+      it { should return_exit_status 0 }
+    end
+  end
+end

--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -32,8 +32,16 @@ cleanup
 
 <% end -%>
 <% if @backupdatabases.empty? -%>
+<% if @file_per_database -%>
+mysql -s -r -N -e 'SHOW DATABASES' | while read dbname
+do
+  mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \
+    ${dbname} <% if @backupcompress %>| bzcat -zc <% end %>> ${DIR}/${PREFIX}${dbname}_`date +%Y%m%d-%H%M%S`.sql<% if @backupcompress %>.bz2<% end  %>
+done
+<% else -%>
 mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \
  --all-databases <% if @backupcompress %>| bzcat -zc <% end %>> ${DIR}/${PREFIX}`date +%Y%m%d-%H%M%S`.sql<% if @backupcompress %>.bz2<% end  %>
+<% end -%>
 <% else -%>
 <% @backupdatabases.each do |db| -%>
 mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \


### PR DESCRIPTION
I added a **file_per_database** parameter to mysql::backup that will modify the mysqlbackup.sh script to loop over all databases and dump each database to it's own file.

Alternatively, a "magic" value for backupdatabases could be used that performs the same changes as file_per_database, something like `backupdatabases => 'each'`.  

Also added rspec-system based tests for the mysql::backup class.
