### PR TITLE
Method for loading .my.cnf file is changed from "defaults-file" to "defaults-extra-file" (mysql option)

### DIFF
--- a/files/mysqltuner.pl
+++ b/files/mysqltuner.pl
@@ -294,7 +294,7 @@ sub mysql_setup {
 		}
 	} elsif ( -r "/etc/mysql/debian.cnf" and $doremote == 0 ){
 		# We have a debian maintenance account, use it
-		$mysqllogin = "--defaults-file=/etc/mysql/debian.cnf";
+		$mysqllogin = "--defaults-extra-file=/etc/mysql/debian.cnf";
 		my $loginstatus = `mysqladmin $mysqllogin ping 2>&1`;
 		if ($loginstatus =~ /mysqld is alive/) {
 			goodprint "Logged in using credentials from debian maintenance account.\n";

--- a/lib/puppet/provider/database/mysql.rb
+++ b/lib/puppet/provider/database/mysql.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:database).provide(:mysql) do
 
   def self.defaults_file
     if File.file?("#{Facter.value(:root_home)}/.my.cnf")
-      "--defaults-file=#{Facter.value(:root_home)}/.my.cnf"
+      "--defaults-extra-file=#{Facter.value(:root_home)}/.my.cnf"
     else
       nil
     end

--- a/lib/puppet/provider/database_grant/mysql.rb
+++ b/lib/puppet/provider/database_grant/mysql.rb
@@ -198,7 +198,7 @@ Puppet::Type.type(:database_grant).provide(:mysql) do
   # Optional defaults file
   def self.defaults_file
     if File.file?("#{Facter.value(:root_home)}/.my.cnf")
-      "--defaults-file=#{Facter.value(:root_home)}/.my.cnf"
+      "--defaults-extra-file=#{Facter.value(:root_home)}/.my.cnf"
     else
       nil
     end

--- a/lib/puppet/provider/database_user/mysql.rb
+++ b/lib/puppet/provider/database_user/mysql.rb
@@ -64,7 +64,7 @@ Puppet::Type.type(:database_user).provide(:mysql) do
   # Optional defaults file
   def self.defaults_file
     if File.file?("#{Facter.value(:root_home)}/.my.cnf")
-      "--defaults-file=#{Facter.value(:root_home)}/.my.cnf"
+      "--defaults-extra-file=#{Facter.value(:root_home)}/.my.cnf"
     else
       nil
     end

--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -13,6 +13,7 @@ class Puppet::Provider::Mysql < Puppet::Provider
       nil
     end
   end
+  
   def defaults_file
     self.class.defaults_file
   end

--- a/lib/puppet/provider/mysql_database/mysql.rb
+++ b/lib/puppet/provider/mysql_database/mysql.rb
@@ -1,19 +1,8 @@
-Puppet::Type.type(:mysql_database).provide(:mysql) do
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'mysql'))
+Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::Mysql) do
   desc 'Manages MySQL databases.'
 
   commands :mysql => 'mysql'
-
-  def self.defaults_file
-    if File.file?("#{Facter.value(:root_home)}/.my.cnf")
-      "--defaults-extra-file=#{Facter.value(:root_home)}/.my.cnf"
-    else
-      nil
-    end
-  end
-
-  def defaults_file
-    self.class.defaults_file
-  end
 
   def self.instances
     mysql([defaults_file, '-NBe', 'show databases'].compact).split("\n").collect do |name|

