### PR TITLE
mysql_database: prevent syntax error with collate=>'binary'

### DIFF
--- a/lib/puppet/provider/mysql_database/mysql.rb
+++ b/lib/puppet/provider/mysql_database/mysql.rb
@@ -31,7 +31,7 @@ Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::
   end
 
   def create
-    mysql([defaults_file, '-NBe', "create database if not exists `#{@resource[:name]}` character set #{@resource[:charset]} collate #{@resource[:collate]}"].compact)
+    mysql([defaults_file, '-NBe', "create database if not exists `#{@resource[:name]}` character set `#{@resource[:charset]}` collate `#{@resource[:collate]}`"].compact)
 
     @property_hash[:ensure]  = :present
     @property_hash[:charset] = @resource[:charset]

--- a/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
@@ -56,7 +56,7 @@ test
 
   describe 'create' do
     it 'makes a database' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "create database if not exists `#{resource[:name]}` character set #{resource[:charset]} collate #{resource[:collate]}"])
+      provider.expects(:mysql).with([defaults_file, '-NBe', "create database if not exists `#{resource[:name]}` character set `#{resource[:charset]}` collate `#{resource[:collate]}`"])
       provider.expects(:exists?).returns(true)
       expect(provider.create).to be_truthy
     end

--- a/tests/mysql_database.pp
+++ b/tests/mysql_database.pp
@@ -10,3 +10,8 @@ database{ 'test4':
   ensure  => present,
   charset => 'latin1',
 }
+database{ 'test5':
+  ensure  => present,
+  charset => 'binary',
+  collate => 'binary',
+}


### PR DESCRIPTION
On MySQL v5.5.38, creating a database such as:

```
CREATE DATABASE `mydb` CHARACTER SET binary COLLATE binary;
```

seems to hit a parser bug. A workaround is simply to quote COLLATE
`binary`. As the quoting is harmless, and for aesthetics, quote both
the CHARACTER SET and COLLATE arguments.
