### PR TITLE
future parser converts explicit undef to empty string

### DIFF
--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -10,7 +10,7 @@
 <%         vi.each do |vii| -%>
 <%=          ki %> = <%= vii %>
 <%         end -%>
-<%       elsif vi != :undef -%>
+<%       elsif ![nil, '', :undef].include?(vi) -%>
 <%=        ki %> = <%= vi %>
 <%       end -%>
 <%     end -%>


### PR DESCRIPTION
With the future parser and puppet 4, explicit undef seems to be converted to blank string for erb templates
This change allows you to continue to omit config options in the main my.cnf
