### PR TITLE
Add 'REQUIRE' clause to the grant command. (Issue #371)

### DIFF
--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -64,4 +64,16 @@ class Puppet::Provider::Mysql < Puppet::Provider
     option_string
   end
 
+    # Take in potential 'require' ssl option and build up a query string with them.
+  def self.cmd_grant_require(grant_require)
+    grant_require_string = ' REQUIRE'
+    grant_require.each_with_index do |opt, index|
+        if index > 0
+          grant_require_string << ' AND'
+        end
+        grant_require_string << " #{opt}"
+    end
+    grant_require_string
+  end
+
 end

--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -23,6 +23,10 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
           end
           # Same here, but to remove OPTION leaving just GRANT.
           options = rest.match(/WITH\s(.*)\sOPTION$/).captures if rest.include?('WITH')
+
+          # Get all REQUIRE options.
+          grant_require = rest.match(/REQUIRE\s(.*)\sWITH/).captures if rest.include?('REQUIRE')
+
           # We need to return an array of instances so capture these
           instances << new(
               :name       => "#{user}@#{host}/#{table}",
@@ -30,7 +34,8 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
               :privileges => stripped_privileges.sort,
               :table      => table,
               :user       => "#{user}@#{host}",
-              :options    => options
+              :options    => options,
+              :grant_require  => grant_require
           )
         end
       end
@@ -47,24 +52,26 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
     end
   end
 
-  def grant(user, table, privileges, options)
+  def grant(user, table, privileges, options, grant_require)
     user_string = self.class.cmd_user(user)
     priv_string = self.class.cmd_privs(privileges)
     table_string = self.class.cmd_table(table)
     query = "GRANT #{priv_string}"
     query << " ON #{table_string}"
     query << " TO #{user_string}"
+    query << self.class.cmd_grant_require(grant_require) unless grant_require.nil?
     query << self.class.cmd_options(options) unless options.nil?
     mysql([defaults_file, '-e', query].compact)
   end
 
   def create
-    grant(@resource[:user], @resource[:table], @resource[:privileges], @resource[:options])
+    grant(@resource[:user], @resource[:table], @resource[:privileges], @resource[:options], @resource[:grant_require] )
 
     @property_hash[:ensure]     = :present
     @property_hash[:table]      = @resource[:table]
     @property_hash[:user]       = @resource[:user]
     @property_hash[:options]    = @resource[:options] if @resource[:options]
+    @property_hash[:grant_require] = @resource[:grant_require] if @resource[:grant_require]
     @property_hash[:privileges] = @resource[:privileges]
 
     exists? ? (return true) : (return false)
@@ -98,7 +105,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
 
   def privileges=(privileges)
     revoke(@property_hash[:user], @property_hash[:table])
-    grant(@property_hash[:user], @property_hash[:table], privileges, @property_hash[:options])
+    grant(@property_hash[:user], @property_hash[:table], privileges, @property_hash[:options], @property_hash[:grant_require])
     @property_hash[:privileges] = privileges
 
     self.privileges
@@ -106,10 +113,18 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
 
   def options=(options)
     revoke(@property_hash[:user], @property_hash[:table])
-    grant(@property_hash[:user], @property_hash[:table], @property_hash[:privileges], options)
+    grant(@property_hash[:user], @property_hash[:table], @property_hash[:privileges], options, @property_hash[:grant_require])
     @property_hash[:options] = options
 
     self.options
+  end
+
+    def grant_require=(grant_require)
+    revoke(@property_hash[:user], @property_hash[:table])
+    grant(@property_hash[:user], @property_hash[:table], @property_hash[:privileges], @property_hash[:options], grant_require)
+    @property_hash[:grant_require] = grant_require
+
+    self.grant_require
   end
 
 end

--- a/lib/puppet/type/mysql_grant.rb
+++ b/lib/puppet/type/mysql_grant.rb
@@ -69,4 +69,8 @@ Puppet::Type.newtype(:mysql_grant) do
     desc 'Options to grant.'
   end
 
+  newproperty(:grant_require, :array_matching => :all) do
+    desc 'Options for require.'
+  end
+
 end


### PR DESCRIPTION
Added the option add 'REQUIRE' clause to the grant command. This allow SSL based authentication.
http://dev.mysql.com/doc/refman/5.5/en/grant.html

Example:

``` puppet
mysql_grant { 'user1@host1/*.*":
  ensure => 'present',
  options => ['GRANT'],
  privileges => ['ALL'],
  table => '*.*',
  user => 'user1@host1',
  grant_require => ['SUBJECT "/CN=user1/OU=Company"', 'ISSUER "CompanyCA"' ] ,
}
```

generates:

```
GRANT ALL PRIVILEGES ON *.* TO 'user1'@'host1' REQUIRE ISSUER 'CompanyCA' SUBJECT '/CN=user1/OU=Company' WITH GRANT OPTION
```
