### PR TITLE
Support multiple lines of the same option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,24 @@ thing
 You can just make an entry like `thing => true` in the hash.  MySQL doesn't
 care if thing is alone or set to a value, it'll happily accept both.
 
+If an option need multiple instances, you can pass an Array. For example :
+
+```puppet
+$override_options = {
+  'mysqld' => {
+    'replicate-do-db' => ['base1', 'base2'],
+  }
+}
+```
+
+will produce :
+
+<pre>
+[mysql]
+replicate-do-db = base1
+replicate-do-db = base2
+</pre>
+
 ###Custom configuration
 
 To add custom mysql configuration you can drop additional files into

--- a/spec/acceptance/mysql_server_spec.rb
+++ b/spec/acceptance/mysql_server_spec.rb
@@ -83,6 +83,27 @@ describe 'mysql class' do
     end
   end
 
+  describe 'my.cnf should contain multiple instances of the same option' do
+    it 'sets multiple values' do
+      pp = <<-EOS
+        class { 'mysql::server':
+          override_options => { 'mysqld' => 
+            { 'replicate-do-db' => ['base1', 'base2', 'base3'], }
+          }  
+        }
+      EOS
+      puppet_apply(pp) do |r|
+        r.exit_code.should_not == 1
+      end
+    end
+
+    describe file(mycnf) do
+      it { should contain 'replicate-do-db = base1' }
+      it { should contain 'replicate-do-db = base2' }
+      it { should contain 'replicate-do-db = base3' }
+    end
+  end
+
   describe 'package_ensure => absent' do
     it 'uninstalls mysql' do
       pp = <<-EOS

--- a/spec/classes/mysql_server_spec.rb
+++ b/spec/classes/mysql_server_spec.rb
@@ -20,6 +20,19 @@ describe 'mysql::server' do
     end
   end
 
+  describe 'with multiple instance of an option' do
+    let(:params) {{ :override_options => { 'mysqld' => { 'replicate-do-db' => ['base1', 'base2', 'base3'], } }}}
+    it do
+      should contain_file('/etc/my.cnf').with_content(
+        /^replicate-do-db = base1$/
+      ).with_content(
+        /^replicate-do-db = base2$/
+      ).with_content(
+        /^replicate-do-db = base3$/
+      )
+    end
+  end
+
   context 'with remove_default_accounts set' do
     let (:params) {{ :remove_default_accounts => true }}
     it { should contain_class('mysql::server::account_security') }

--- a/spec/system/mysql_server_spec.rb
+++ b/spec/system/mysql_server_spec.rb
@@ -82,4 +82,25 @@ describe 'mysql class' do
     end
   end
 
+  describe 'my.cnf should contain multiple instances of the same option' do
+    it 'sets multiple values' do
+      pp = <<-EOS
+        class { 'mysql::server':
+          override_options => { 'mysqld' => 
+            { 'replicate-do-db' => ['base1', 'base2', 'base3'], }
+          }  
+        }
+      EOS
+      puppet_apply(pp) do |r|
+        r.exit_code.should_not == 1
+      end
+    end
+
+    describe file(mycnf) do
+      it { should contain 'replicate-do-db = base1' }
+      it { should contain 'replicate-do-db = base2' }
+      it { should contain 'replicate-do-db = base3' }
+    end
+  end
+
 end

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -4,6 +4,10 @@
 <% @options[k].sort.map do |ki, vi| -%>
 <% if vi == true -%>
 <%= ki %>
+<% elsif vi.is_a?(Array) -%>
+<% vi.each do |vii| -%>
+<%= ki %> = <%= vii %>
+<% end -%>
 <% elsif vi and vi != '' -%>
 <%= ki %> = <%= vi %>
 <% elsif vi -%>


### PR DESCRIPTION
  Some MySQL options need to be passed several time. Example :

  http://dev.mysql.com/doc/refman/5.5/en/replication-options-slave.html#option_mysqld_replicate-do-db

  This is currently impossible with the override_options. This patch allows to
  pass array as value. Example :

```
override_options => {
  'client' => {
    'password' => 'xxx',
  },
  'mysqld' => {
    'bind_address'    => '0.0.0.0',
    'replicate-do-db' => ['base1', 'base2', 'base3'],
  },
}
```

  Which will be evaluated into :

```
[client]
password = xxx

[mysqld]
bind_address = 0.0.0.0
replicate-do-db = base1
replicate-do-db = base2
replicate-do-db = base3
```
