### PR TITLE
Repair this by ensuring calls to mysql include the database name.

### DIFF
--- a/lib/puppet/provider/mysql_database/mysql.rb
+++ b/lib/puppet/provider/mysql_database/mysql.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::
   def self.instances
     mysql([defaults_file, '-NBe', 'show databases'].compact).split("\n").collect do |name|
       attributes = {}
-      mysql([defaults_file, '-NBe', "show variables like '%_database'"].compact).split("\n").each do |line|
+      mysql([defaults_file, '-NBe', "show variables like '%_database'", name].compact).split("\n").each do |line|
         k,v = line.split(/\s/)
         attributes[k] = v
       end

--- a/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
@@ -31,7 +31,7 @@ test
     Puppet::Util.stubs(:which).with('mysql').returns('/usr/bin/mysql')
     File.stubs(:file?).with('/root/.my.cnf').returns(true)
     provider.class.stubs(:mysql).with([defaults_file, '-NBe', 'show databases']).returns('new_database')
-    provider.class.stubs(:mysql).with([defaults_file, '-NBe', "show variables like '%_database'"]).returns("character_set_database latin1\ncollation_database latin1_swedish_ci\nskip_show_database OFF")
+    provider.class.stubs(:mysql).with([defaults_file, '-NBe', "show variables like '%_database'", 'new_database']).returns("character_set_database latin1\ncollation_database latin1_swedish_ci\nskip_show_database OFF")
   end
 
   let(:instance) { provider.class.instances.first }
@@ -40,7 +40,7 @@ test
     it 'returns an array of databases' do
       provider.class.stubs(:mysql).with([defaults_file, '-NBe', 'show databases']).returns(raw_databases)
       raw_databases.each_line do |db|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "show variables like '%_database'"]).returns("character_set_database latin1\ncollation_database  latin1_swedish_ci\nskip_show_database  OFF")
+        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "show variables like '%_database'", db.chomp]).returns("character_set_database latin1\ncollation_database  latin1_swedish_ci\nskip_show_database  OFF")
       end
       databases = provider.class.instances.collect {|x| x.name }
       parsed_databases.should match_array(databases)


### PR DESCRIPTION
A prior commit accidently broke this, meaning that mysql_database
was querying the mysql defaults instead of each individual database
when trying to determine the current collate settings.
