### PR TITLE
Prevent ERROR 1008 in mysql_database provider

### DIFF
--- a/lib/puppet/provider/mysql_database/mysql.rb
+++ b/lib/puppet/provider/mysql_database/mysql.rb
@@ -41,7 +41,7 @@ Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::
   end
 
   def destroy
-    mysql([defaults_file, '-NBe', "drop database `#{@resource[:name]}`"].compact)
+    mysql([defaults_file, '-NBe', "drop database if exists `#{@resource[:name]}`"].compact)
 
     @property_hash.clear
     exists? ? (return false) : (return true)

--- a/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
@@ -64,7 +64,7 @@ test
 
   describe 'destroy' do
     it 'removes a database if present' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "drop database `#{resource[:name]}`"])
+      provider.expects(:mysql).with([defaults_file, '-NBe', "drop database if exists `#{resource[:name]}`"])
       provider.expects(:exists?).returns(false)
       provider.destroy.should be_truthy
     end


### PR DESCRIPTION
Check for database existence when dropping to prevent

  ERROR 1008 (HY000): Can't drop database 'test'; database doesn't exist

Signed-off-by: Ray Lehtiniemi rayl@mail.com
