### PR TITLE
Add quote to username and host in mysql_grant constructor

### DIFF
--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -6,7 +6,8 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
   def self.instances
     instances = []
     users.select{ |user| user =~ /.+@/ }.collect do |user|
-      query = "SHOW GRANTS FOR #{user};"
+      user_string  = "'#{user.sub('@', "'@'")}'"
+      query = "SHOW GRANTS FOR #{user_string};"
       grants = mysql([defaults_file, "-NBe", query].compact)
       # Once we have the list of grants generate entries for each.
       grants.each_line do |grant|


### PR DESCRIPTION
The quote is need for username and host in mysql grant. revoke and grant function is already doing it with cmd_user(). not sure why the constructor didn't do it. This patch fixed #261 and #262.
