### PR TITLE
Fix ordering causing mysql_grant to reapply.

### DIFF
--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
           instances << new(
               :name       => "#{user}@#{host}/#{table}",
               :ensure     => :present,
-              :privileges => stripped_privileges,
+              :privileges => stripped_privileges.sort,
               :table      => table,
               :user       => "#{user}@#{host}",
               :options    => options

--- a/lib/puppet/type/mysql_grant.rb
+++ b/lib/puppet/type/mysql_grant.rb
@@ -16,6 +16,10 @@ Puppet::Type.newtype(:mysql_grant) do
     if self[:ensure] == :present and Array(self[:privileges]).count > 1 and self[:privileges].to_s.include?('ALL')
       self[:privileges] = 'ALL'
     end
+    # Sort the privileges array in order to ensure the comparision in the provider
+    # self.instances method match.  Otherwise this causes it to keep resetting the
+    # privileges.
+    self[:privileges] = Array(self[:privileges]).sort!
   end
 
   validate do
@@ -26,6 +30,7 @@ Puppet::Type.newtype(:mysql_grant) do
 
   newparam(:name, :namevar => true) do
     desc 'Name to describe the grant.'
+
     munge do |value|
       value.delete("'")
     end
@@ -33,7 +38,6 @@ Puppet::Type.newtype(:mysql_grant) do
 
   newproperty(:privileges, :array_matching => :all) do
     desc 'Privileges for user'
-
   end
 
   newproperty(:table) do


### PR DESCRIPTION
Because arrays are ordered lists, Puppet compares the list of retrieved
privileges against the defined privilege list.  This causes it to
reapply privilege if the ordering differs.  We now forcibly order in
the type and the provider to make sure we never falsely reapply
privileges.
