### PR TITLE
RSpec renamed be_true to be_truthy in 3.0

### DIFF
--- a/spec/unit/puppet/provider/database_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/database_user/mysql_spec.rb
@@ -52,7 +52,7 @@ usvn_user@localhost
       subject.expects(:mysql).with([defaults_file, 'mysql', '-e', "grant usage on *.* to 'joe'@'localhost' identified by PASSWORD
       '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4' with max_user_connections 10"])
       @provider.expects(:exists?).returns(true)
-      @provider.create.should be_true
+      @provider.create.should be_truthy
     end
   end
 
@@ -60,7 +60,7 @@ usvn_user@localhost
     it 'removes a user if present' do
       subject.expects(:mysql).with([defaults_file, 'mysql', '-e', "drop user 'joe'@'localhost'"])
       @provider.expects(:exists?).returns(false)
-      @provider.destroy.should be_true
+      @provider.destroy.should be_truthy
     end
   end
 
@@ -98,7 +98,7 @@ usvn_user@localhost
   describe 'exists?' do
     it 'checks if user exists' do
       subject.expects(:mysql).with([defaults_file, 'mysql', '-NBe', "select '1' from mysql.user where CONCAT(user, '@', host) = 'joe@localhost'"]).returns('1')
-      @provider.exists?.should be_true
+      @provider.exists?.should be_truthy
     end
   end
 

--- a/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
@@ -58,7 +58,7 @@ test
     it 'makes a database' do
       provider.expects(:mysql).with([defaults_file, '-NBe', "create database if not exists `#{resource[:name]}` character set #{resource[:charset]} collate #{resource[:collate]}"])
       provider.expects(:exists?).returns(true)
-      provider.create.should be_true
+      provider.create.should be_truthy
     end
   end
 
@@ -66,13 +66,13 @@ test
     it 'removes a database if present' do
       provider.expects(:mysql).with([defaults_file, '-NBe', "drop database `#{resource[:name]}`"])
       provider.expects(:exists?).returns(false)
-      provider.destroy.should be_true
+      provider.destroy.should be_truthy
     end
   end
 
   describe 'exists?' do
     it 'checks if database exists' do
-      instance.exists?.should be_true
+      instance.exists?.should be_truthy
     end
   end
 

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -65,7 +65,7 @@ usvn_user@localhost
     it 'makes a user' do
       provider.expects(:mysql).with([defaults_file, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' IDENTIFIED BY PASSWORD '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4' WITH MAX_USER_CONNECTIONS 10 MAX_CONNECTIONS_PER_HOUR 10 MAX_QUERIES_PER_HOUR 10 MAX_UPDATES_PER_HOUR 10"])
       provider.expects(:exists?).returns(true)
-      provider.create.should be_true
+      provider.create.should be_truthy
     end
   end
 
@@ -73,13 +73,13 @@ usvn_user@localhost
     it 'removes a user if present' do
       provider.expects(:mysql).with([defaults_file, '-e', "DROP USER 'joe'@'localhost'"])
       provider.expects(:exists?).returns(false)
-      provider.destroy.should be_true
+      provider.destroy.should be_truthy
     end
   end
 
   describe 'exists?' do
     it 'checks if user exists' do
-      instance.exists?.should be_true
+      instance.exists?.should be_truthy
     end
   end
 


### PR DESCRIPTION
This commits updates the spec tests to use the renamed function.
