### PR TITLE
Fix mysql::client.

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,6 +1,8 @@
 #
 class mysql::client (
-  $bindings_enable = false,
+  $bindings_enable = $mysql::params::bindings_enable,
+  $package_ensure  = $mysql::params::client_package_ensure,
+  $package_name    = $mysql::params::client_package_name,
 ) inherits mysql::params {
 
   include '::mysql::client::install'

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -1,11 +1,8 @@
-class mysql::client::install(
-  $package_name   = $mysql::params::client_package_name,
-  $package_ensure = $mysql::params::client_package_ensure
-) {
+class mysql::client::install {
 
   package { 'mysql_client':
-    ensure => $package_ensure,
-    name   => $package_name,
+    ensure => $mysql::client::package_ensure,
+    name   => $mysql::client::package_name,
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class mysql::params {
   $server_service_manage  = true
   $server_service_enabled = true
   # mysql::bindings
+  $bindings_enable        = false
   $java_package_ensure    = 'present'
   $perl_package_ensure    = 'present'
   $php_package_ensure     = 'present'


### PR DESCRIPTION
This was still relying on globals.  Allow you to pass params into
mysql::client properly to set the package.
