### PR TITLE
Fix acceptance test for mysql::bindings.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -80,7 +80,7 @@ class mysql::params {
       $php_package_name        = 'php-mysql'
       $python_package_name     = 'MySQL-python'
       $ruby_package_name       = 'ruby-mysql'
-      $client_dev_package_name = 'libmysqlclient-devel'
+      $client_dev_package_name = undef
       $daemon_dev_package_name = 'mysql-devel'
     }
 
@@ -153,7 +153,7 @@ class mysql::params {
         default            => 'libmysql-ruby',
       }
       $client_dev_package_name = 'libmysqlclient-dev'
-      $daemon_dev_package_name = 'mysqld-dev'
+      $daemon_dev_package_name = 'libmysqld-dev'
     }
 
     'FreeBSD': {

--- a/spec/acceptance/mysql_bindings_spec.rb
+++ b/spec/acceptance/mysql_bindings_spec.rb
@@ -14,7 +14,7 @@ when 'RedHat'
   if fact('operatingsystemmajrelease') == '7'
     ruby_package_provider = 'gem'
   end
-  client_dev_package = 'libmysqlclient-devel'
+  client_dev_package = 'undef'
   daemon_dev_package = 'mysql-devel'
 when 'Suse'
   java_package       = 'mysql-connector-java'
@@ -40,15 +40,15 @@ when 'Debian'
     ruby_package   = 'libmysql-ruby'
   end
   client_dev_package = 'libmysqlclient-dev'
-  daemon_dev_package = 'mysqld-dev'
+  daemon_dev_package = 'libmysqld-dev'
 when 'FreeBSD'
   java_package = 'databases/mysql-connector-java'
   perl_package   = 'p5-DBD-mysql'
   php_package    = 'php5-mysql'
   python_package = 'databases/py-MySQLdb'
   ruby_package   = 'ruby-mysql'
-  client_dev_package = nil
-  daemon_dev_package = nil
+  client_dev_package = 'undef'
+  daemon_dev_package = 'undef'
 else
   case operatingsystem
   when 'Amazon'
@@ -57,8 +57,8 @@ else
     php_package    = 'php5-mysql'
     python_package = 'MySQL-python'
     ruby_package   = 'ruby-mysql'
-    client_dev_package = nil
-    daemon_dev_package = nil
+    client_dev_package = 'undef'
+    daemon_dev_package = 'undef'
   end
 end
 
@@ -87,34 +87,34 @@ describe 'mysql::bindings class', :unless => UNSUPPORTED_PLATFORMS.include?(fact
     it 'should work with no errors' do
       pp = <<-EOS
         class { 'mysql::bindings':
-          java_enable             => true,
-          perl_enable             => true,
-          php_enable              => true,
-          python_enable           => true,
-          ruby_enable             => true,
-          client_dev              => true,
-          daemon_dev              => true,
-          java_package_ensure     => present,
-          perl_package_ensure     => present,
-          php_package_ensure      => present,
-          python_package_ensure   => present,
-          ruby_package_ensure     => present,
-          client_dev_ensure       => present,
-          daemon_dev_ensure       => present,
-          java_package_name       => #{java_package},
-          perl_package_name       => #{perl_package},
-          php_package_name        => #{php_package},
-          python_package_name     => #{python_package},
-          ruby_package_name       => #{ruby_package},
-          client_dev_package_name => #{client_dev_package},
-          daemon_dev_package_name => #{daemon_dev_package},
-          java_package_provider   => undef,
-          perl_package_provider   => undef,
-          php_package_provider    => undef,
-          python_package_provider => undef,
-          ruby_package_provider   => #{ruby_package_provider},
-          client_dev_provider     => undef,
-          daemon_dev_provider     => undef,
+          java_enable                 => true,
+          perl_enable                 => true,
+          php_enable                  => true,
+          python_enable               => true,
+          ruby_enable                 => true,
+          client_dev                  => true,
+          daemon_dev                  => true,
+          java_package_ensure         => present,
+          perl_package_ensure         => present,
+          php_package_ensure          => present,
+          python_package_ensure       => present,
+          ruby_package_ensure         => present,
+          client_dev_package_ensure   => present,
+          daemon_dev_package_ensure   => present,
+          java_package_name           => #{java_package},
+          perl_package_name           => #{perl_package},
+          php_package_name            => #{php_package},
+          python_package_name         => #{python_package},
+          ruby_package_name           => #{ruby_package},
+          client_dev_package_name     => #{client_dev_package},
+          daemon_dev_package_name     => #{daemon_dev_package},
+          java_package_provider       => undef,
+          perl_package_provider       => undef,
+          php_package_provider        => undef,
+          python_package_provider     => undef,
+          ruby_package_provider       => #{ruby_package_provider},
+          client_dev_package_provider => undef,
+          daemon_dev_package_provider => undef,
         }
       EOS
 

--- a/spec/classes/mysql_bindings_spec.rb
+++ b/spec/classes/mysql_bindings_spec.rb
@@ -48,8 +48,8 @@ describe 'mysql::bindings' do
   end
 
   context 'Debian' do
-    it_behaves_like 'bindings', 'Debian', 'Debian', '7.4','libmysql-java', 'libdbd-mysql-perl', 'php5-mysql', 'python-mysqldb', 'libmysql-ruby', 'libmysqlclient-dev', 'mysqld-dev'
-    it_behaves_like 'bindings', 'Debian', 'Ubuntu', '14.04', 'libmysql-java', 'libdbd-mysql-perl', 'php5-mysql', 'python-mysqldb', 'libmysql-ruby', 'libmysqlclient-dev', 'mysqld-dev'
+    it_behaves_like 'bindings', 'Debian', 'Debian', '7.4','libmysql-java', 'libdbd-mysql-perl', 'php5-mysql', 'python-mysqldb', 'libmysql-ruby', 'libmysqlclient-dev', 'libmysqld-dev'
+    it_behaves_like 'bindings', 'Debian', 'Ubuntu', '14.04', 'libmysql-java', 'libdbd-mysql-perl', 'php5-mysql', 'python-mysqldb', 'libmysql-ruby', 'libmysqlclient-dev', 'libmysqld-dev'
   end
 
   context 'freebsd' do
@@ -57,8 +57,8 @@ describe 'mysql::bindings' do
   end
 
   context 'redhat' do
-    it_behaves_like 'bindings', 'RedHat', 'RedHat', '6.5', 'mysql-connector-java', 'perl-DBD-MySQL', 'php-mysql', 'MySQL-python', 'ruby-mysql', 'libmysqlclient-devel', 'mysql-devel'
-    it_behaves_like 'bindings', 'RedHat', 'OpenSuSE', '11.3', 'mysql-connector-java', 'perl-DBD-MySQL', 'php-mysql', 'MySQL-python', 'ruby-mysql', 'libmysqlclient-devel', 'mysql-devel'
+    it_behaves_like 'bindings', 'RedHat', 'RedHat', '6.5', 'mysql-connector-java', 'perl-DBD-MySQL', 'php-mysql', 'MySQL-python', 'ruby-mysql', nil, 'mysql-devel'
+    it_behaves_like 'bindings', 'RedHat', 'OpenSuSE', '11.3', 'mysql-connector-java', 'perl-DBD-MySQL', 'php-mysql', 'MySQL-python', 'ruby-mysql', nil, 'mysql-devel'
   end
 
   describe 'on any other os' do


### PR DESCRIPTION
Fix acceptance test for bindings to use correct parameter names, when
instantiating mysql::bindings class. Fix client and server dev package names
for couple of distros.

Tested on centos-64-x64 and ubuntu-1404. Did not manage to get Beaker working with Sles or fedora images from spec/acceptance/nodesets.
