### PR TITLE
Add check for puppet rpm before trying to install

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -22,7 +22,7 @@ RSpec.configure do |c|
       # Required for binding tests.
       if fact('osfamily') == 'RedHat'
         version = fact("operatingsystemmajrelease")
-        shell("rpm -q puppetlabs-release || rpm -i http://yum.puppetlabs.com/puppetlabs-release-el-#{version}.noarch.rpm")
+        shell("yum localinstall -y http://yum.puppetlabs.com/puppetlabs-release-el-#{version}.noarch.rpm")
       end
 
       shell('/bin/touch /etc/puppet/hiera.yaml')


### PR DESCRIPTION
This fixes an issue where subsequent tests will fail when the `RS_PROVISION=no` and `RS_DESTROY=no` flag is set for centos. The error is caused by attempting to install the puppet rpm on a machine that already has the puppet rpm installed.
