### PR TITLE
Allow configuration of Gem source in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :development, :test do
   gem 'mime-types', '<2.0',      :require => false


### PR DESCRIPTION
This commit allows configuring of the Gem source via an environment
variable "GEM_SOURCE" with a default of 'https://rubygems.org'.
This follows the conventions of Puppet Labs Open Source Platform team.