--- a/lib/puppet/provider/mysql_user/mysql.rb
+++ b/lib/puppet/provider/mysql_user/mysql.rb
@@ -4,18 +4,6 @@ Puppet::Type.type(:mysql_user).provide(:mysql, :parent => Puppet::Provider::Mysq
   desc 'manage users for a mysql database.'
   commands :mysql => 'mysql'
 
-  # Optional defaults file
-  def self.defaults_file
-    if File.file?("#{Facter.value(:root_home)}/.my.cnf")
-      "--defaults-extra-file=#{Facter.value(:root_home)}/.my.cnf"
-    else
-      nil
-    end
-  end
-  def defaults_file
-    self.class.defaults_file
-  end
-
   # Build a property_hash containing all the discovered information about MySQL
   # users.
   def self.instances

--- a/spec/unit/puppet/provider/database/mysql_spec.rb
+++ b/spec/unit/puppet/provider/database/mysql_spec.rb
@@ -6,7 +6,7 @@ describe provider_class do
   subject { provider_class }
 
   let(:root_home) { '/root' }
-  let(:defaults_file) { '--defaults-file=/root/.my.cnf' }
+  let(:defaults_file) { '--defaults-extra-file=/root/.my.cnf' }
 
   let(:raw_databases) do
     <<-SQL_OUTPUT
@@ -28,7 +28,7 @@ test
     Facter.stubs(:value).with(:root_home).returns(root_home)
     Puppet::Util.stubs(:which).with('mysql').returns('/usr/bin/mysql')
     subject.stubs(:which).with('mysql').returns('/usr/bin/mysql')
-    subject.stubs(:defaults_file).returns('--defaults-file=/root/.my.cnf')
+    subject.stubs(:defaults_file).returns('--defaults-extra-file=/root/.my.cnf')
   end
 
   describe 'self.instances' do
@@ -77,9 +77,9 @@ test
   end
 
   describe 'self.defaults_file' do
-    it 'sets --defaults-file' do
+    it 'sets --defaults-extra-file' do
       File.stubs(:file?).with('#{root_home}/.my.cnf').returns(true)
-      @provider.defaults_file.should == '--defaults-file=/root/.my.cnf'
+      @provider.defaults_file.should == '--defaults-extra-file=/root/.my.cnf'
     end
   end
 

--- a/spec/unit/puppet/provider/database_grant/mysql_spec.rb
+++ b/spec/unit/puppet/provider/database_grant/mysql_spec.rb
@@ -18,7 +18,7 @@ describe provider_class do
   end
 
   it 'should query privileges from the database' do
-    provider_class.expects(:mysql) .with(["--defaults-file=#{root_home}/.my.cnf", 'mysql', '-Be', 'describe user']).returns <<-EOT
+    provider_class.expects(:mysql) .with(["--defaults-extra-file=#{root_home}/.my.cnf", 'mysql', '-Be', 'describe user']).returns <<-EOT
 Field	Type	Null	Key	Default	Extra
 Host	char(60)	NO	PRI		
 User	char(16)	NO	PRI		
@@ -27,7 +27,7 @@ Select_priv	enum('N','Y')	NO		N
 Insert_priv	enum('N','Y')	NO		N	
 Update_priv	enum('N','Y')	NO		N
 EOT
-    provider_class.expects(:mysql).with(["--defaults-file=#{root_home}/.my.cnf", 'mysql', '-Be', 'describe db']).returns <<-EOT
+    provider_class.expects(:mysql).with(["--defaults-extra-file=#{root_home}/.my.cnf", 'mysql', '-Be', 'describe db']).returns <<-EOT
 Field	Type	Null	Key	Default	Extra
 Host	char(60)	NO	PRI		
 Db	char(64)	NO	PRI		
@@ -41,7 +41,7 @@ EOT
   end
 
   it 'should query set privileges' do
-    provider_class.expects(:mysql).with(["--defaults-file=#{root_home}/.my.cnf", 'mysql', '-Be', "select * from mysql.user where user='user' and host='host'"]).returns <<-EOT
+    provider_class.expects(:mysql).with(["--defaults-extra-file=#{root_home}/.my.cnf", 'mysql', '-Be', "select * from mysql.user where user='user' and host='host'"]).returns <<-EOT
 Host	User	Password	Select_priv	Insert_priv	Update_priv
 host	user		Y	N	Y
 EOT
@@ -49,7 +49,7 @@ EOT
   end
 
   it 'should recognize when all privileges are set' do
-    provider_class.expects(:mysql).with(["--defaults-file=#{root_home}/.my.cnf", 'mysql', '-Be', "select * from mysql.user where user='user' and host='host'"]).returns <<-EOT
+    provider_class.expects(:mysql).with(["--defaults-extra-file=#{root_home}/.my.cnf", 'mysql', '-Be', "select * from mysql.user where user='user' and host='host'"]).returns <<-EOT
 Host	User	Password	Select_priv	Insert_priv	Update_priv
 host	user		Y	Y	Y
 EOT
@@ -57,7 +57,7 @@ EOT
   end
 
   it 'should recognize when all privileges are not set' do
-    provider_class.expects(:mysql).with(["--defaults-file=#{root_home}/.my.cnf", 'mysql', '-Be', "select * from mysql.user where user='user' and host='host'"]).returns <<-EOT
+    provider_class.expects(:mysql).with(["--defaults-extra-file=#{root_home}/.my.cnf", 'mysql', '-Be', "select * from mysql.user where user='user' and host='host'"]).returns <<-EOT
 Host	User	Password	Select_priv	Insert_priv	Update_priv
 host	user		Y	N	Y
 EOT
@@ -65,27 +65,27 @@ EOT
   end
 
   it 'should be able to set all privileges' do
-    provider_class.expects(:mysql).with(["--defaults-file=#{root_home}/.my.cnf", 'mysql', '-NBe', "SELECT '1' FROM user WHERE user='user' AND host='host'"]).returns "1\n"
-    provider_class.expects(:mysql).with(["--defaults-file=#{root_home}/.my.cnf", 'mysql', '-Be', "update user set Select_priv = 'Y', Insert_priv = 'Y', Update_priv = 'Y' where user='user' and host='host'"])
-    provider_class.expects(:mysqladmin).with(%W(--defaults-file=#{root_home}/.my.cnf flush-privileges))
+    provider_class.expects(:mysql).with(["--defaults-extra-file=#{root_home}/.my.cnf", 'mysql', '-NBe', "SELECT '1' FROM user WHERE user='user' AND host='host'"]).returns "1\n"
+    provider_class.expects(:mysql).with(["--defaults-extra-file=#{root_home}/.my.cnf", 'mysql', '-Be', "update user set Select_priv = 'Y', Insert_priv = 'Y', Update_priv = 'Y' where user='user' and host='host'"])
+    provider_class.expects(:mysqladmin).with(%W(--defaults-extra-file=#{root_home}/.my.cnf flush-privileges))
     @provider.privileges=(%w(all))
   end
 
   it 'should be able to set partial privileges' do
-    provider_class.expects(:mysql).with(["--defaults-file=#{root_home}/.my.cnf", 'mysql', '-NBe', "SELECT '1' FROM user WHERE user='user' AND host='host'"]).returns "1\n"
-    provider_class.expects(:mysql).with(["--defaults-file=#{root_home}/.my.cnf", 'mysql', '-Be', "update user set Select_priv = 'Y', Insert_priv = 'N', Update_priv = 'Y' where user='user' and host='host'"])
-    provider_class.expects(:mysqladmin).with(%W(--defaults-file=#{root_home}/.my.cnf flush-privileges))
+    provider_class.expects(:mysql).with(["--defaults-extra-file=#{root_home}/.my.cnf", 'mysql', '-NBe', "SELECT '1' FROM user WHERE user='user' AND host='host'"]).returns "1\n"
+    provider_class.expects(:mysql).with(["--defaults-extra-file=#{root_home}/.my.cnf", 'mysql', '-Be', "update user set Select_priv = 'Y', Insert_priv = 'N', Update_priv = 'Y' where user='user' and host='host'"])
+    provider_class.expects(:mysqladmin).with(%W(--defaults-extra-file=#{root_home}/.my.cnf flush-privileges))
     @provider.privileges=(%w(Select_priv Update_priv))
   end
 
   it 'should be case insensitive' do
-    provider_class.expects(:mysql).with(["--defaults-file=#{root_home}/.my.cnf", 'mysql', '-NBe', "SELECT '1' FROM user WHERE user='user' AND host='host'"]).returns "1\n"
-    provider_class.expects(:mysql).with(["--defaults-file=#{root_home}/.my.cnf", 'mysql', '-Be', "update user set Select_priv = 'Y', Insert_priv = 'Y', Update_priv = 'Y' where user='user' and host='host'"])
-    provider_class.expects(:mysqladmin).with(["--defaults-file=#{root_home}/.my.cnf", 'flush-privileges'])
+    provider_class.expects(:mysql).with(["--defaults-extra-file=#{root_home}/.my.cnf", 'mysql', '-NBe', "SELECT '1' FROM user WHERE user='user' AND host='host'"]).returns "1\n"
+    provider_class.expects(:mysql).with(["--defaults-extra-file=#{root_home}/.my.cnf", 'mysql', '-Be', "update user set Select_priv = 'Y', Insert_priv = 'Y', Update_priv = 'Y' where user='user' and host='host'"])
+    provider_class.expects(:mysqladmin).with(["--defaults-extra-file=#{root_home}/.my.cnf", 'flush-privileges'])
     @provider.privileges=(%w(SELECT_PRIV insert_priv UpDaTe_pRiV))
   end
 
-  it 'should not pass --defaults-file if $root_home/.my.cnf is absent' do
+  it 'should not pass --defaults-extra-file if $root_home/.my.cnf is absent' do
     File.stubs(:file?).with("#{root_home}/.my.cnf").returns(false)
     provider_class.expects(:mysql).with(['mysql', '-NBe', "SELECT '1' FROM user WHERE user='user' AND host='host'"]).returns "1\n"
     provider_class.expects(:mysql).with(['mysql', '-Be', "update user set Select_priv = 'Y', Insert_priv = 'N', Update_priv = 'Y' where user='user' and host='host'"])

--- a/spec/unit/puppet/provider/database_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/database_user/mysql_spec.rb
@@ -6,7 +6,7 @@ describe provider_class do
   subject { provider_class }
 
   let(:root_home) { '/root' }
-  let(:defaults_file) { '--defaults-file=/root/.my.cnf' }
+  let(:defaults_file) { '--defaults-extra-file=/root/.my.cnf' }
   let(:newhash) { '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5' }
 
   let(:raw_users) do
@@ -35,7 +35,7 @@ usvn_user@localhost
     Facter.stubs(:value).with(:root_home).returns(root_home)
     Puppet::Util.stubs(:which).with('mysql').returns('/usr/bin/mysql')
     subject.stubs(:which).with('mysql').returns('/usr/bin/mysql')
-    subject.stubs(:defaults_file).returns('--defaults-file=/root/.my.cnf')
+    subject.stubs(:defaults_file).returns('--defaults-extra-file=/root/.my.cnf')
   end
 
   describe 'self.instances' do
@@ -110,9 +110,9 @@ usvn_user@localhost
   end
 
   describe 'self.defaults_file' do
-    it 'sets --defaults-file' do
+    it 'sets --defaults-extra-file' do
       File.stubs(:file?).with('#{root_home}/.my.cnf').returns(true)
-      @provider.defaults_file.should == '--defaults-file=/root/.my.cnf'
+      @provider.defaults_file.should == '--defaults-extra-file=/root/.my.cnf'
     end
   end
 

--- a/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:mysql_database).provider(:mysql) do
 
-  let(:defaults_file) { '--defaults-file=/root/.my.cnf' }
+  let(:defaults_file) { '--defaults-extra-file=/root/.my.cnf' }
 
   let(:raw_databases) do
     <<-SQL_OUTPUT
@@ -77,9 +77,9 @@ test
   end
 
   describe 'self.defaults_file' do
-    it 'sets --defaults-file' do
+    it 'sets --defaults-extra-file' do
       File.stubs(:file?).with('/root/.my.cnf').returns(true)
-      provider.defaults_file.should eq '--defaults-file=/root/.my.cnf'
+      provider.defaults_file.should eq '--defaults-extra-file=/root/.my.cnf'
     end
     it 'fails if file missing' do
       File.stubs(:file?).with('/root/.my.cnf').returns(false)

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:mysql_user).provider(:mysql) do
-  let(:defaults_file) { '--defaults-file=/root/.my.cnf' }
+  let(:defaults_file) { '--defaults-extra-file=/root/.my.cnf' }
   let(:newhash) { '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5' }
 
   let(:raw_users) do
@@ -84,9 +84,9 @@ usvn_user@localhost
   end
 
   describe 'self.defaults_file' do
-    it 'sets --defaults-file' do
+    it 'sets --defaults-extra-file' do
       File.stubs(:file?).with('/root/.my.cnf').returns(true)
-      provider.defaults_file.should eq '--defaults-file=/root/.my.cnf'
+      provider.defaults_file.should eq '--defaults-extra-file=/root/.my.cnf'
     end
     it 'fails if file missing' do
       File.expects(:file?).with('/root/.my.cnf').returns(false)


### PR DESCRIPTION
The providers should load the .my.cnf file with "--defaults-extra-file" instead of "--defaults-file". This is necessary if we have global my.cnf file but we want to use both of them. 
