### PR TITLE
Update mysql::server test

### DIFF
--- a/tests/server.pp
+++ b/tests/server.pp
@@ -1,3 +1,3 @@
 class { 'mysql::server':
-  config_hash => { 'root_password' => 'password', },
+  root_password => 'password',
 }


### PR DESCRIPTION
With the update to the new version of mysql, the test for the mysql::server
class is incorrect.  This quick commit updates the test according to the new
syntax.
