### PR TITLE
Added missing declaration for perl_package_provider

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -76,7 +76,7 @@ class mysql::params {
       # mysql::bindings
       $java_package_name     = 'mysql-connector-java'
       $perl_package_name     = 'perl-DBD-MySQL'
-      $perl_package_provider = 'yum'
+      $perl_package_provider = undef
       $python_package_name   = 'MySQL-python'
       $ruby_package_name     = 'ruby-mysql'
       $ruby_package_provider = 'gem'
@@ -115,7 +115,7 @@ class mysql::params {
       # mysql::bindings
       $java_package_name     = 'mysql-connector-java'
       $perl_package_name     = 'perl-DBD-mysql'
-      $perl_package_provider = 'rug'
+      $perl_package_provider = undef
       $python_package_name   = 'python-mysql'
       $ruby_package_name     = $::operatingsystem ? {
         /OpenSuSE/           => 'rubygem-mysql',
@@ -142,7 +142,7 @@ class mysql::params {
       # mysql::bindings
       $java_package_name     = 'libmysql-java'
       $perl_package_name     = 'libdbd-mysql-perl'
-      $perl_package_provider = 'apt'
+      $perl_package_provider = undef
       $python_package_name   = 'python-mysqldb'
       $ruby_package_name     = 'libmysql-ruby'
     }
@@ -166,7 +166,7 @@ class mysql::params {
       # mysql::bindings
       $java_package_name     = 'databases/mysql-connector-java'
       $perl_package_name     = 'p5-DBD-mysql'
-      $perl_package_provider = 'ports'
+      $perl_package_provider = undef
       $python_package_name   = 'databases/py-MySQLdb'
       $ruby_package_name     = 'ruby-mysql'
       $ruby_package_provider = 'gem'
@@ -192,7 +192,7 @@ class mysql::params {
           # mysql::bindings
           $java_package_name     = 'mysql-connector-java'
           $perl_package_name     = 'perl-DBD-MySQL'
-          $perl_package_provider = 'yum'
+          $perl_package_provider = undef
           $python_package_name   = 'MySQL-python'
           $ruby_package_name     = 'ruby-mysql'
           $ruby_package_provider = 'gem'

--- a/spec/classes/mysql_bindings_perl_spec.rb
+++ b/spec/classes/mysql_bindings_perl_spec.rb
@@ -9,7 +9,7 @@ describe 'mysql::bindings::perl' do
     it { should contain_package('perl_mysql').with(
       :name     => 'libdbd-mysql-perl',
       :ensure   => 'present',
-      :provider => 'apt'
+      :provider => ''
     )}
   end
 
@@ -20,7 +20,7 @@ describe 'mysql::bindings::perl' do
     it { should contain_package('perl_mysql').with(
       :name     => 'p5-DBD-mysql',
       :ensure   => 'present',
-      :provider => 'ports'
+      :provider => ''
     )}
   end
 
@@ -31,7 +31,7 @@ describe 'mysql::bindings::perl' do
     it { should contain_package('perl_mysql').with(
       :name   => 'perl-DBD-MySQL',
       :ensure => 'present',
-      :provider => 'yum'
+      :provider => ''
     )}
     describe 'when parameters are supplied' do
       let :params do


### PR DESCRIPTION
The variable perl_package_provider which is used in mysql::bindings, mysql::perl and mysql::bindings::perl as a default parameter value was never declared in mysql::params
