### PR TITLE
Parametrize !includedir

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ replicate-do-db = base2
 ###Custom configuration
 
 To add custom MySQL configuration, drop additional files into
-`/etc/mysql/conf.d/`. Dropping files into conf.d allows you to override settings or add additional ones, which is helpful if you choose not to use `override_options` in `mysql::server`. The conf.d location is hardcoded into the my.cnf template file.
+`includedir`. Dropping files into `includedir` allows you to override settings or add additional ones, which is helpful if you choose not to use `override_options` in `mysql::server`. The `includedir` location is by default set to /etc/mysql/conf.d.
 
 ##Reference
 
@@ -173,9 +173,12 @@ The location of the MySQL configuration file.
 
 Whether the MySQL configuration file should be managed.
 
+#####`includedir`
+The location of !includedir for custom configuration overrides.
+
 #####`purge_conf_dir`
 
-Whether the conf.d directory should be purged.
+Whether the `includedir` directory should be purged.
 
 #####`restart`
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,6 +51,8 @@ class mysql::params {
         $server_service_name = 'mariadb'
         $log_error           = '/var/log/mariadb/mariadb.log'
         $config_file         = '/etc/my.cnf.d/server.cnf'
+        # mariadb package by default has !includedir set in my.cnf to /etc/my.cnf.d
+        $includedir          = undef
         $pidfile             = '/var/run/mariadb/mariadb.pid'
       } else {
         $client_package_name = 'mysql'
@@ -58,6 +60,7 @@ class mysql::params {
         $server_service_name = 'mysqld'
         $log_error           = '/var/log/mysqld.log'
         $config_file         = '/etc/my.cnf'
+        $includedir          = '/etc/my.cnf.d'
         $pidfile             = '/var/run/mysqld/mysqld.pid'
       }
 
@@ -88,6 +91,7 @@ class mysql::params {
       }
       $basedir             = '/usr'
       $config_file         = '/etc/my.cnf'
+      $includedir          = '/etc/my.cnf.d'
       $datadir             = '/var/lib/mysql'
       $log_error           = $::operatingsystem ? {
         /OpenSuSE/         => '/var/log/mysql/mysqld.log',
@@ -124,6 +128,7 @@ class mysql::params {
 
       $basedir             = '/usr'
       $config_file         = '/etc/mysql/my.cnf'
+      $includedir          = '/etc/mysql/conf.d'
       $datadir             = '/var/lib/mysql'
       $log_error           = '/var/log/mysql/error.log'
       $pidfile             = '/var/run/mysqld/mysqld.pid'
@@ -147,6 +152,7 @@ class mysql::params {
       $server_package_name = 'databases/mysql55-server'
       $basedir             = '/usr/local'
       $config_file         = '/var/db/mysql/my.cnf'
+      $includedir          = '/var/db/mysql/my.cnf.d'
       $datadir             = '/var/db/mysql'
       $log_error           = "/var/db/mysql/${::hostname}.err"
       $pidfile             = '/var/db/mysql/mysql.pid'
@@ -172,6 +178,7 @@ class mysql::params {
           $server_package_name = 'mysql-server'
           $basedir             = '/usr'
           $config_file         = '/etc/my.cnf'
+          $includedir          = '/etc/my.cnf.d'
           $datadir             = '/var/lib/mysql'
           $log_error           = '/var/log/mysqld.log'
           $pidfile             = '/var/run/mysqld/mysqld.pid'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,6 +1,7 @@
 # Class: mysql::server:  See README.md for documentation.
 class mysql::server (
   $config_file             = $mysql::params::config_file,
+  $includedir              = $mysql::params::includedir,
   $manage_config_file      = $mysql::params::manage_config_file,
   $old_root_password       = $mysql::params::old_root_password,
   $override_options        = {},

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -2,6 +2,7 @@
 class mysql::server::config {
 
   $options = $mysql::server::options
+  $includedir = $mysql::server::includedir
 
   File {
     owner  => 'root',
@@ -9,16 +10,13 @@ class mysql::server::config {
     mode   => '0400',
   }
 
-  file { '/etc/mysql':
-    ensure => directory,
-    mode   => '0755',
-  }
-
-  file { '/etc/mysql/conf.d':
-    ensure  => directory,
-    mode    => '0755',
-    recurse => $mysql::server::purge_conf_dir,
-    purge   => $mysql::server::purge_conf_dir,
+  if $includedir and $includedir != '' {
+    file { "$mysql::server::includedir":
+      ensure  => directory,
+      mode    => '0755',
+      recurse => $mysql::server::purge_conf_dir,
+      purge   => $mysql::server::purge_conf_dir,
+    }
   }
 
   if $mysql::server::manage_config_file  {

--- a/spec/acceptance/mysql_server_config_spec.rb
+++ b/spec/acceptance/mysql_server_config_spec.rb
@@ -36,6 +36,47 @@ describe 'manage_config_file' do
   end
 end
 
+describe 'includedir location', :unless => UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem')) do
+  it 'creates the file elsewhere' do
+    pp = <<-EOS
+        class { 'mysql::server':
+          includedir => '/etc/my.cnf.d',
+          config_file => '/etc/testmy.cnf',
+        }
+    EOS
+    # Make sure this doesn't exist so we can test if puppet
+    # readded it.  It may not exist in the first place on
+    # some platforms.
+    shell('rmdir /etc/my.cnf.d', :acceptable_exit_codes => [0,1,2])
+    apply_manifest(pp, :catch_failures => true)
+  end
+
+  describe file('/etc/my.cnf.d') do
+    it { should be_directory }
+  end
+
+  describe file('/etc/testmy.cnf') do
+    it { sould contain "!includedir /etc/my.cnf.d" }
+  end
+end
+
+describe 'no includedir location', :unless => UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem')) do
+  it 'creates the file elsewhere' do
+    pp = <<-EOS
+        class { 'mysql::server':
+          includedir => '',
+          config_file => '/etc/testmy.cnf',
+        }
+    EOS
+    apply_manifest(pp, :catch_failures => true)
+  end
+
+  describe file('/etc/testmy.cnf') do
+    it { should_not contain "includedir" }
+  end
+end
+
+
 describe 'resets' do
   it 'cleans up' do
     pp = <<-EOS
@@ -45,3 +86,4 @@ describe 'resets' do
     shell('rm /etc/testmy.cnf')
   end
 end
+

--- a/spec/classes/mysql_server_spec.rb
+++ b/spec/classes/mysql_server_spec.rb
@@ -76,24 +76,44 @@ describe 'mysql::server' do
   end
 
   context 'mysql::server::config' do
-    it do
-      should contain_file('/etc/mysql').with({
-        :ensure => :directory,
-        :mode   => '0755',
-      })
+    context 'with includedir' do
+      let(:params) {{ :includedir => '/etc/my.cnf.d' }}
+      it do
+        should contain_file('/etc/my.cnf.d').with({
+          :ensure => :directory,
+          :mode   => '0755',
+        })
+      end
+
+      it do
+        should contain_file('/etc/my.cnf').with({
+          :mode => '0644',
+        })
+      end
+
+      it do
+         should contain_file('/etc/my.cnf').with_content(/!includedir/)
+      end
     end
 
-    it do
-      should contain_file('/etc/mysql/conf.d').with({
-        :ensure => :directory,
-        :mode   => '0755',
-      })
-    end
+    context 'without includedir' do
+      let(:params) {{ :includedir => '' }}
+      it do
+        should_not contain_file('/etc/my.cnf.d').with({
+          :ensure => :directory,
+          :mode   => '0755',
+        })
+      end
 
-    it do
-      should contain_file('/etc/my.cnf').with({
-        :mode => '0644',
-      })
+      it do
+        should contain_file('/etc/my.cnf').with({
+          :mode => '0644',
+        })
+      end
+
+      it do
+         should contain_file('/etc/my.cnf').without_content(/!includedir/)
+      end
     end
   end
 

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -17,4 +17,6 @@
 <%   end %>
 <% end -%>
 
-!includedir /etc/mysql/conf.d/
+<% if @includedir and @includedir != '' %>
+!includedir <%= @includedir %>
+<% end %>


### PR DESCRIPTION
Hardcoded path provided by puppet is now replaced by providing only the final directory as on
most systems includedir is provided by package and it's matter of user to provide it if he
wants to override it. This also allows disabling including at all.
