### PR TITLE
Captilize all privileges supplied to mysql_grant

### DIFF
--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
             priv == 'ALL PRIVILEGES' ? 'ALL' : priv.lstrip.rstrip
           end
           # Same here, but to remove OPTION leaving just GRANT.
-          options = rest.match(/WITH\s(.*)\sOPTION$/).captures if rest.include?('WITH')
+          options = rest.include?('WITH') ? rest.match(/WITH\s(.*)\sOPTION$/).captures : ['']
           # We need to return an array of instances so capture these
           instances << new(
               :name       => "#{user}@#{host}/#{table}",
@@ -54,7 +54,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
     query = "GRANT #{priv_string}"
     query << " ON #{table_string}"
     query << " TO #{user_string}"
-    query << self.class.cmd_options(options) unless options.nil?
+    query << self.class.cmd_options(options)
     mysql([defaults_file, '-e', query].compact)
   end
 
@@ -64,7 +64,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
     @property_hash[:ensure]     = :present
     @property_hash[:table]      = @resource[:table]
     @property_hash[:user]       = @resource[:user]
-    @property_hash[:options]    = @resource[:options] if @resource[:options]
+    @property_hash[:options]    = @resource[:options]
     @property_hash[:privileges] = @resource[:privileges]
 
     exists? ? (return true) : (return false)

--- a/lib/puppet/type/mysql_grant.rb
+++ b/lib/puppet/type/mysql_grant.rb
@@ -11,6 +11,14 @@ Puppet::Type.newtype(:mysql_grant) do
     if self[:ensure] == :present and Array(self[:privileges]).count > 0 and self[:privileges].to_s.include?('GRANT')
       fail('GRANT OPTION not allowed in privileges. Set via options.')
     end
+    # options should be replaced by a boolean property grant, but for 
+    # compatibility sake: Any option with grant in it is handled as grant grant
+    # option and any option without is handled as revoke grant option:
+    if self[:ensure] == :present and self[:options].to_s.upcase.include?('GRANT')
+      self[:options] = 'GRANT'
+    else
+      self[:options] = ''
+    end
     # Forcibly munge any privilege with 'ALL' in the array to exist of just
     # 'ALL'.  This can't be done in the munge in the property as that iterates
     # over the array and there's no way to replace the entire array before it's


### PR DESCRIPTION
It's possible to use privilege names that are not capitalized. They are granted correctly, but in subsequent puppet runs they are kept resetting, because they don't match the capitalized privileges the provider uses.
