### PR TITLE
[MODULES-1333] Add explicit dependencies for mysql_database and mysql_user types

### DIFF
--- a/lib/puppet/type/mysql_database.rb
+++ b/lib/puppet/type/mysql_database.rb
@@ -3,6 +3,8 @@ Puppet::Type.newtype(:mysql_database) do
 
   ensurable
 
+  autorequire(:file) { '/root/.my.cnf' }
+
   newparam(:name, :namevar => true) do
     desc 'The name of the MySQL database to manage.'
   end

--- a/lib/puppet/type/mysql_user.rb
+++ b/lib/puppet/type/mysql_user.rb
@@ -4,6 +4,8 @@ Puppet::Type.newtype(:mysql_user) do
 
   ensurable
 
+  autorequire(:file) { '/root/.my.cnf' }
+
   newparam(:name, :namevar => true) do
     desc "The name of the user. This uses the 'username@hostname' or username@hostname."
     validate do |value|


### PR DESCRIPTION
Add an autorequire() dependency on /root/.my.cnf to the mysql_database and mysql_user types.
