### PR TITLE
my.cnf: typo fix (bind-address) + migrate key_buffer (deprecated) to key_buffer_size

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -196,7 +196,7 @@ class mysql::params {
       'bind-address'          => '127.0.0.1',
       'datadir'               => $mysql::params::datadir,
       'expire_logs_days'      => '10',
-      'key_buffer'            => '16M',
+      'key_buffer_size'       => '16M',
       'log_error'             => $mysql::params::log_error,
       'max_allowed_packet'    => '16M',
       'max_binlog_size'       => '100M',
@@ -223,7 +223,7 @@ class mysql::params {
       'quote-names'         => true,
     },
     'isamchk'      => {
-      'key_buffer' => '16M',
+      'key_buffer_size' => '16M',
     },
   }
 


### PR DESCRIPTION
Fix a typo in the config file where we can find bind_adress instead of bind-address (cf. https://dev.mysql.com/doc/refman/5.5/en/server-options.html#option_mysqld_bind-address [Option-File Format])

It also change the key_buffer which is deprecated into key_buffer_size (warning issued during installation on Ubuntu 12.04 machine).
