### PR TITLE
Add centos65-x64 acceptance test yaml file

### DIFF
--- a/spec/acceptance/nodesets/centos-65-x64.yml
+++ b/spec/acceptance/nodesets/centos-65-x64.yml
@@ -3,7 +3,7 @@ HOSTS:
     roles:
       - master
     platform: el-6-x86_64
-    box : centos-65-x64-vbox4210-nocm
+    box : centos-65-x64-vbox436-nocm
     box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-65-x64-virtualbox-nocm.box
     hypervisor : vagrant
 CONFIG:


### PR DESCRIPTION
It's almost as simple as a s/64/65/ from the centos64 file. vbox version changed from 4210 to 436, and path for box url changed.
