### PR TITLE
Ignore internal mysql databases when creating a backup

### DIFF
--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -40,7 +40,7 @@ cleanup
 <% end -%>
 <% if @backupdatabases.empty? -%>
 <% if @file_per_database -%>
-mysql -s -r -N -e 'SHOW DATABASES' | while read dbname
+mysql -s -r -N -e 'SELECT SCHEMA_NAME FROM information_schema.schemata WHERE SCHEMA_NAME NOT IN ("information_schema", "performance_schema", "test", "mysql");' | while read dbname
 do
   mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \
     ${EVENTS} \


### PR DESCRIPTION
In my cases I usually don't want to backup the internal event + information_schema table of mysql, since backupping them raises the following error in:

``` console
# /usr/local/sbin/mysqlbackup.sh
-- Warning: Skipping the data of table mysql.event. Specify the --events option explicitly.
# /usr/local/sbin/mysqlbackup.sh
mysqldump: Couldn't execute 'SELECT /*!40001 SQL_NO_CACHE */ * FROM `INNODB_BUFFER_PAGE`': Access denied; you need (at least one of) the PROCESS privilege(s) for this operation (1227)
```

This small pull request, uses the INFORMATION_SCHEMA table and excludes "information_schema", "performance_schema", "test", "mysql" from the dumped databases.
