### PR TITLE
Add OpenBSD support.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -251,6 +251,33 @@ class mysql::params {
       $daemon_dev_package_name     = undef
     }
 
+    'OpenBSD': {
+      $client_package_name = 'mariadb-client'
+      $server_package_name = 'mariadb-server'
+      $basedir             = '/usr/local'
+      $config_file         = '/etc/my.cnf'
+      $includedir          = undef
+      $datadir             = '/var/mysql'
+      $log_error           = "/var/mysql/${::hostname}.err"
+      $pidfile             = '/var/mysql/mysql.pid'
+      $root_group          = 'wheel'
+      $server_service_name = 'mysqld'
+      $socket              = '/var/run/mysql/mysql.sock'
+      $ssl_ca              = undef
+      $ssl_cert            = undef
+      $ssl_key             = undef
+      $tmpdir              = '/tmp'
+      # mysql::bindings
+      $java_package_name   = undef
+      $perl_package_name   = 'p5-DBD-mysql'
+      $php_package_name    = 'php-mysql'
+      $python_package_name = 'py-mysql'
+      $ruby_package_name   = 'ruby-mysql'
+      # The libraries installed by these packages are included in client and server packages, no installation required.
+      $client_dev_package_name     = undef
+      $daemon_dev_package_name     = undef
+    }
+
     default: {
       case $::operatingsystem {
         'Amazon': {

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -10,10 +10,16 @@ class mysql::server::service {
     }
   }
 
+  if $mysql::server::override_options['mysqld'] and $mysql::server::override_options['mysqld']['user'] {
+    $mysqluser = $mysql::server::override_options['mysqld']['user']
+  } else {
+    $mysqluser = $options['mysqld']['user']
+  }
+
   file { $options['mysqld']['log-error']:
     ensure => present,
-    owner  => 'mysql',
-    group  => 'mysql',
+    owner  => $mysqluser,
+    group  => $::mysql::server::root_group,
   }
 
   service { 'mysqld':


### PR DESCRIPTION
This is a first step in OpenBSD support, tested with mysql-server-5.1.73p0v0 package on OpenBSD 5.6-current, using the following configuration stored in hiera.
```yaml
mysql::server::root_password: topsecret
mysql::server::manage_config_file: true
mysql::server::purge_conf_dir: true
mysql::server::package_ensure: present
mysql::server::service_enabled: true
mysql::server::remove_default_accounts: true
mysql::server::users:
  'dashboard@localhost':
    ensure: present
    max_connections_per_hour: 0
    max_queries_per_hour: 0
    max_updates_per_hour: 0
    max_user_connections: 0
    password_hash: '*TOPSECRETTOPSECRETTOPSECRET'
mysql::server::grants:
  'dashboard@localhost/dashboard_production.*':
    ensure: present
    options:
      - GRANT
    privileges:
      - ALL
    table: 'dashboard_production.*'
    user: dashboard@localhost
mysql::server::databases:
  dashboard_production:
    ensure: present
    charset: utf8
mysql::server::override_options:
  mysqld:
    user: _mysql
    datadir: /var/mysql
```

The odds are that I have to use the mysql::server::override_options :(
Fixing that, is for another diff, in order to keep this one clean and easier to review.

The change to server/service.pp is because there is no 'mysql' user and group, but _mysql user and _mysql group.
Another solution would be to add a $mysqlgroup variable to mysql::params list and use that. 
However, the $mysql::params::log_error file is owned by _mysql:_mysql on my OpenBSD system instead of the root_group.

This is only a first step, that allowed me to create a database. 
 - Further steps I'd look into would be:
   * get rid of the currently required usage of override_options
   * introduce a $mysqluser and $mysqlgroup to params.pp and use those throughout the classes
   * in other places, i.e. the backup config, there the group root is hardcoded, but on OpenBSD there is no group root, but wheel, so use the $root_group there