### PR TITLE
Parameterize backup directory mode and ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,21 @@ MySQL user password for backups.
 
 Directory to backup into.
 
+#####`backupdirmode`
+
+Permissions applied to the backup directory. This parameter is passed directly
+to the `file` resource.
+
+#####`backupdirowner`
+
+Owner for the backup directory. This parameter is passed directly to the `file`
+resource.
+
+#####`backupdirgroup`
+
+Group owner for the backup directory. This parameter is passed directly to the
+`file` resource.
+
 #####`backupcompress`
 
 Boolean to determine if backups should be compressed.

--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -3,6 +3,9 @@ class mysql::server::backup (
   $backupuser,
   $backuppassword,
   $backupdir,
+  $backupdirmode = '0700',
+  $backupdirowner = 'root',
+  $backupdirgroup = 'root',
   $backupcompress = true,
   $backuprotate = 30,
   $delete_before_dump = false,
@@ -48,9 +51,9 @@ class mysql::server::backup (
   file { 'mysqlbackupdir':
     ensure => 'directory',
     path   => $backupdir,
-    mode   => '0700',
-    owner  => 'root',
-    group  => 'root',
+    mode   => $backupdirmode,
+    owner  => $backupdirowner,
+    group  => $backupdirgroup,
   }
 
 }

--- a/spec/classes/mysql_server_backup_spec.rb
+++ b/spec/classes/mysql_server_backup_spec.rb
@@ -46,6 +46,23 @@ describe 'mysql::server::backup' do
     end
   end
 
+  context 'custom ownership and mode for backupdir' do
+    let(:params) do
+      { :backupdirmode => '0750',
+        :backupdirowner => 'testuser',
+        :backupdirgroup => 'testgrp',
+      }.merge(default_params)
+    end
+
+    it { should contain_file('mysqlbackupdir').with(
+      :path => '/tmp',
+      :ensure => 'directory',
+      :mode => '0750',
+      :owner => 'testuser',
+      :group => 'testgrp'
+    ) }
+  end
+
   context 'with compression disabled' do
     let(:params) do
       { :backupcompress => false }.merge(default_params)


### PR DESCRIPTION
I have a need to allow a non-root user to read the backup scripts. This PR makes this possible.

Thanks for reading.
