### PR TITLE
Allow rspec-beaker to update.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :development, :test do
   gem 'mime-types', '<2.0',      :require => false
-  gem 'rake',  '10.1.1',         :require => false
   gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'serverspec',              :require => false

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,1 @@
 require 'puppetlabs_spec_helper/rake_tasks'
-require 'rspec-system/rake_task'


### PR DESCRIPTION
Previously the dependencies for rspec-system were holding back rspec-beaker and specinfra.
