### PR TITLE
Adds example to set root password

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ pass in an override hash as seen below:
 
 ```puppet
 class { '::mysql::server':
+  root_password    => 'strongpassword',
   override_options => { 'mysqld' => { 'max_connections' => '1024' } }
 }
 ```


### PR DESCRIPTION
The documentation in README.md states that it is possible to set the root password, but it does not give an example. 

This pull request adds an example of how to set the root password
