### PR TITLE
mysql_grant provider fix

### DIFF
--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -79,8 +79,16 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
   def revoke(user, table)
     user_string = self.class.cmd_user(user)
     table_string = self.class.cmd_table(table)
-
-    query = "REVOKE ALL ON #{table_string} FROM #{user_string}"
+    priv_string = self.class.cmd_privs(privileges)
+    
+    if priv_string == 'PROXY'
+      table_string = "''@''"
+    else
+      table_string = self.class.cmd_table(table)
+    end
+    
+    query = "REVOKE #{priv_string}"
+    query << " ON #{table_string} FROM #{user_string}"
     mysql([defaults_file, '-e', query].compact)
   end
 


### PR DESCRIPTION
Fixed grant function to be able to handle proxy privilege addition. 
Fixed revoke function to not only work with "revoke all privileges" but also work with specified options (insert, select, proxy, all, etc)
