### PR TITLE
Fix issue:

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,14 +28,15 @@ class mysql::params {
       if $::operatingsystem == 'Fedora' and (is_integer($::operatingsystemrelease) and $::operatingsystemrelease >= 19 or $::operatingsystemrelease == "Rawhide") {
         $client_package_name = 'mariadb'
         $server_package_name = 'mariadb-server'
+        $log_error           = '/var/log/mariadb/mariadb.log'
       } else {
         $client_package_name = 'mysql'
         $server_package_name = 'mysql-server'
+        $log_error           = '/var/log/mysqld.log'
       }
       $basedir             = '/usr'
       $config_file         = '/etc/my.cnf'
       $datadir             = '/var/lib/mysql'
-      $log_error           = '/var/log/mysqld.log'
       $pidfile             = '/var/run/mysqld/mysqld.pid'
       $root_group          = 'root'
       $server_service_name = 'mysqld'

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -8,6 +8,9 @@ class mysql::server::service {
   }
 
   if $mysql::server::real_service_manage {
+    file { $mysql::params::log_error:
+      owner => 'mysql'
+    }
     service { 'mysqld':
       ensure   => $service_ensure,
       name     => $mysql::server::service_name,


### PR DESCRIPTION
Fedora, starting from 19 ships with MariaDB as its default MySQL.
In order to keep supporting this distro we need to make a number of
changes:
1. Change service name to mariadb
2. Change log file to /var/log/mariadb/mariadb.log
3. Change ownership of log file to mysql
