### PR TITLE
Require title of mysql_grant resource to match form user/table

### DIFF
--- a/lib/puppet/type/mysql_grant.rb
+++ b/lib/puppet/type/mysql_grant.rb
@@ -24,6 +24,7 @@ Puppet::Type.newtype(:mysql_grant) do
     fail('privileges parameter is required.') if self[:ensure] == :present and self[:privileges].nil?
     fail('table parameter is required.') if self[:ensure] == :present and self[:table].nil?
     fail('user parameter is required.') if self[:ensure] == :present and self[:user].nil?
+    fail('name must match user and table parameters') if self[:name] != "#{self[:user]}/#{self[:table]}"
   end
 
   newparam(:name, :namevar => true) do

--- a/spec/acceptance/types/mysql_grant_spec.rb
+++ b/spec/acceptance/types/mysql_grant_spec.rb
@@ -70,6 +70,21 @@ describe 'mysql_grant', :unless => UNSUPPORTED_PLATFORMS.include?(fact('operatin
     end
   end
 
+  describe 'adding privileges with invalid name' do
+    it 'should fail' do
+      pp = <<-EOS
+        mysql_grant { 'test':
+          ensure     => 'present',
+          table      => 'test.*',
+          user       => 'test2@tester',
+          privileges => ['SELECT', 'UPDATE'],
+        }
+      EOS
+
+      expect(apply_manifest(pp, :expect_failures => true).stderr).to match(/name must match user and table parameters/)
+    end
+  end
+
   describe 'adding option' do
     it 'should work without errors' do
       pp = <<-EOS

--- a/spec/unit/puppet/type/mysql_grant_spec.rb
+++ b/spec/unit/puppet/type/mysql_grant_spec.rb
@@ -41,4 +41,10 @@ describe Puppet::Type.type(:mysql_grant) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  it 'should require the name to match the user and table' do
+    expect {
+      Puppet::Type.type(:mysql_grant).new(:name => 'foo', :privileges => ['ALL', 'PROXY'], :table => ['*.*','@'], :user => 'foo@localhost')
+    }.to raise_error /name must match user and table parameters/
+  end
+
 end


### PR DESCRIPTION
This addresses https://tickets.puppetlabs.com/browse/MODULES-1040.
The user parameter is required to have the form username@host. A grant
is identified in the instances method by a name of the form
username@host/table. The resource will fail to be identified as already
existing if the name given to the resource does not match this form.

I'm happy to dig into this more if there are other suggestions for how to fix this.
