### PR TITLE
[BUG] [Critical] Removing extra space after slash in mysqlbackup.sh

### DIFF
--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -53,7 +53,7 @@ mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \
 <% end -%>
 <% else -%>
 <% @backupdatabases.each do |db| -%>
-mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \ 
+mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \
     ${EVENTS} \
  <%= db %><% if @backupcompress %>| bzcat -zc <% end %>> ${DIR}/${PREFIX}<%= db %>_`date +%Y%m%d-%H%M%S`.sql<% if @backupcompress %>.bz2<% end  %>
 <% end -%>


### PR DESCRIPTION
This extra space was breaking the backup script when running with
`backupdatabases`.
