### PR TITLE
Fix failing backup spec test

### DIFF
--- a/spec/acceptance/mysql_backup_spec.rb
+++ b/spec/acceptance/mysql_backup_spec.rb
@@ -31,7 +31,7 @@ describe 'mysql::server::backup class' do
   describe 'mysqlbackup.sh' do
     it 'should run mysqlbackup.sh with no errors' do
       shell("/usr/local/sbin/mysqlbackup.sh") do |r|
-        expect(r.stderr).to eq("-- Warning: Skipping the data of table mysql.event. Specify the --events option explicitly.\n")
+        expect(r.stderr).to eq("")
       end
     end
 


### PR DESCRIPTION
This partially reverts 7224f12c250a20fa24935a9026ada81269b7fce8
since after #416 the warnings are actually fixed at the source
