### PR TITLE
Some options can not take a argument. 

### DIFF
--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -2,9 +2,11 @@
 <% if v.is_a?(Hash) -%>
 [<%= k %>]
 <% @options[k].sort.map do |ki, vi| -%>
-<% if vi and vi != '' -%>
+<% if vi == true -%>
+<%= ki %>
+<% elsif vi and vi != '' -%>
 <%= ki %> = <%= vi %>
-<% else -%>
+<% elsif vi -%>
 <%= ki %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Gets rid of the '= true' when an option is set to true. Also, leaves out options when set to false. See Issues #338 and #363
