### PR TITLE
(MODULES-1338) Allow mysql::db to import several files

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -2,20 +2,21 @@
 define mysql::db (
   $user,
   $password,
-  $dbname      = $name,
-  $charset     = 'utf8',
-  $collate     = 'utf8_general_ci',
-  $host        = 'localhost',
-  $grant       = 'ALL',
-  $sql         = undef,
-  $enforce_sql = false,
-  $ensure      = 'present',
+  $dbname         = $name,
+  $charset        = 'utf8',
+  $collate        = 'utf8_general_ci',
+  $host           = 'localhost',
+  $grant          = 'ALL',
+  $sql            = undef,
+  $enforce_sql    = false,
+  $ensure         = 'present',
   $import_timeout = 300,
 ) {
   #input validation
   validate_re($ensure, '^(present|absent)$',
   "${ensure} is not supported for ensure. Allowed values are 'present' and 'absent'.")
   $table = "${dbname}.*"
+  $sql_inputs = join(any2array($sql), ' ')
 
   include '::mysql::client'
 
@@ -49,10 +50,11 @@ define mysql::db (
 
     if $sql {
       exec{ "${dbname}-import":
-        command     => "/usr/bin/mysql ${dbname} < ${sql}",
+        command     => "cat ${sql_inputs} | mysql ${dbname}",
         logoutput   => true,
         environment => "HOME=${::root_home}",
         refreshonly => $refresh,
+        path        => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin',
         require     => Mysql_grant["${user}@${host}/${table}"],
         subscribe   => Mysql_database[$dbname],
         timeout     => $import_timeout,

--- a/spec/defines/mysql_db_spec.rb
+++ b/spec/defines/mysql_db_spec.rb
@@ -35,6 +35,11 @@ describe 'mysql::db', :type => :define do
     is_expected.to contain_exec('test_db-import').with_refreshonly(false)
   end
 
+  it 'should import sql scripts when more than one is specified' do
+    params.merge!({'sql' => ['test_sql', 'test_2_sql']})
+    is_expected.to contain_exec('test_db-import').with_command('cat test_sql test_2_sql | mysql test_db')
+  end
+
   it 'should not create database and database user' do
     params.merge!({'ensure' => 'absent', 'host' => 'localhost'})
     is_expected.to contain_mysql_database('test_db').with_ensure('absent')


### PR DESCRIPTION
A user might need to import several files on database creation.
Currently the module only allows the import of a single file.
This commit allows one to, from now on, import severals.

Before :

``` puppet
  mysql::db { 'test' :
    sql => '/tmp/my_import1.sql',
  }
```

Now :

``` puppet
  mysql::db { 'test' :
    sql => [
      '/tmp/my_import1.sql',
      '/tmp/my_import2.sql',
    ]
  }
```
