### PR TITLE
As we're deleting /etc/my.cnf, lets not restart MySQL in the middle

### DIFF
--- a/spec/acceptance/mysql_server_config_spec.rb
+++ b/spec/acceptance/mysql_server_config_spec.rb
@@ -21,6 +21,7 @@ describe 'manage_config_file' do
       class { 'mysql::server':
         config_file        => '/etc/my.cnf',
         manage_config_file => false,
+        restart            => false,
       }
     EOS
     # Make sure this doesn't exist so we can test if puppet


### PR DESCRIPTION
of this and cause a terrible explosion.
