### PR TITLE
lowercase hostname values in qualified usernames

### DIFF
--- a/lib/puppet/type/database_user.rb
+++ b/lib/puppet/type/database_user.rb
@@ -16,6 +16,11 @@ Puppet::Type.newtype(:database_user) do
         raise ArgumentError, 'MySQL usernames are limited to a maximum of 16 characters'
       end
     end
+
+    munge do |value|
+      user_part, host_part = value.split('@')
+      "#{user_part}@#{host_part.downcase}"
+    end
   end
 
   newproperty(:password_hash) do

--- a/lib/puppet/type/mysql_user.rb
+++ b/lib/puppet/type/mysql_user.rb
@@ -15,6 +15,11 @@ Puppet::Type.newtype(:mysql_user) do
         raise ArgumentError, 'MySQL usernames are limited to a maximum of 16 characters'
       end
     end
+
+    munge do |value|
+      user_part, host_part = value.split('@')
+      "#{user_part}@#{host_part.downcase}"
+    end
   end
 
   newproperty(:password_hash) do

--- a/spec/acceptance/types/mysql_user_spec.rb
+++ b/spec/acceptance/types/mysql_user_spec.rb
@@ -11,21 +11,44 @@ describe 'mysql_user', :unless => UNSUPPORTED_PLATFORMS.include?(fact('operating
     end
   end
 
-  describe 'adding user' do
-    it 'should work without errors' do
-      pp = <<-EOS
-        mysql_user { 'ashp@localhost':
-          password_hash => '6f8c114b58f2ce9e',
-        }
-      EOS
+  context 'using ashp@localhost' do
+    describe 'adding user' do
+      it 'should work without errors' do
+        pp = <<-EOS
+          mysql_user { 'ashp@localhost':
+            password_hash => '6f8c114b58f2ce9e',
+          }
+        EOS
 
-      apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_failures => true)
+      end
+
+      it 'should find the user' do
+        shell("mysql -NBe \"select '1' from mysql.user where CONCAT(user, '@', host) = 'ashp@localhost'\"") do |r|
+          expect(r.stdout).to match(/^1$/)
+          expect(r.stderr).to be_empty
+        end
+      end
     end
+  end
 
-    it 'should find the user' do
-      shell("mysql -NBe \"select '1' from mysql.user where CONCAT(user, '@', host) = 'ashp@localhost'\"") do |r|
-        expect(r.stdout).to match(/^1$/)
-        expect(r.stderr).to be_empty
+  context 'using ashp@LocalHost' do
+    describe 'adding user' do
+      it 'should work without errors' do
+        pp = <<-EOS
+          mysql_user { 'ashp@LocalHost':
+            password_hash => '6f8c114b58f2ce9e',
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+      end
+
+      it 'should find the user' do
+        shell("mysql -NBe \"select '1' from mysql.user where CONCAT(user, '@', host) = 'ashp@localhost'\"") do |r|
+          expect(r.stdout).to match(/^1$/)
+          expect(r.stderr).to be_empty
+        end
       end
     end
   end

--- a/spec/unit/puppet/type/mysql_user_spec.rb
+++ b/spec/unit/puppet/type/mysql_user_spec.rb
@@ -2,23 +2,10 @@ require 'puppet'
 require 'puppet/type/mysql_user'
 describe Puppet::Type.type(:mysql_user) do
 
-  before :each do
-    @user = Puppet::Type.type(:mysql_user).new(:name => 'foo@localhost', :password_hash => 'pass')
-  end
-
-  it 'should accept a user name' do
-    @user[:name].should == 'foo@localhost'
-  end
-
   it 'should fail with a long user name' do
     expect {
       Puppet::Type.type(:mysql_user).new({:name => '12345678901234567@localhost', :password_hash => 'pass'})
-      }.to raise_error /MySQL usernames are limited to a maximum of 16 characters/
-  end
-
-  it 'should accept a password' do
-    @user[:password_hash] = 'foo'
-    @user[:password_hash].should == 'foo'
+    }.to raise_error /MySQL usernames are limited to a maximum of 16 characters/
   end
 
   it 'should require a name' do
@@ -27,4 +14,29 @@ describe Puppet::Type.type(:mysql_user) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  context 'using foo@localhost' do
+    before :each do
+      @user = Puppet::Type.type(:mysql_user).new(:name => 'foo@localhost', :password_hash => 'pass')
+    end
+
+    it 'should accept a user name' do
+      @user[:name].should == 'foo@localhost'
+    end
+
+    it 'should accept a password' do
+      @user[:password_hash] = 'foo'
+      @user[:password_hash].should == 'foo'
+    end
+  end
+
+  context 'using foo@LocalHost' do
+    before :each do
+      @user = Puppet::Type.type(:mysql_user).new(:name => 'foo@LocalHost', :password_hash => 'pass')
+    end
+
+    it 'should lowercase the user name' do
+      @user[:name].should == 'foo@localhost'
+    end
+
+  end
 end


### PR DESCRIPTION
MySQL/MariaDB automatically downcase hostnames:

```
MariaDB [mysql]> create user 'testuser'@'HOSTNAME';
MariaDB [mysql]> select user,host from user where host = 'hostname';
+----------+----------+
| user     | host     |
+----------+----------+
| testuser | hostname |
+----------+----------+
```

This causes problems when a mysql_user or datbase_user has an hostname
with non-lowercase characters:

```
database_user { "root@HOSTNAME":
  ensure => absent,
}
```

The SELECT statements used to determine if the user exists will fail
because the comparisons use "HOSTNAME" but the database has "hostname".
This patch forces the hostname part of "user@hostname" to lower case in
the custom type definitions.
