### PR TITLE
User needs PROCESS privilege when doing file-per-database backup

### DIFF
--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -29,7 +29,7 @@ class mysql::server::backup (
     ensure     => present,
     user       => "${backupuser}@localhost",
     table      => '*.*',
-    privileges => [ 'SELECT', 'RELOAD', 'LOCK TABLES', 'SHOW VIEW' ],
+    privileges => [ 'SELECT', 'RELOAD', 'LOCK TABLES', 'SHOW VIEW', 'PROCESS' ],
     require    => Mysql_user["${backupuser}@localhost"],
   }
 

--- a/spec/classes/mysql_server_backup_spec.rb
+++ b/spec/classes/mysql_server_backup_spec.rb
@@ -19,7 +19,7 @@ describe 'mysql::server::backup' do
         )}
 
         it { should contain_mysql_grant('testuser@localhost/*.*').with(
-            :privileges => ["SELECT", "RELOAD", "LOCK TABLES", "SHOW VIEW"]
+            :privileges => ["SELECT", "RELOAD", "LOCK TABLES", "SHOW VIEW", "PROCESS"]
         )}
 
         it { should contain_cron('mysql-backup').with(


### PR DESCRIPTION
The following error occured:
mysqldump: Couldn't execute 'SELECT /*!40001 SQL_NO_CACHE */ \* FROM `INNODB_BUFFER_PAGE`': Access denied; you need (at least one of) the PROCESS privilege(s) for this operation (1227)
