### PR TITLE
Package cross-definition fix

### DIFF
--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -1,8 +1,9 @@
 class mysql::client::install {
 
-  package { 'mysql_client':
-    ensure => $mysql::client::package_ensure,
-    name   => $mysql::client::package_name,
+  if ! defined ( Package[$mysql::client::package_name] ) {
+    package { 'mysql_client':
+      ensure => $mysql::client::package_ensure,
+      name   => $mysql::client::package_name,
+    }
   }
-
 }


### PR DESCRIPTION
Added a check to see if the mysql-client package is already defined. This prevents conflicts with other modules which define it. The old syntax throws errors even if the other package definition uses the same syntax to check for the definition before defining it.

Are there better ways to avoid the common issue of resource re-declarations?
