### PR TITLE
Change sql param to default to undef instead of empty string

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -7,7 +7,7 @@ define mysql::db (
   $collate     = 'utf8_general_ci',
   $host        = 'localhost',
   $grant       = 'ALL',
-  $sql         = '',
+  $sql         = undef,
   $enforce_sql = false,
   $ensure      = 'present'
 ) {


### PR DESCRIPTION
The future parser treats the empty string '' as a truthy value. This
means that mysql::db will always try to include the db import exec in
the catalog. With the empty string as the $sql value, the command
attempts to import '' into a database, which fails. This patch changes
the default $sql value to undef so that the exec won't be included if
there is no sql to import.
