### PR TITLE
give testers something to see while waiting for beaker to fail

### DIFF
--- a/spec/acceptance/nodesets/centos-64-x64.yml
+++ b/spec/acceptance/nodesets/centos-64-x64.yml
@@ -6,3 +6,6 @@ HOSTS:
     box : centos-64-x64-vbox4210-nocm
     box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210-nocm.box
     hypervisor : vagrant
+CONFIG:
+  log_level: debug
+  type: git

--- a/spec/acceptance/nodesets/ubuntu-server-12042-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-12042-x64.yml
@@ -6,3 +6,6 @@ HOSTS:
     box : ubuntu-server-12042-x64-vbox4210-nocm
     box_url : http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210-nocm.box
     hypervisor : vagrant
+CONFIG:
+  log_level: debug
+  type: git


### PR DESCRIPTION
it's extremely frustrating to stare at the console while _nothing_ is
happening, only to get a single stack trace at the end. Let's make the
wait for a horrible failure less enraging by adding debug output.
