### PR TITLE
Add logic to ignore mysql.events

### DIFF
--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -8,6 +8,7 @@ class mysql::server::backup (
   $backupdirgroup = 'root',
   $backupcompress = true,
   $backuprotate = 30,
+  $ignore_events = true,
   $delete_before_dump = false,
   $backupdatabases = [],
   $file_per_database = false,

--- a/spec/classes/mysql_server_backup_spec.rb
+++ b/spec/classes/mysql_server_backup_spec.rb
@@ -2,130 +2,154 @@ require 'spec_helper'
 
 describe 'mysql::server::backup' do
 
-  let(:default_params) {
-    { 'backupuser'         => 'testuser',
-      'backuppassword'     => 'testpass',
-      'backupdir'          => '/tmp',
-      'backuprotate'       => '25',
-      'delete_before_dump' => true,
+    let(:default_params) {
+        { 'backupuser'         => 'testuser',
+            'backuppassword'     => 'testpass',
+            'backupdir'          => '/tmp',
+            'backuprotate'       => '25',
+            'delete_before_dump' => true,
+        }
     }
-  }
-  context 'standard conditions' do
-    let(:params) { default_params }
+    context 'standard conditions' do
+        let(:params) { default_params }
 
-    it { should contain_mysql_user('testuser@localhost').with(
-      :require => 'Class[Mysql::Server::Root_password]'
-    )}
+        it { should contain_mysql_user('testuser@localhost').with(
+            :require => 'Class[Mysql::Server::Root_password]'
+        )}
 
-    it { should contain_mysql_grant('testuser@localhost/*.*').with(
-      :privileges => ["SELECT", "RELOAD", "LOCK TABLES", "SHOW VIEW"]
-    )}
+        it { should contain_mysql_grant('testuser@localhost/*.*').with(
+            :privileges => ["SELECT", "RELOAD", "LOCK TABLES", "SHOW VIEW"]
+        )}
 
-    it { should contain_cron('mysql-backup').with(
-      :command => '/usr/local/sbin/mysqlbackup.sh',
-      :ensure  => 'present'
-    )}
+        it { should contain_cron('mysql-backup').with(
+            :command => '/usr/local/sbin/mysqlbackup.sh',
+            :ensure  => 'present'
+        )}
 
-    it { should contain_file('mysqlbackup.sh').with(
-      :path   => '/usr/local/sbin/mysqlbackup.sh',
-      :ensure => 'present'
-    ) }
+        it { should contain_file('mysqlbackup.sh').with(
+            :path   => '/usr/local/sbin/mysqlbackup.sh',
+            :ensure => 'present'
+        ) }
 
-    it { should contain_file('mysqlbackupdir').with(
-      :path   => '/tmp',
-      :ensure => 'directory'
-    )}
+        it { should contain_file('mysqlbackupdir').with(
+            :path   => '/tmp',
+            :ensure => 'directory'
+        )}
 
-    it 'should have compression by default' do
-      verify_contents(subject, 'mysqlbackup.sh', [
-        ' --all-databases | bzcat -zc > ${DIR}/${PREFIX}`date +%Y%m%d-%H%M%S`.sql.bz2',
-      ])
+        it 'should have compression by default' do
+            verify_contents(subject, 'mysqlbackup.sh', [
+                            ' --all-databases | bzcat -zc > ${DIR}/${PREFIX}`date +%Y%m%d-%H%M%S`.sql.bz2',
+            ])
+        end
+        it 'should skip backing up events table by default' do
+            verify_contents(subject, 'mysqlbackup.sh', [
+                            'EVENTS="--ignore-table=mysql.event"',
+            ])
+        end
+
+        it 'should have 25 days of rotation' do
+            # MySQL counts from 0 I guess.
+            should contain_file('mysqlbackup.sh').with_content(/.*ROTATE=24.*/)
+        end
     end
 
-    it 'should have 25 days of rotation' do
-      # MySQL counts from 0 I guess.
-      should contain_file('mysqlbackup.sh').with_content(/.*ROTATE=24.*/)
-    end
-  end
+    context 'custom ownership and mode for backupdir' do
+        let(:params) do
+            { :backupdirmode => '0750',
+                :backupdirowner => 'testuser',
+                :backupdirgroup => 'testgrp',
+            }.merge(default_params)
+        end
 
-  context 'custom ownership and mode for backupdir' do
-    let(:params) do
-      { :backupdirmode => '0750',
-        :backupdirowner => 'testuser',
-        :backupdirgroup => 'testgrp',
-      }.merge(default_params)
-    end
-
-    it { should contain_file('mysqlbackupdir').with(
-      :path => '/tmp',
-      :ensure => 'directory',
-      :mode => '0750',
-      :owner => 'testuser',
-      :group => 'testgrp'
-    ) }
-  end
-
-  context 'with compression disabled' do
-    let(:params) do
-      { :backupcompress => false }.merge(default_params)
+        it { should contain_file('mysqlbackupdir').with(
+            :path => '/tmp',
+            :ensure => 'directory',
+            :mode => '0750',
+            :owner => 'testuser',
+            :group => 'testgrp'
+        ) }
     end
 
-    it { should contain_file('mysqlbackup.sh').with(
-      :path   => '/usr/local/sbin/mysqlbackup.sh',
-      :ensure => 'present'
-    ) }
-
-    it 'should be able to disable compression' do
-      verify_contents(subject, 'mysqlbackup.sh', [
-        ' --all-databases > ${DIR}/${PREFIX}`date +%Y%m%d-%H%M%S`.sql',
-      ])
-    end
-  end
-
-  context 'with database list specified' do
-    let(:params) do
-      { :backupdatabases => ['mysql'] }.merge(default_params)
-    end
-
-    it { should contain_file('mysqlbackup.sh').with(
-      :path   => '/usr/local/sbin/mysqlbackup.sh',
-      :ensure => 'present'
-    ) }
-
-    it 'should have a backup file for each database' do
-      content = subject.resource('file','mysqlbackup.sh').send(:parameters)[:content]
-      content.should match(' mysql | bzcat -zc \${DIR}\\\${PREFIX}mysql_`date')
-#      verify_contents(subject, 'mysqlbackup.sh', [
-#        ' mysql | bzcat -zc ${DIR}/${PREFIX}mysql_`date +%Y%m%d-%H%M%S`.sql',
-#      ])
-    end 
-  end
-  
-  context 'with file per database' do
-    let(:params) do
-      default_params.merge({ :file_per_database => true })
-    end
-    
-    it 'should loop through backup all databases' do
-      verify_contents(subject, 'mysqlbackup.sh', [
-        'mysql -s -r -N -e \'SHOW DATABASES\' | while read dbname',
-        'do',
-        '  mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \\',
-        '    ${dbname} | bzcat -zc > ${DIR}/${PREFIX}${dbname}_`date +%Y%m%d-%H%M%S`.sql.bz2',
-        'done',
-      ])
-    end
-    
     context 'with compression disabled' do
-      let(:params) do
-        default_params.merge({ :file_per_database => true, :backupcompress => false })
-      end
-      
-      it 'should loop through backup all databases without compression' do
-        verify_contents(subject, 'mysqlbackup.sh', [
-          '    ${dbname} > ${DIR}/${PREFIX}${dbname}_`date +%Y%m%d-%H%M%S`.sql',
-        ])
-      end
+        let(:params) do
+            { :backupcompress => false }.merge(default_params)
+        end
+
+        it { should contain_file('mysqlbackup.sh').with(
+            :path   => '/usr/local/sbin/mysqlbackup.sh',
+            :ensure => 'present'
+        ) }
+
+        it 'should be able to disable compression' do
+            verify_contents(subject, 'mysqlbackup.sh', [
+                            ' --all-databases > ${DIR}/${PREFIX}`date +%Y%m%d-%H%M%S`.sql',
+            ])
+        end
     end
-  end
+
+    context 'with mysql.events backedup' do
+        let(:params) do
+            { :ignore_events => false }.merge(default_params)
+        end
+
+        it { should contain_file('mysqlbackup.sh').with(
+            :path   => '/usr/local/sbin/mysqlbackup.sh',
+            :ensure => 'present'
+        ) }
+
+        it 'should be able to backup events table' do
+            verify_contents(subject, 'mysqlbackup.sh', [
+                            'EVENTS="--events"',
+            ])
+        end
+    end
+
+
+    context 'with database list specified' do
+        let(:params) do
+            { :backupdatabases => ['mysql'] }.merge(default_params)
+        end
+
+        it { should contain_file('mysqlbackup.sh').with(
+            :path   => '/usr/local/sbin/mysqlbackup.sh',
+            :ensure => 'present'
+        ) }
+
+        it 'should have a backup file for each database' do
+            content = subject.resource('file','mysqlbackup.sh').send(:parameters)[:content]
+            content.should match(' mysql | bzcat -zc \${DIR}\\\${PREFIX}mysql_`date')
+            #      verify_contents(subject, 'mysqlbackup.sh', [
+            #        ' mysql | bzcat -zc ${DIR}/${PREFIX}mysql_`date +%Y%m%d-%H%M%S`.sql',
+            #      ])
+        end 
+    end
+
+    context 'with file per database' do
+        let(:params) do
+            default_params.merge({ :file_per_database => true })
+        end
+
+        it 'should loop through backup all databases' do
+            verify_contents(subject, 'mysqlbackup.sh', [
+                            'mysql -s -r -N -e \'SHOW DATABASES\' | while read dbname',
+                            'do',
+                            '  mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \\',
+                            '    ${EVENTS} \\',
+                            '    ${dbname} | bzcat -zc > ${DIR}/${PREFIX}${dbname}_`date +%Y%m%d-%H%M%S`.sql.bz2',
+                            'done',
+            ])
+        end
+
+        context 'with compression disabled' do
+            let(:params) do
+                default_params.merge({ :file_per_database => true, :backupcompress => false })
+            end
+
+            it 'should loop through backup all databases without compression' do
+                verify_contents(subject, 'mysqlbackup.sh', [
+                                '    ${dbname} > ${DIR}/${PREFIX}${dbname}_`date +%Y%m%d-%H%M%S`.sql',
+                ])
+            end
+        end
+    end
 end

--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -16,9 +16,16 @@ DIR=<%= @backupdir %>
 ROTATE=<%= [ Integer(@backuprotate) - 1, 0 ].max %>
 
 PREFIX=mysql_backup_
+<% if @ignore_events %>
+EVENTS="--ignore-table=mysql.event"
+<% else %>
+EVENTS="--events"
+<% end %>
 
 ##### STOP CONFIG ####################################################
 PATH=/usr/bin:/usr/sbin:/bin:/sbin
+
+
 
 set -o pipefail
 
@@ -36,15 +43,18 @@ cleanup
 mysql -s -r -N -e 'SHOW DATABASES' | while read dbname
 do
   mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \
+    ${EVENTS} \
     ${dbname} <% if @backupcompress %>| bzcat -zc <% end %>> ${DIR}/${PREFIX}${dbname}_`date +%Y%m%d-%H%M%S`.sql<% if @backupcompress %>.bz2<% end  %>
 done
 <% else -%>
 mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \
+ ${EVENTS} \
  --all-databases <% if @backupcompress %>| bzcat -zc <% end %>> ${DIR}/${PREFIX}`date +%Y%m%d-%H%M%S`.sql<% if @backupcompress %>.bz2<% end  %>
 <% end -%>
 <% else -%>
 <% @backupdatabases.each do |db| -%>
-mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \
+mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \ 
+    ${EVENTS} \
  <%= db %><% if @backupcompress %>| bzcat -zc <% end %>> ${DIR}/${PREFIX}<%= db %>_`date +%Y%m%d-%H%M%S`.sql<% if @backupcompress %>.bz2<% end  %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
mysqldump throws a warning unless you explicitly choose what to do with the events table.  See here

http://www.linuxbrigade.com/warning-skipping-data-table-mysql-event/

This current script mails after each cron iteration because of this warning.  This small patch adds a variable to control wether to skip the mysql.events table or back it up.
