### PR TITLE
Fixed travis by updating Gemfile to pin Rake to 10.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :development, :test do
   gem 'mime-types', '<2.0',      :require => false
-  gem 'rake',                    :require => false
+  gem 'rake',  '10.1.1',         :require => false
   gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'rspec-system',            :require => false


### PR DESCRIPTION
The latest Rake update requires Ruby >= 1.9. This update
fixes the failing 1.8.7 tests by pinning Rake to the last
supported version on ruby 1.8.7.

This is a direct copy from @blkperl's fix for puppetlabs-apache
https://github.com/puppetlabs/puppetlabs-apache/pull/685
