### PR TITLE
Fixes to get tests running on RHEL5.

### DIFF
--- a/spec/acceptance/mysql_bindings_spec.rb
+++ b/spec/acceptance/mysql_bindings_spec.rb
@@ -54,6 +54,13 @@ end
 
 describe 'mysql::bindings class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem')) do
 
+  if fact('osfamily') == 'RedHat' and fact('operatingsystemmajrelease') =~ /(5|6)/
+    it 'adds epel' do
+      pp = "class { 'epel': }"
+      apply_manifest(pp, :catch_failures => true)
+    end
+  end
+
   describe 'running puppet code' do
     it 'should work with no errors' do
       pp = <<-EOS

--- a/spec/acceptance/nodesets/centos-510-x64.yml
+++ b/spec/acceptance/nodesets/centos-510-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  centos-510-x64:
+    roles:
+      - master
+    platform: el-5-x86_64
+    box : centos-510-x64-virtualbox-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-510-x64-virtualbox-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  type: git

--- a/spec/acceptance/nodesets/centos-59-x64.yml
+++ b/spec/acceptance/nodesets/centos-59-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  centos-59-x64:
+    roles:
+      - master
+    platform: el-5-x86_64
+    box : centos-59-x64-vbox4210-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-59-x64-vbox4210-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  type: git

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -29,20 +29,11 @@ RSpec.configure do |c|
       if fact('osfamily') == 'RedHat'
         version = fact("operatingsystemmajrelease")
         shell("yum localinstall -y http://yum.puppetlabs.com/puppetlabs-release-el-#{version}.noarch.rpm")
-        if version == '6'
-          shell("yum localinstall -y http://mirror.pnl.gov/epel/6/i386/epel-release-6-8.noarch.rpm")
-        elsif version == '5'
-          shell("yum localinstall -y http://mirrors.servercentral.net/fedora/epel/5/i386/epel-release-5-4.noarch.rpm")
-        elsif version == '7'
-          puts "There aren't actually any failures on RHEL7 without EPEL."
-        else
-          puts "Sorry, this version is not supported."
-          exit
-        end
       end
 
       shell("/bin/touch #{default['puppetpath']}/hiera.yaml")
       shell('puppet module install puppetlabs-stdlib --version 3.2.0', { :acceptable_exit_codes => [0,1] })
+      on host, puppet('module','install','stahnma/epel'), { :acceptable_exit_codes => [0,1] }
     end
   end
 end


### PR DESCRIPTION
Existing EPEL addition in spec_helper_acceptance wasn't actually working, so pulled in stahnma-epel and applied that in the bindings test, since that's the only place it's actually required.
