### PR TITLE
Fix problem with GRANT not recognizing backslash

### DIFF
--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -36,6 +36,8 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
           end
           # Same here, but to remove OPTION leaving just GRANT.
           options = ['GRANT'] if rest.match(/WITH\sGRANT\sOPTION/)
+          # fix double backslash that MySQL prints, so resources match
+          table.gsub!("\\\\", "\\")
           # We need to return an array of instances so capture these
           instances << new(
               :name       => "#{user}@#{host}/#{table}",


### PR DESCRIPTION
If database grant has backslash in database name (for example: example_dev), then puppet will try to apply same resource every run because MySQL reports that table name with double backslash (for example: example\_dev). By global replace of double backslash with single one, this issue is fixed.
