### PR TITLE
parameterize mysqld config_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,11 @@ You can just make an entry like `thing => true`, `thing => value`, or `thing => 
 
 The location of the MySQL configuration file.
 
+#####`config_dir`
+
+The location of the MySQL configuration dir. Note: This is not the conf.d
+directory!
+
 #####`manage_config_file`
 
 Whether the MySQL configuration file should be managed.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@ class mysql::params {
   $manage_config_file     = true
   $old_root_password      = ''
   $purge_conf_dir         = false
+  $config_dir             = '/etc/mysql'
   $restart                = false
   $root_password          = 'UNSET'
   $server_package_ensure  = 'present'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,6 +1,7 @@
 # Class: mysql::server:  See README.md for documentation.
 class mysql::server (
   $config_file             = $mysql::params::config_file,
+  $config_dir              = $mysql::params::config_dir,
   $manage_config_file      = $mysql::params::manage_config_file,
   $old_root_password       = $mysql::params::old_root_password,
   $override_options        = {},

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -9,12 +9,12 @@ class mysql::server::config {
     mode   => '0400',
   }
 
-  file { '/etc/mysql':
+  file { $mysql::server::config_dir:
     ensure => directory,
     mode   => '0755',
   }
 
-  file { '/etc/mysql/conf.d':
+  file { "${mysql::server::config_dir}/conf.d":
     ensure  => directory,
     mode    => '0755',
     recurse => $mysql::server::purge_conf_dir,

--- a/spec/acceptance/mysql_server_config_spec.rb
+++ b/spec/acceptance/mysql_server_config_spec.rb
@@ -15,6 +15,36 @@ describe 'config location', :unless => UNSUPPORTED_PLATFORMS.include?(fact('oper
   end
 end
 
+describe 'config dir location', :unless => UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem')) do
+  it 'creates the config dir elsewhere' do
+    pp = <<-EOS
+        class { 'mysql::server':
+          config_dir => '/etc/alternativedir',
+        }
+    EOS
+    apply_manifest(pp, :catch_failures => true)
+  end
+
+  describe file('/etc/alternativedir') do
+    it { should be_directory }
+  end
+end
+
+describe 'config dir location', :unless => UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem')) do
+  it 'creates the config dir elsewhere' do
+    pp = <<-EOS
+        class { 'mysql::server':
+          config_dir => '/etc/alternativedir',
+        }
+    EOS
+    apply_manifest(pp, :catch_failures => true)
+  end
+
+  describe file('/etc/alternativedir') do
+    it { should be_directory }
+  end
+end
+
 describe 'manage_config_file' do
   it 'wont reset the location of my.cnf' do
     pp = <<-EOS

--- a/spec/classes/mysql_server_spec.rb
+++ b/spec/classes/mysql_server_spec.rb
@@ -75,6 +75,27 @@ describe 'mysql::server' do
     end
   end
 
+  context 'mysql::server::config alternative conf dir' do
+    let(:params){{ :config_dir => '/etc/mysql-alternative' }}
+    it do
+      should contain_file('/etc/mysql-alternative').with({
+        :ensure => :directory,
+        :mode   => '0755',
+      })
+    end
+    it do
+      should contain_file('/etc/mysql-alternative/conf.d').with({
+        :ensure => :directory,
+        :mode   => '0755',
+      })
+    end
+    it do
+      should contain_file('/etc/mysql-alternative/my.cnf').with_content(
+        %r{^!includedir /etc/mysql-alternative/conf.d/$}
+      )
+    end
+  end
+
   context 'mysql::server::config' do
     it do
       should contain_file('/etc/mysql').with({

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -17,4 +17,4 @@
 <%   end %>
 <% end -%>
 
-!includedir /etc/mysql/conf.d/
+!includedir <%= scope.lookupvar('mysql::server::config_dir') %>/conf.d


### PR DESCRIPTION
This ensures config dir is overridable so we can install MySQL 5.5 from http://wiki.centos.org/AdditionalResources/Repositories/SCL
