### PR TITLE
Remove duplicate service_provider description

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,10 +261,6 @@ $databases = {
 }
 ```
 
-#####`service_provider`
-
-The provider for the service
-
 ####mysql::server::backup
 
 #####`backupuser`


### PR DESCRIPTION
The `service_provider` parameter was explained in the README twice, so I've removed one of them.
