### PR TITLE
Actually use upstart on Ubuntu by fixing misspelled variable name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -174,10 +174,10 @@ class mysql::params {
 
   case $::operatingsystem {
     'Ubuntu': {
-      $service_provider = upstart
+      $server_service_provider = upstart
     }
     default: {
-      $service_provider = undef
+      $server_service_provider = undef
     }
   }
 


### PR DESCRIPTION
Fixes inconsistent use of variable: service_provider vs server_service_provider.
