### PR TITLE
Added support for backing up triggers and routines to the mysql::server:backup module

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,14 @@ Array of databases to specifically back up.
 
 Whether a separate file be used per database.
 
+#####`include_triggers`
+
+Whether or not to include triggers for a each database when doing a `file_per_database` backup. Defaults to `true`.
+
+#####`include_routines`
+
+Whether or not to include routines for each database when doing a `file_per_database` backup. Defaults to `true`.
+
 #####`ensure`
 
 Allows you to remove the backup scripts. Can be 'present' or 'absent'.

--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -12,6 +12,8 @@ class mysql::server::backup (
   $delete_before_dump = false,
   $backupdatabases = [],
   $file_per_database = false,
+  $include_triggers = true,
+  $include_routines = true,
   $ensure = 'present',
   $time = ['23', '5'],
   $postscript = false,

--- a/spec/acceptance/mysql_backup_spec.rb
+++ b/spec/acceptance/mysql_backup_spec.rb
@@ -66,4 +66,49 @@ describe 'mysql::server::backup class', :unless => UNSUPPORTED_PLATFORMS.include
       end
     end
   end
+
+  context 'triggers and routines should work with no errors' do
+    it 'when configuring mysql backups with triggers and routines' do
+      pp = <<-EOS
+        class { 'mysql::server': root_password => 'password' }
+        mysql::db { [
+          'backup1',
+          'backup2'
+        ]:
+          user     => 'backup',
+          password => 'secret',
+        }
+
+        package { 'bzip2':
+          ensure => present,
+        }
+
+        class { 'mysql::server::backup':
+          backupuser     => 'myuser',
+          backuppassword => 'mypassword',
+          backupdir      => '/tmp/backups',
+          backupcompress => true,
+          file_per_database => true,
+          include_triggers => true,
+          include_routines => true,
+          postscript     => [
+            'rm -rf /var/tmp/mysqlbackups',
+            'rm -f /var/tmp/mysqlbackups.done',
+            'cp -r /tmp/backups /var/tmp/mysqlbackups',
+            'touch /var/tmp/mysqlbackups.done',
+          ],
+          execpath      => '/usr/bin:/usr/sbin:/bin:/sbin:/opt/zimbra/bin',
+          require       => Package['bzip2'],
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    it 'should run mysqlbackup.sh with no errors' do
+      shell("/usr/local/sbin/mysqlbackup.sh") do |r|
+        expect(r.stderr).to eq("")
+      end
+    end
+  end
+
 end

--- a/spec/classes/mysql_server_backup_spec.rb
+++ b/spec/classes/mysql_server_backup_spec.rb
@@ -2,262 +2,262 @@ require 'spec_helper'
 
 describe 'mysql::server::backup' do
 
-    let(:default_params) {
-        { 'backupuser'         => 'testuser',
-            'backuppassword'     => 'testpass',
-            'backupdir'          => '/tmp',
-            'backuprotate'       => '25',
-            'delete_before_dump' => true,
-            'execpath'           => '/usr/bin:/usr/sbin:/bin:/sbin:/opt/zimbra/bin',
-        }
+  let(:default_params) {
+    { 'backupuser'         => 'testuser',
+      'backuppassword'     => 'testpass',
+      'backupdir'          => '/tmp',
+      'backuprotate'       => '25',
+      'delete_before_dump' => true,
+      'execpath'           => '/usr/bin:/usr/sbin:/bin:/sbin:/opt/zimbra/bin',
     }
-    context 'standard conditions' do
-        let(:params) { default_params }
+  }
+  context 'standard conditions' do
+    let(:params) { default_params }
 
-        it { should contain_mysql_user('testuser@localhost').with(
-            :require => 'Class[Mysql::Server::Root_password]'
-        )}
+    it { should contain_mysql_user('testuser@localhost').with(
+      :require => 'Class[Mysql::Server::Root_password]'
+    )}
 
-        it { should contain_mysql_grant('testuser@localhost/*.*').with(
-            :privileges => ["SELECT", "RELOAD", "LOCK TABLES", "SHOW VIEW", "PROCESS"]
-        )}
+    it { should contain_mysql_grant('testuser@localhost/*.*').with(
+      :privileges => ["SELECT", "RELOAD", "LOCK TABLES", "SHOW VIEW", "PROCESS"]
+    )}
 
-        it { should contain_cron('mysql-backup').with(
-            :command => '/usr/local/sbin/mysqlbackup.sh',
-            :ensure  => 'present'
-        )}
+    it { should contain_cron('mysql-backup').with(
+      :command => '/usr/local/sbin/mysqlbackup.sh',
+      :ensure  => 'present'
+    )}
 
-        it { should contain_file('mysqlbackup.sh').with(
-            :path   => '/usr/local/sbin/mysqlbackup.sh',
-            :ensure => 'present'
-        ) }
+    it { should contain_file('mysqlbackup.sh').with(
+      :path   => '/usr/local/sbin/mysqlbackup.sh',
+      :ensure => 'present'
+    )}
 
-        it { should contain_file('mysqlbackupdir').with(
-            :path   => '/tmp',
-            :ensure => 'directory'
-        )}
+    it { should contain_file('mysqlbackupdir').with(
+      :path   => '/tmp',
+      :ensure => 'directory'
+    )}
 
-        it 'should have compression by default' do
-            verify_contents(subject, 'mysqlbackup.sh', [
-                            ' --all-databases | bzcat -zc > ${DIR}/${PREFIX}`date +%Y%m%d-%H%M%S`.sql.bz2',
-            ])
-        end
-        it 'should skip backing up events table by default' do
-            verify_contents(subject, 'mysqlbackup.sh', [
-                            'ADDITIONAL_OPTIONS="--ignore-table=mysql.event"',
-            ])
-        end
-
-        it 'should have 25 days of rotation' do
-            # MySQL counts from 0 I guess.
-            should contain_file('mysqlbackup.sh').with_content(/.*ROTATE=24.*/)
-        end
-
-        it 'should have a standard PATH' do
-            should contain_file('mysqlbackup.sh').with_content(%r{PATH=/usr/bin:/usr/sbin:/bin:/sbin:/opt/zimbra/bin})
-        end
-
-        # We should not include routines and triggers by default because the
-        # default has no named databases, and uses one file.
-        it 'should not include triggers or routines by default' do
-            should contain_file('mysqlbackup.sh').without_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --triggers".*/)
-            should contain_file('mysqlbackup.sh').without_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --routines".*/)
-        end
+    it 'should have compression by default' do
+      verify_contents(subject, 'mysqlbackup.sh', [
+                      ' --all-databases | bzcat -zc > ${DIR}/${PREFIX}`date +%Y%m%d-%H%M%S`.sql.bz2',
+      ])
     end
 
-    context 'custom ownership and mode for backupdir' do
-        let(:params) do
-            { :backupdirmode => '0750',
-                :backupdirowner => 'testuser',
-                :backupdirgroup => 'testgrp',
-            }.merge(default_params)
-        end
-
-        it { should contain_file('mysqlbackupdir').with(
-            :path => '/tmp',
-            :ensure => 'directory',
-            :mode => '0750',
-            :owner => 'testuser',
-            :group => 'testgrp'
-        ) }
+    it 'should skip backing up events table by default' do
+      verify_contents(subject, 'mysqlbackup.sh', [
+                      'ADDITIONAL_OPTIONS="--ignore-table=mysql.event"',
+      ])
     end
+
+    it 'should have 25 days of rotation' do
+      # MySQL counts from 0 I guess.
+      should contain_file('mysqlbackup.sh').with_content(/.*ROTATE=24.*/)
+    end
+
+    it 'should have a standard PATH' do
+      should contain_file('mysqlbackup.sh').with_content(%r{PATH=/usr/bin:/usr/sbin:/bin:/sbin:/opt/zimbra/bin})
+    end
+
+    # We should not include routines and triggers by default because the
+    # default has no named databases, and uses one file.
+    it 'should not include triggers or routines by default' do
+      should contain_file('mysqlbackup.sh').without_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --triggers".*/)
+      should contain_file('mysqlbackup.sh').without_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --routines".*/)
+    end
+  end
+
+  context 'custom ownership and mode for backupdir' do
+    let(:params) do
+      { :backupdirmode => '0750',
+        :backupdirowner => 'testuser',
+        :backupdirgroup => 'testgrp',
+       }.merge(default_params)
+    end
+
+    it { should contain_file('mysqlbackupdir').with(
+      :path => '/tmp',
+      :ensure => 'directory',
+      :mode => '0750',
+      :owner => 'testuser',
+      :group => 'testgrp'
+    )}
+  end
+
+  context 'with compression disabled' do
+    let(:params) do
+      { :backupcompress => false }.merge(default_params)
+    end
+
+    it { should contain_file('mysqlbackup.sh').with(
+      :path   => '/usr/local/sbin/mysqlbackup.sh',
+      :ensure => 'present'
+    )}
+
+    it 'should be able to disable compression' do
+      verify_contents(subject, 'mysqlbackup.sh', [
+                      ' --all-databases > ${DIR}/${PREFIX}`date +%Y%m%d-%H%M%S`.sql',
+      ])
+    end
+  end
+
+  context 'with mysql.events backedup' do
+    let(:params) do
+      { :ignore_events => false }.merge(default_params)
+    end
+
+    it { should contain_file('mysqlbackup.sh').with(
+      :path   => '/usr/local/sbin/mysqlbackup.sh',
+      :ensure => 'present'
+    )}
+
+    it 'should be able to backup events table' do
+      verify_contents(subject, 'mysqlbackup.sh', [
+                      'ADDITIONAL_OPTIONS="--events"',
+      ])
+    end
+  end
+
+  context 'with database list specified' do
+    let(:params) do
+      { :backupdatabases => ['mysql'] }.merge(default_params)
+    end
+
+    it { should contain_file('mysqlbackup.sh').with(
+      :path   => '/usr/local/sbin/mysqlbackup.sh',
+      :ensure => 'present'
+    )}
+
+    it 'should have a backup file for each database' do
+      content = subject.resource('file','mysqlbackup.sh').send(:parameters)[:content]
+      content.should match(' mysql | bzcat -zc \${DIR}\\\${PREFIX}mysql_`date')
+      #      verify_contents(subject, 'mysqlbackup.sh', [
+      #        ' mysql | bzcat -zc ${DIR}/${PREFIX}mysql_`date +%Y%m%d-%H%M%S`.sql',
+      #      ])
+    end
+
+    # Specifying a database list implies file per database.  This tests
+    # that the default value for routines and triggers is true.
+    it 'should include triggers and routines' do
+        should contain_file('mysqlbackup.sh').with_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --triggers".*/)
+        should contain_file('mysqlbackup.sh').with_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --routines".*/)
+    end
+
+  end
+
+  context 'with file per database' do
+    let(:params) do
+      default_params.merge({ :file_per_database => true })
+    end
+
+    it 'should loop through backup all databases' do
+      verify_contents(subject, 'mysqlbackup.sh', [
+                      'mysql -s -r -N -e \'SHOW DATABASES\' | while read dbname',
+                      'do',
+                      '  mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \\',
+                      '    ${ADDITIONAL_OPTIONS} \\',
+                      '    ${dbname} | bzcat -zc > ${DIR}/${PREFIX}${dbname}_`date +%Y%m%d-%H%M%S`.sql.bz2',
+                      'done',
+      ])
+    end
+
+    # Again, the default is true...
+    it 'should include triggers and routines' do
+      should contain_file('mysqlbackup.sh').with_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --triggers".*/)
+      should contain_file('mysqlbackup.sh').with_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --routines".*/)
+    end
+
 
     context 'with compression disabled' do
-        let(:params) do
-            { :backupcompress => false }.merge(default_params)
-        end
+      let(:params) do
+        default_params.merge({ :file_per_database => true, :backupcompress => false })
+      end
 
-        it { should contain_file('mysqlbackup.sh').with(
-            :path   => '/usr/local/sbin/mysqlbackup.sh',
-            :ensure => 'present'
-        ) }
+      it 'should loop through backup all databases without compression' do
+        verify_contents(subject, 'mysqlbackup.sh', [
+                        '    ${dbname} > ${DIR}/${PREFIX}${dbname}_`date +%Y%m%d-%H%M%S`.sql',
+        ])
+      end
+    end
+  end
 
-        it 'should be able to disable compression' do
-            verify_contents(subject, 'mysqlbackup.sh', [
-                            ' --all-databases > ${DIR}/${PREFIX}`date +%Y%m%d-%H%M%S`.sql',
-            ])
-        end
+  context 'with postscript' do
+    let(:params) do
+      default_params.merge({ :postscript => 'rsync -a /tmp backup01.local-lan:' })
     end
 
-    context 'with mysql.events backedup' do
-        let(:params) do
-            { :ignore_events => false }.merge(default_params)
-        end
+    it 'should be add postscript' do
+      verify_contents(subject, 'mysqlbackup.sh', [
+        'rsync -a /tmp backup01.local-lan:',
+      ])
+    end
+  end
 
-        it { should contain_file('mysqlbackup.sh').with(
-            :path   => '/usr/local/sbin/mysqlbackup.sh',
-            :ensure => 'present'
-        ) }
-
-        it 'should be able to backup events table' do
-            verify_contents(subject, 'mysqlbackup.sh', [
-                            'ADDITIONAL_OPTIONS="--events"',
-            ])
-        end
+  context 'with postscripts' do
+    let(:params) do
+      default_params.merge({ :postscript => [
+        'rsync -a /tmp backup01.local-lan:',
+        'rsync -a /tmp backup02.local-lan:',
+      ]})
     end
 
+    it 'should be add postscript' do
+      verify_contents(subject, 'mysqlbackup.sh', [
+        'rsync -a /tmp backup01.local-lan:',
+        'rsync -a /tmp backup02.local-lan:',
+      ])
+    end
+  end
 
-    context 'with database list specified' do
-        let(:params) do
-            { :backupdatabases => ['mysql'] }.merge(default_params)
-        end
-
-        it { should contain_file('mysqlbackup.sh').with(
-            :path   => '/usr/local/sbin/mysqlbackup.sh',
-            :ensure => 'present'
-        ) }
-
-        it 'should have a backup file for each database' do
-            content = subject.resource('file','mysqlbackup.sh').send(:parameters)[:content]
-            content.should match(' mysql | bzcat -zc \${DIR}\\\${PREFIX}mysql_`date')
-            #      verify_contents(subject, 'mysqlbackup.sh', [
-            #        ' mysql | bzcat -zc ${DIR}/${PREFIX}mysql_`date +%Y%m%d-%H%M%S`.sql',
-            #      ])
-        end
-
-        # Specifying a database list implies file per database.  This tests
-        # that the default value for routines and triggers is true.
-        it 'should include triggers and routines' do
-            should contain_file('mysqlbackup.sh').with_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --triggers".*/)
-            should contain_file('mysqlbackup.sh').with_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --routines".*/)
-        end
-
+  # Make sure we toggle routines with the right switch.
+  context 'with file_per_database and no routines' do
+    let(:params) do
+      { :file_per_database => true,
+        :include_triggers => true,
+        :include_routines => false,
+      }.merge(default_params)
     end
 
-    context 'with file per database' do
-        let(:params) do
-            default_params.merge({ :file_per_database => true })
-        end
-
-        it 'should loop through backup all databases' do
-            verify_contents(subject, 'mysqlbackup.sh', [
-                            'mysql -s -r -N -e \'SHOW DATABASES\' | while read dbname',
-                            'do',
-                            '  mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \\',
-                            '    ${ADDITIONAL_OPTIONS} \\',
-                            '    ${dbname} | bzcat -zc > ${DIR}/${PREFIX}${dbname}_`date +%Y%m%d-%H%M%S`.sql.bz2',
-                            'done',
-            ])
-        end
-
-        # Again, the default is true...
-        it 'should include triggers and routines' do
-            should contain_file('mysqlbackup.sh').with_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --triggers".*/)
-            should contain_file('mysqlbackup.sh').with_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --routines".*/)
-        end
-
-
-        context 'with compression disabled' do
-            let(:params) do
-                default_params.merge({ :file_per_database => true, :backupcompress => false })
-            end
-
-            it 'should loop through backup all databases without compression' do
-                verify_contents(subject, 'mysqlbackup.sh', [
-                                '    ${dbname} > ${DIR}/${PREFIX}${dbname}_`date +%Y%m%d-%H%M%S`.sql',
-                ])
-            end
-        end
+    it 'should include triggers' do
+      should contain_file('mysqlbackup.sh').with_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --triggers".*/)
     end
 
-		context 'with postscript' do
-			  let(:params) do
-				    default_params.merge({ :postscript => 'rsync -a /tmp backup01.local-lan:' })
-			  end
-
-			  it 'should be add postscript' do
-				    verify_contents(subject, 'mysqlbackup.sh', [
-					      'rsync -a /tmp backup01.local-lan:',
-				    ])
-			  end
-		end
-
-		context 'with postscripts' do
-			  let(:params) do
-				    default_params.merge({ :postscript => [
-					      'rsync -a /tmp backup01.local-lan:',
-					      'rsync -a /tmp backup02.local-lan:',
-				    ]})
-			  end
-
-			  it 'should be add postscript' do
-				    verify_contents(subject, 'mysqlbackup.sh', [
-					      'rsync -a /tmp backup01.local-lan:',
-					      'rsync -a /tmp backup02.local-lan:',
-				    ])
-			  end
+    it 'should not include routines' do
+      should contain_file('mysqlbackup.sh').without_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --routines".*/)
     end
 
-    # Make sure we toggle routines with the right switch.
-    context 'with file_per_database and no routines' do
-        let(:params) do
-            { :file_per_database => true,
-              :include_triggers => true,
-              :include_routines => false,
-            }.merge(default_params)
-        end
+  end
 
-        it 'should include triggers' do
-            should contain_file('mysqlbackup.sh').with_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --triggers".*/)
-        end
-
-        it 'should not include routines' do
-            should contain_file('mysqlbackup.sh').without_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --routines".*/)
-        end
-
+  # Make sure we toggle triggers with the right switch.
+  context 'with file_per_database and no routines' do
+    let(:params) do
+      { :file_per_database => true,
+        :include_triggers => false,
+        :include_routines => true,
+      }.merge(default_params)
     end
 
-    # Make sure we toggle triggers with the right switch.
-    context 'with file_per_database and no routines' do
-        let(:params) do
-            { :file_per_database => true,
-              :include_triggers => false,
-              :include_routines => true,
-            }.merge(default_params)
-        end
-
-        it 'should not include triggers' do
-            should contain_file('mysqlbackup.sh').without_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --triggers".*/)
-        end
-
-        it 'should include routines' do
-            should contain_file('mysqlbackup.sh').with_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --routines".*/)
-        end
+    it 'should not include triggers' do
+      should contain_file('mysqlbackup.sh').without_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --triggers".*/)
     end
 
-    # Specifying databases to backup implies file-per-database, but we should
-    # still exclude triggers and resources if we set those options to false.
-    context 'with database list and no triggers or routines' do
-        let(:params) do
-            { :backupdatabases => ['mysql'],
-              :include_triggers => false,
-              :include_routines => false,
-            }.merge(default_params)
-        end
-
-        it 'should not include triggers or routines' do
-            should contain_file('mysqlbackup.sh').without_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --triggers".*/)
-            should contain_file('mysqlbackup.sh').without_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --routines".*/)
-        end
+    it 'should include routines' do
+      should contain_file('mysqlbackup.sh').with_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --routines".*/)
     end
+  end
+
+  # Specifying databases to backup implies file-per-database, but we should
+  # still exclude triggers and resources if we set those options to false.
+  context 'with database list and no triggers or routines' do
+    let(:params) do
+      { :backupdatabases => ['mysql'],
+        :include_triggers => false,
+        :include_routines => false,
+      }.merge(default_params)
+    end
+
+    it 'should not include triggers or routines' do
+      should contain_file('mysqlbackup.sh').without_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --triggers".*/)
+      should contain_file('mysqlbackup.sh').without_content(/.*ADDITIONAL_OPTIONS="\$ADDITIONAL_OPTIONS --routines".*/)
+    end
+  end
 end

--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -17,10 +17,21 @@ ROTATE=<%= [ Integer(@backuprotate) - 1, 0 ].max %>
 
 PREFIX=mysql_backup_
 <% if @ignore_events %>
-EVENTS="--ignore-table=mysql.event"
+ADDITIONAL_OPTIONS="--ignore-table=mysql.event"
 <% else %>
-EVENTS="--events"
+ADDITIONAL_OPTIONS="--events"
 <% end %>
+<%# Only include routines or triggers if we're doing a file per database -%>
+<%# backup. This happens if we named databases, or if we explicitly set -%>
+<%# file per database mode -%>
+<% if !@backupdatabases.empty? || @file_per_database -%>
+<% if @include_triggers -%>
+ADDITIONAL_OPTIONS="$ADDITIONAL_OPTIONS --triggers"
+<% end -%>
+<% if @include_routines -%>
+ADDITIONAL_OPTIONS="$ADDITIONAL_OPTIONS --routines"
+<% end -%>
+<% end -%>
 
 ##### STOP CONFIG ####################################################
 PATH=<%= @execpath %>
@@ -43,18 +54,18 @@ cleanup
 mysql -s -r -N -e 'SHOW DATABASES' | while read dbname
 do
   mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \
-    ${EVENTS} \
+    ${ADDITIONAL_OPTIONS} \
     ${dbname} <% if @backupcompress %>| bzcat -zc <% end %>> ${DIR}/${PREFIX}${dbname}_`date +%Y%m%d-%H%M%S`.sql<% if @backupcompress %>.bz2<% end  %>
 done
 <% else -%>
 mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \
- ${EVENTS} \
+ ${ADDITIONAL_OPTIONS} \
  --all-databases <% if @backupcompress %>| bzcat -zc <% end %>> ${DIR}/${PREFIX}`date +%Y%m%d-%H%M%S`.sql<% if @backupcompress %>.bz2<% end  %>
 <% end -%>
 <% else -%>
 <% @backupdatabases.each do |db| -%>
 mysqldump -u${USER} -p${PASS} --opt --flush-logs --single-transaction \
-    ${EVENTS} \
+    ${ADDITIONAL_OPTIONS} \
  <%= db %><% if @backupcompress %>| bzcat -zc <% end %>> ${DIR}/${PREFIX}<%= db %>_`date +%Y%m%d-%H%M%S`.sql<% if @backupcompress %>.bz2<% end  %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
The mysqldump command issued by the module-generated mysqlbackup.sh script does not include triggers or routines when it does a file-per-database backup.  This means that if users try to restore a database using one of theses backup files, they will not be restoring the full structure of their database, just the data, which can leave users with broken applications due to missing routines.   I think that it is important to support triggers and routines in a backup, especially if users are only backing up selected database, in which case the triggers and routines will not get backed up anywhere else. 

To resolve this issue, I’ve added support for 2 new ```mysql::server::backup``` parameters (```mysql::backup``` is marked as deprecated, so I didn’t modify it) .  The first is called ```include_triggers``` and the second is called ```include_routines```.  When these parameters are true, the appropriate options are added to the mysqldump command.  These flags have no effect when we are doing a full backup to a single file, since the triggers and routines will be backed up with the information_schema.

The default value for both new options is true, reflecting my belief that omitting triggers and routines is an oversight and not a feature.  If you agree, this pull request is ready to go.

If, on the other hand, you feel that including triggers and routines should be an opt-in choice instead of default behavior, you’ll need to change the defaults in the module and fix some unit tests accordingly.

Either way, I think the ability to support the backup of triggers and routines in a file-per-database mode is important because it is the only way for users to generate a backup file for a single database that can be used to fully restore a single named database to its original state.
