### PR TITLE
Add Anchor pattern to client.pp

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -20,7 +20,10 @@ class mysql::client (
   anchor { 'mysql::client::start': }
   anchor { 'mysql::client::end': }
 
+  # Anchor pattern workaround to avoid resources of mysql::client::install 
+  # to "float off" outside mysql::client
   Anchor['mysql::client::start'] ->
+  Class['mysql::client'] ->
   Class['mysql::client::install'] ->
   Anchor['mysql::client::end']
 


### PR DESCRIPTION
The class mysql::client::install should be "contained" in the mysql::client to avoid floating, like it's the case for mysql::server.
