### PR TITLE
Grants for the backupuser should be conditional

### DIFF
--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -26,7 +26,7 @@ class mysql::server::backup (
   }
 
   mysql_grant { "${backupuser}@localhost/*.*":
-    ensure     => present,
+    ensure     => $ensure,
     user       => "${backupuser}@localhost",
     table      => '*.*',
     privileges => [ 'SELECT', 'RELOAD', 'LOCK TABLES', 'SHOW VIEW', 'PROCESS' ],


### PR DESCRIPTION
The mysql::server::backup class checks the ensure parameter when it creates the backup user, but it assumes 'present' when it does the grants for the backup user.  This means that when we try to turn off backups for a server, it removes the backup user, then tries to grant this no longer existing user permissions to perform a backup.

It will continue to try to perform the grant on each puppet run.

This pull request addresses this by changing the `ensure` value passed to `mysql_grant`  from 'present' to $ensure.
