### PR TITLE
Made mysqlbackup.sh template configurable

### DIFF
--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -16,6 +16,7 @@ class mysql::server::backup (
   $time = ['23', '5'],
   $postscript = false,
   $execpath   = '/usr/bin:/usr/sbin:/bin:/sbin',
+  $mysqlbackup_sh_template = 'mysql/mysqlbackup.sh.erb',
 ) {
 
   mysql_user { "${backupuser}@localhost":
@@ -48,7 +49,7 @@ class mysql::server::backup (
     mode    => '0700',
     owner   => 'root',
     group   => 'root',
-    content => template('mysql/mysqlbackup.sh.erb'),
+    content => template($mysqlbackup_sh_template),
   }
 
   file { 'mysqlbackupdir':


### PR DESCRIPTION
Sometimes you want to modify/extend the mysqlbackup.sh file for your project. So it would be nice to make it configurable as class argument for mysql::server::backup.
