### PR TITLE
Add optional 'innodb_file_per_table' parameter to mysql server config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -129,7 +129,8 @@ class mysql::config(
   $replicate_wild_do_table          = 'UNSET',
   $replicate_wild_ignore_table      = 'UNSET',
   $ft_min_word_len                  = 'UNSET',
-  $ft_max_word_len                  = 'UNSET'
+  $ft_max_word_len                  = 'UNSET',
+  $innodb_file_per_table            = 'UNSET'
 ) inherits mysql {
 
   File {
@@ -172,12 +173,11 @@ class mysql::config(
     }
 
     exec { 'set_mysql_rootpw':
-      command     => "mysqladmin -u root ${old_pw} password '${root_password}'",
-      logoutput   => true,
-      environment => "HOME=${root_home}",
-      unless      => "mysqladmin -u root -p'${root_password}' status > /dev/null",
-      path        => '/usr/local/sbin:/usr/bin:/usr/local/bin',
-      notify      => $restart ? {
+      command   => "mysqladmin -u root ${old_pw} password '${root_password}'",
+      logoutput => true,
+      unless    => "mysqladmin -u root -p'${root_password}' status > /dev/null",
+      path      => '/usr/local/sbin:/usr/bin:/usr/local/bin',
+      notify    => $restart ? {
         true  => Exec['mysqld-restart'],
         false => undef,
       },

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -96,6 +96,10 @@ ssl-cert  = <%= @ssl_cert %>
 ssl-key   = <%= @ssl_key %>
 <% end -%>
 
+<%if @innodb_file_per_table != 'UNSET' %>
+innodb_file_per_table = <%= @innodb_file_per_table %>
+<% end -%>
+
 [mysqldump]
 quick
 quote-names


### PR DESCRIPTION
Hi,

I needed this parameter to be set on my mysql servers.

Would it be a good idea to add all innodb options to the my.cnf or would it be better to create a separated config in conf.d?

Cheers,

Jeroen
