### PR TITLE
mysqlbackup.sh should be able to find mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ Whether a separate file be used per database.
 
 Allows you to remove the backup scripts. Can be 'present' or 'absent'.
 
+#####`execpath`
+
+Allows you to set a custom PATH should your mysql installation be non-standard places. Defaults to `/usr/bin:/usr/sbin:/bin:/sbin`
+
 #####`time`
 
 An array of two elements to set the backup time.  Allows ['23', '5'] or ['3', '45'] for HH:MM times.

--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -15,6 +15,7 @@ class mysql::server::backup (
   $ensure = 'present',
   $time = ['23', '5'],
   $postscript = false,
+  $execpath   = '/usr/bin:/usr/sbin:/bin:/sbin',
 ) {
 
   mysql_user { "${backupuser}@localhost":

--- a/spec/acceptance/mysql_backup_spec.rb
+++ b/spec/acceptance/mysql_backup_spec.rb
@@ -21,6 +21,7 @@ describe 'mysql::server::backup class' do
             'cp -r /tmp/backups /var/tmp/mysqlbackups',
             'touch /var/tmp/mysqlbackups.done',
           ],
+          execpath      => '/usr/bin:/usr/sbin:/bin:/sbin:/opt/zimbra/bin',
         }
       EOS
 

--- a/spec/classes/mysql_server_backup_spec.rb
+++ b/spec/classes/mysql_server_backup_spec.rb
@@ -8,6 +8,7 @@ describe 'mysql::server::backup' do
             'backupdir'          => '/tmp',
             'backuprotate'       => '25',
             'delete_before_dump' => true,
+            'execpath'           => '/usr/bin:/usr/sbin:/bin:/sbin:/opt/zimbra/bin',
         }
     }
     context 'standard conditions' do
@@ -50,6 +51,10 @@ describe 'mysql::server::backup' do
         it 'should have 25 days of rotation' do
             # MySQL counts from 0 I guess.
             should contain_file('mysqlbackup.sh').with_content(/.*ROTATE=24.*/)
+        end
+
+        it 'should have a standard PATH' do
+            should contain_file('mysqlbackup.sh').with_content(%r{PATH=/usr/bin:/usr/sbin:/bin:/sbin:/opt/zimbra/bin})
         end
     end
 

--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -23,7 +23,7 @@ EVENTS="--events"
 <% end %>
 
 ##### STOP CONFIG ####################################################
-PATH=/usr/bin:/usr/sbin:/bin:/sbin
+PATH=<%= @execpath %>
 
 
 


### PR DESCRIPTION
anywhere. This should enable use to use mysql::server::backup
idependantly, even if mysql is preinstalled, and preinstalled in non
standard locations
