### PR TITLE
Add new parameters create_root_user and create_root_my_cnf.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,28 @@ To add custom MySQL configuration, drop additional files into
 
 ####mysql::server
 
+#####`create_root_user`
+
+Specify whether root user should be created or not. Defaults to 'true'.
+
+This is useful for a cluster setup with Galera. The root user has to
+be created once only. `create_root_user` can be set to 'true' on one node while
+it is set to 'false' on the remaining nodes.
+
+#####`create_root_my_cnf`
+
+If set to 'true' create `/root/.my.cnf`. Defaults to 'true'.
+
+`create_root_my_cnf` allows to create `/root/.my.cnf` independently of `create_root_user`.
+This can be used for a cluster setup with Galera where you want to have `/root/.my.cnf`
+on all nodes.
+
 #####`root_password`
 
 The MySQL root password.  Puppet will attempt to set the root password and update `/root/.my.cnf` with it.
+
+Has to be set if `create_root_user` or `create_root_my_cnf` are true. If `root_password` is 'UNSET' `create_root_user`
+and `create_root_my_cnf` are assumed to be false, i.e. the MySQL root user and `/root/.my.cnf` are not created.
 
 #####`old_root_password`
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,8 @@ class mysql::params {
   $server_service_manage  = true
   $server_service_enabled = true
   $client_package_ensure  = 'present'
+  $create_root_user       = true
+  $create_root_my_cnf     = true
   # mysql::bindings
   $bindings_enable             = false
   $java_package_ensure         = 'present'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -16,6 +16,8 @@ class mysql::server (
   $service_manage          = $mysql::params::server_service_manage,
   $service_name            = $mysql::params::server_service_name,
   $service_provider        = $mysql::params::server_service_provider,
+  $create_root_user        = $mysql::params::create_root_user,
+  $create_root_my_cnf      = $mysql::params::create_root_my_cnf,
   $users                   = {},
   $grants                  = {},
   $databases               = {},

--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -4,12 +4,14 @@ class mysql::server::root_password {
   $options = $mysql::server::options
 
   # manage root password if it is set
-  if $mysql::server::root_password != 'UNSET' {
+  if $mysql::server::create_root_user == true and $mysql::server::root_password != 'UNSET' {
     mysql_user { 'root@localhost':
       ensure        => present,
       password_hash => mysql_password($mysql::server::root_password),
     }
+  }
 
+  if $mysql::server::create_root_my_cnf == true and $mysql::server::root_password != 'UNSET' {
     file { "${::root_home}/.my.cnf":
       content => template('mysql/my.cnf.pass.erb'),
       owner   => 'root',

--- a/spec/classes/mysql_server_spec.rb
+++ b/spec/classes/mysql_server_spec.rb
@@ -52,10 +52,25 @@ describe 'mysql::server' do
             it { is_expected.not_to contain_mysql_user('root@localhost') }
             it { is_expected.not_to contain_file('/root/.my.cnf') }
           end
-          describe 'when set' do
+          describe 'when root_password set' do
             let(:params) {{:root_password => 'SET' }}
             it { is_expected.to contain_mysql_user('root@localhost') }
             it { is_expected.to contain_file('/root/.my.cnf') }
+          end
+          describe 'when root_password set, create_root_user set to false' do
+            let(:params) {{ :root_password => 'SET', :create_root_user => false }}
+            it { is_expected.not_to contain_mysql_user('root@localhost') }
+            it { is_expected.to contain_file('/root/.my.cnf') }
+          end
+          describe 'when root_password set, create_root_my_cnf set to false' do
+            let(:params) {{ :root_password => 'SET', :create_root_my_cnf => false }}
+            it { is_expected.to contain_mysql_user('root@localhost') }
+            it { is_expected.not_to contain_file('/root/.my.cnf') }
+          end
+          describe 'when root_password set, create_root_user and create_root_my_cnf set to false' do
+            let(:params) {{ :root_password => 'SET', :create_root_user => false, :create_root_my_cnf => false }}
+            it { is_expected.not_to contain_mysql_user('root@localhost') }
+            it { is_expected.not_to contain_file('/root/.my.cnf') }
           end
         end
 


### PR DESCRIPTION
This allows the galera module and others to write ${::root_home}/.my.cnf
independently from create the mysql user. This is useful for cluster
setups where you want to create ${::root_home}/.my.cnf on every node
but create the user only once.