### PR TITLE
Fix missing mysql::config when including mysql

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -114,6 +114,5 @@ class mysql(
   include '::mysql::client::install'
   include '::mysql::bindings'
 
-  Class['mysql::config'] -> Mysql::Db <| |>
 
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -55,4 +55,7 @@ class mysql::server (
       provider => $service_provider,
     }
   }
+
+  Class['mysql::config'] -> Mysql::Db <| |>
+
 }


### PR DESCRIPTION
In init.pp a depency between mysql::config and all db resources is
made. But mysql::config is not defined if only class mysql is included
on a node. This moves the dependency definition to mysql::server as
the dependency should only be needed on servers anyway.
