### PR TITLE
Added backupcronjob variable to server/backup.pp

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,10 @@ Allows you to remove the backup scripts. Can be 'present' or 'absent'.
 
 An array of two elements to set the backup time.  Allows ['23', '5'] or ['3', '45'] for HH:MM times.
 
+#####`backupcronjob`
+
+Defines whether to install the Backup Cron Job. Defaults to true. Useful when you want Bacula to start the backup process.
+
 ####mysql::server::monitor
 
 #####`mysql_monitor_username`

--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -8,6 +8,7 @@ class mysql::server::backup (
   $backupdirgroup = 'root',
   $backupcompress = true,
   $backuprotate = 30,
+  $backupcronjob = true,
   $delete_before_dump = false,
   $backupdatabases = [],
   $file_per_database = false,
@@ -31,7 +32,7 @@ class mysql::server::backup (
   }
 
   cron { 'mysql-backup':
-    ensure  => $ensure,
+    ensure  => $backupcronjob ? { false => 'absent', default => $ensure },
     command => '/usr/local/sbin/mysqlbackup.sh',
     user    => 'root',
     hour    => $time[0],


### PR DESCRIPTION
Added backupcronjob variable to server/backup.pp. This variable allows to disable the installation of the Backup Cron Job, useful when you want Bacula (or other Backup solution) to initiate the backup process.
