### PR TITLE
Adds Support for CentOS and Scientific Linux 7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,8 +38,8 @@ class mysql::params {
             $provider = 'mysql'
           }
         }
-        'RedHat': {
-          if $::operatingsystemrelease >= 7 {
+        /^(RedHat|CentOS|Scientific)$/: {
+          if $::operatingsystemmajrelease >= 7 {
             $provider = 'mariadb'
           } else {
             $provider = 'mysql'

--- a/spec/classes/mysql_server_spec.rb
+++ b/spec/classes/mysql_server_spec.rb
@@ -75,6 +75,40 @@ describe 'mysql::server' do
     end
   end
 
+  context 'mysql::server::install on RHEL 7' do
+    let :facts do
+      { :osfamily                  => 'RedHat',
+        :operatingsystem           => 'RedHat',
+        :operatingsystemmajrelease => 7
+      }
+    end
+
+    let(:params) {{ :package_ensure => 'present', :name => 'mariadb-server' }}
+    it do
+      should contain_package('mysql-server').with({
+      :ensure => :present,
+      :name   => 'mariadb-server',
+    })
+    end
+  end
+
+  context 'mysql::server::install on CentOS 7' do
+    let :facts do
+      { :osfamily                  => 'RedHat',
+        :operatingsystem           => 'CentOS',
+        :operatingsystemmajrelease => 7
+      }
+    end
+
+    let(:params) {{ :package_ensure => 'present', :name => 'mariadb-server' }}
+    it do
+      should contain_package('mysql-server').with({
+      :ensure => :present,
+      :name   => 'mariadb-server',
+    })
+    end
+  end
+
   context 'mysql::server::config' do
     it do
       should contain_file('/etc/mysql').with({


### PR DESCRIPTION
CentOS Project has adopted a new rule for versioning numbers. The major number
matches the RHEL major number, but the minor number is generated from the
release date. For example, CentOS 7.0.1406.

Uses $::operatingsystemmajrelease instead of $::operatingsystemrelease for
avoiding issue like "Comparison of String with 7 failed" for CentOS 7.

Signed-off-by: Gael Chamoulaud gchamoul@redhat.com
