### PR TITLE
fix beaker breakage: upgrade beaker-rspec, explicitly add vagrant-wrapper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,9 @@ group :development, :test do
   gem 'puppet-lint',             :require => false
   gem 'pry',                     :require => false
   gem 'simplecov',               :require => false
+  gem 'vagrant-wrapper',         :require => false
   gem 'beaker',                  :require => false
-  gem 'beaker-rspec',            :require => false
+  gem 'beaker-rspec', '>2.2.0',  :require => false
 end
 
 if puppetversion = ENV['PUPPET_GEM_VERSION']


### PR DESCRIPTION
This makes beaker actually work on my platform.
