### PR TITLE
Add quotes to backup password to be able to use more complex passwords.

### DIFF
--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -11,7 +11,7 @@
 ##### START CONFIG ###################################################
 
 USER=<%= @backupuser %>
-PASS=<%= @backuppassword %>
+PASS='<%= @backuppassword %>'
 DIR=<%= @backupdir %>
 ROTATE=<%= [ Integer(@backuprotate) - 1, 0 ].max %>
 


### PR DESCRIPTION
to be able to use generated, complex passwords with special characters in them
it is necessary to quote PASS in the backup script.
