### PR TITLE
Defined type for managing conf.d entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ replicate-do-db = base2
 
 ###Custom configuration
 
-To add custom MySQL configuration, drop additional files into
-`/etc/mysql/conf.d/`. Dropping files into conf.d allows you to override settings or add additional ones, which is helpful if you choose not to use `override_options` in `mysql::server`. The conf.d location is hardcoded into the my.cnf template file.
+See [`mysql::server::confd`](#mysqlserverconfd).
 
 ##Reference
 
@@ -420,6 +419,23 @@ What to set the package to.  Can be 'present', 'absent', or 'x.y.z'.
 What is the name of the mysql client package to install.
 
 ###Defines
+
+####mysql::server::confd
+
+Create additional `conf.d` configuration files which will supplement or
+override the `override_options` param of `mysql::server`. It will set the
+correct file path and relationships for you. Takes either a `content` or
+`source` param per a normal `file{}` resource.
+
+```puppet
+mysql::server::confd { 'read_only':
+  content => "[mysqld]\nread_only\n",
+}
+
+mysql::server::confd { 'innodb_extra':
+  source => 'puppet:///some/path/innodb_extra.cnf',
+}
+```
 
 ####mysql::db
 

--- a/manifests/server/confd.pp
+++ b/manifests/server/confd.pp
@@ -1,0 +1,16 @@
+# Define: mysql::server::confd:  See README.md for documentation.
+define mysql::server::confd (
+  $content = undef,
+  $source = undef,
+) {
+  file { "/etc/mysql/conf.d/${name}.cnf":
+    ensure  => file,
+    content => $content,
+    source  => $source,
+    require => Class['mysql::server::config'],
+  }
+
+  if $::mysql::server::restart {
+    File["/etc/mysql/conf.d/${name}.cnf"] ~> Class['mysql::server::service']
+  }
+}

--- a/spec/acceptance/mysql_server_confd_spec.rb
+++ b/spec/acceptance/mysql_server_confd_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper_acceptance'
+
+describe 'mysql::server::confd' do
+  let(:mysql_server_pp) { <<-EOS
+    class { 'mysql::server':
+      restart          => true,
+      purge_conf_dir   => true,
+      override_options => {
+        'mysqld' => {
+          'server_id' => '123',
+        },
+      },
+    }
+    EOS
+  }
+
+  it 'should setup mysql::server with no errors' do
+    apply_manifest(mysql_server_pp, :catch_failures => true)
+  end
+
+  it 'should find server_id set by mysql::server' do
+    shell("mysql -NBe \"SHOW VARIABLES LIKE 'server_id'\"") do |r|
+      expect(r.stdout).to match(/^server_id\t123$/)
+      expect(r.stderr).to be_empty
+    end
+  end
+
+  it 'should apply mysql::server::confd with no errors' do
+    pp = <<-EOS
+#{mysql_server_pp}
+      mysql::server::confd { 'server_id':
+        content => "[mysqld]\nserver_id = 456\n",
+      }
+    EOS
+
+    apply_manifest(pp, :catch_failures => true)
+  end
+
+  it 'should find server_id set by mysql::server::confd' do
+    shell("mysql -NBe \"SHOW VARIABLES LIKE 'server_id'\"") do |r|
+      expect(r.stdout).to match(/^server_id\t456$/)
+      expect(r.stderr).to be_empty
+    end
+  end
+end

--- a/spec/defines/mysql_server_confd_spec.rb
+++ b/spec/defines/mysql_server_confd_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe 'mysql::server::confd', :type => :define do
+  let(:facts) {{ :osfamily => 'RedHat' }}
+  let(:title) { 'server_id' }
+  let(:file_path) { '/etc/mysql/conf.d/server_id.cnf' }
+  
+  describe '#content' do
+    let(:params) {{
+      :content => "[mysqld]\nserver_id = 123\n",
+    }}
+
+    it 'should create file with content' do
+      should contain_file(file_path).with({
+        :ensure  => 'file',
+        :source  => nil,
+        :require => 'Class[Mysql::Server::Config]',
+        :content => <<EOS
+[mysqld]
+server_id = 123
+EOS
+      })
+    end
+  end
+
+  describe '#source' do
+    let(:params) {{
+      :source => 'puppet:///foo/bar',
+    }}
+
+    it 'should create file with source' do
+      should contain_file(file_path).with({
+        :ensure  => 'file',
+        :content => nil,
+        :source  => 'puppet:///foo/bar',
+        :require => 'Class[Mysql::Server::Config]',
+      })
+    end
+  end
+
+  describe 'restart service' do
+    describe 'false' do
+      let(:pre_condition) { <<-EOS
+        class { 'mysql::server':
+          restart => false,
+        }
+        EOS
+      }
+
+      it 'should not notify service' do
+        should_not contain_file(file_path).that_notifies('Class[mysql::server::service]')
+      end
+    end
+
+    describe 'true' do
+      let(:pre_condition) { <<-EOS
+        class { 'mysql::server':
+          restart => true,
+        }
+        EOS
+      }
+
+      it 'should notify service' do
+        should contain_file(file_path).that_notifies('Class[mysql::server::service]')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This makes managing individial conf.d entries more DRY and prevents exposing
the internals of this module like directory path, what class to require,
and what service to notify (if at all). It respects the `restart` param of
`mysql::server`.