### PR TITLE
Remove mysql user check to write .my.cnf

### DIFF
--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -12,7 +12,6 @@ class mysql::server::root_password {
 
     file { "${::root_home}/.my.cnf":
       content => template('mysql/my.cnf.pass.erb'),
-      require => Mysql_user['root@localhost'],
     }
   }
 


### PR DESCRIPTION
This is a fix for issue 294.   If .my.cnf is removed or does not exist, puppet is not able to run the MySQL queries required to check that 'root@localhost' exists because the defaults_file does not exist and then, as specified in the reported issue, no password is passed to the query.
