### PR TITLE
(MODULES-1096) Fix double quote / single quote issue in params.pp.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,7 +32,7 @@ class mysql::params {
     'RedHat': {
       case $::operatingsystem {
         'Fedora': {
-          if is_integer($::operatingsystemrelease) and $::operatingsystemrelease >= 19 or $::operatingsystemrelease == "Rawhide" {
+          if is_integer($::operatingsystemrelease) and $::operatingsystemrelease >= 19 or $::operatingsystemrelease == 'Rawhide' {
             $provider = 'mariadb'
           } else {
             $provider = 'mysql'


### PR DESCRIPTION
To follow style guide advice
(http://docs.puppetlabs.com/guides/style_guide.html#quoting) and make
puppet-lint happy, manifests should only use double quotes with strings that
contain variables.

This commit fixes the lone exception to this rule.
