### PR TITLE
Fix mysql::server::monitor mysql_grant privileges

### DIFF
--- a/manifests/server/monitor.pp
+++ b/manifests/server/monitor.pp
@@ -6,18 +6,17 @@ class mysql::server::monitor (
   $mysql_monitor_hostname
 ) {
 
-  Class['mysql::server'] -> Class['mysql::server::monitor']
-
-  mysql_user{ "${mysql_monitor_username}@${mysql_monitor_hostname}":
+  mysql_user { "${mysql_monitor_username}@${mysql_monitor_hostname}":
     ensure        => present,
     password_hash => mysql_password($mysql_monitor_password),
+    require       => Class['mysql::config'],
   }
 
-  mysql_grant { "${mysql_monitor_username}@${mysql_monitor_hostname}":
+  mysql_grant { "${mysql_monitor_username}@${mysql_monitor_hostname}/*.*":
     ensure     => present,
     user       => "${mysql_monitor_username}@${mysql_monitor_hostname}",
     table      => '*.*',
-    privileges => [ 'PROCESS_PRIV', 'SUPER_PRIV' ],
+    privileges => [ 'PROCESS', 'SUPER' ],
     require    => Mysql_user["${mysql_monitor_username}@${mysql_monitor_hostname}"],
   }
 

--- a/spec/classes/mysql_server_monitor_spec.rb
+++ b/spec/classes/mysql_server_monitor_spec.rb
@@ -6,13 +6,26 @@ describe 'mysql::server::monitor' do
   let :pre_condition do
     "include 'mysql::server'"
   end
-  let :params do
+
+  let :default_params do
     {
-      :mysql_monitor_username => 'monitoruser',
-      :mysql_monitor_password => 'monitorpass',
-      :mysql_monitor_hostname => 'monitorhost'
+      :mysql_monitor_username   => 'monitoruser',
+      :mysql_monitor_password   => 'monitorpass',
+      :mysql_monitor_hostname   => 'monitorhost',
     }
   end
 
+  let :params do
+    default_params
+  end
+
   it { should contain_mysql_user('monitoruser@monitorhost')}
+
+  it { should contain_mysql_grant('monitoruser@monitorhost/*.*').with(
+    :ensure     => 'present',
+    :user       => 'monitoruser@monitorhost',
+    :table      => '*.*',
+    :privileges => ["PROCESS", "SUPER"],
+    :require    => 'Mysql_user[monitoruser@monitorhost]'
+  )}
 end

--- a/spec/system/mysql_server_monitor_spec.rb
+++ b/spec/system/mysql_server_monitor_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper_system'
+
+describe 'mysql::server::monitor class' do
+  context 'should work with no errors' do
+    pp = <<-EOS
+      class { 'mysql::server': config_hash => { 'root_password' => 'foo' } }
+      
+      class { 'mysql::server::monitor':
+        mysql_monitor_username => 'monitoruser',
+        mysql_monitor_password => 'monitorpass',
+        mysql_monitor_hostname => 'localhost',
+      }
+    EOS
+
+    context puppet_apply(pp) do
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should_not == 1 }
+      its(:refresh) { should be_nil }
+      its(:stderr) { should be_empty }
+      its(:exit_code) { should be_zero }
+    end
+
+    context 'should run mysqladmin ping with no errors' do
+      describe command("mysqladmin -u monitoruser -pmonitorpass -h localhost ping") do
+        it { should return_stdout /mysqld is alive/ }
+        it { should return_exit_status 0 }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes invalid privileges being used with the mysql_grant type as well as makes the module conform to mysql::backup's style.  Should be released as a bug fix as the class' behavior does not change.

This bug is also present in the 2.0.x releases.

This is the type of error that would be generated before this fix.

```
Error: Execution of '/usr/bin/mysql --defaults-file=/root/.my.cnf -e GRANT PROCESS_PRIV, SUPER_PRIV ON *.* TO 'zabbix-agent'@'localhost'' returned 1: ERROR 1064 (42000) at line 1: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'PROCESS_PRIV, SUPER_PRIV ON *.* TO 'zabbix-agent'@'localhost'' at line 1
```
