### PR TITLE
fix param client_package_ensure

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class mysql::params {
   $server_package_ensure  = 'present'
   $server_service_manage  = true
   $server_service_enabled = true
+  $client_package_ensure  = 'present'
   # mysql::bindings
   $bindings_enable             = false
   $java_package_ensure         = 'present'


### PR DESCRIPTION
Fix for bug MODULES-723
https://tickets.puppetlabs.com/browse/MODULES-723

Variable client_package_ensure is used in mysql::client, but it's not declared in mysql::params
