### PR TITLE
option to specify a script that runs after backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,10 @@ Allows you to remove the backup scripts. Can be 'present' or 'absent'.
 
 An array of two elements to set the backup time.  Allows ['23', '5'] or ['3', '45'] for HH:MM times.
 
+#####`postscript`
+
+A script that is executed at when the backup is finished. This could be used to (r)sync the backup to a central store. This script can be either a single line that is directly executed or a number of lines, when supplied as an array. It could also be one or more externally managed (executable) files.
+
 ####mysql::server::monitor
 
 #####`mysql_monitor_username`

--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -14,6 +14,7 @@ class mysql::server::backup (
   $file_per_database = false,
   $ensure = 'present',
   $time = ['23', '5'],
+  $postscript = false,
 ) {
 
   mysql_user { "${backupuser}@localhost":

--- a/spec/acceptance/mysql_backup_spec.rb
+++ b/spec/acceptance/mysql_backup_spec.rb
@@ -15,6 +15,12 @@ describe 'mysql::server::backup class' do
           backuppassword => 'mypassword',
           backupdir      => '/tmp/backups',
           backupcompress => true,
+          postscript     => [
+            'rm -rf /var/tmp/mysqlbackups',
+            'rm -f /var/tmp/mysqlbackups.done',
+            'cp -r /tmp/backups /var/tmp/mysqlbackups',
+            'touch /var/tmp/mysqlbackups.done',
+          ],
         }
       EOS
 

--- a/spec/classes/mysql_server_backup_spec.rb
+++ b/spec/classes/mysql_server_backup_spec.rb
@@ -152,4 +152,32 @@ describe 'mysql::server::backup' do
             end
         end
     end
+
+		context 'with postscript' do
+			let(:params) do
+				default_params.merge({ :postscript => 'rsync -a /tmp backup01.local-lan:' })
+			end
+
+			it 'should be add postscript' do
+				verify_contents(subject, 'mysqlbackup.sh', [
+					'rsync -a /tmp backup01.local-lan:',
+				])
+			end
+		end
+
+		context 'with postscripts' do
+			let(:params) do
+				default_params.merge({ :postscript => [
+					'rsync -a /tmp backup01.local-lan:',
+					'rsync -a /tmp backup02.local-lan:',
+				]})
+			end
+
+			it 'should be add postscript' do
+				verify_contents(subject, 'mysqlbackup.sh', [
+					'rsync -a /tmp backup01.local-lan:',
+					'rsync -a /tmp backup02.local-lan:',
+				])
+			end
+		end
 end

--- a/spec/system/mysql_backup_spec.rb
+++ b/spec/system/mysql_backup_spec.rb
@@ -14,6 +14,12 @@ describe 'mysql::server::backup class' do
         backuppassword => 'mypassword',
         backupdir      => '/tmp/backups',
         backupcompress => true,
+        postscript     => [
+          'rm -rf /var/tmp/mysqlbackups',
+          'rm -f /var/tmp/mysqlbackups.done',
+          'cp -r /tmp/backups /var/tmp/mysqlbackups',
+          'touch /var/tmp/mysqlbackups.done',
+        ],
       }
     EOS
 

--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -65,3 +65,8 @@ if [ $? -eq 0 ] ; then
 fi
 <% end -%>
 
+<% if @postscript -%>
+  <%- [@postscript].flatten.compact.each do |script|%>
+<%= script %>
+  <%- end -%>
+<% end -%>


### PR DESCRIPTION
This script could be used to sync backups to a central server, or just
to create a file to let external scripts know that backups are
(sucessfully) done and can be picked up.

The postscript option (defaults to false) and can be either a string or
an array of strings. These strings will be directly put into the
mysqlbackup.sh and as such can either be shell commands, or externally
managed files.
