### PR TITLE
run mysql_install_db if datadir is set annd mysql database is missing

### DIFF
--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -6,4 +6,17 @@ class mysql::server::install {
     name   => $mysql::server::package_name,
   }
 
+  # run mysql_install_db if datadir is set and datadir doesn't contain the
+  # mysql database (directory)
+  if $mysql::server::override_options['mysqld'] and $mysql::server::override_options['mysqld']['datadir'] {
+    $mysqluser = $mysql::server::options['mysqld']['user']
+    $datadir = $mysql::server::override_options['mysqld']['datadir']
+
+    exec { "mysql_install_db":
+      command => "mysql_install_db --datadir=$datadir --user=$mysqluser",
+      creates => "$datadir/mysql",
+      logoutput => on_failure,
+    }
+  }
+
 }


### PR DESCRIPTION
If the datadir is changed in the my.cnf, then mysql_install_db must be run to create the basic mysql database etc. in the new datadir. This change checks if datadir is set and if the directory mysql is missing in the datadir, if so mysql_install_db is run.
