### PR TITLE
Include mysql::server class

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -17,6 +17,7 @@ define mysql::db (
   $table = "${dbname}.*"
 
   include '::mysql::client'
+  include '::mysql::server'
 
   $db_resource = {
     ensure   => $ensure,


### PR DESCRIPTION
Use of mysql::db throws: Error: Could not find dependency Class[Mysql::Server] on db.pp line 27.

Included class to fix the problem.

Puppet version: 3.6.2
