### PR TITLE
Ensure error log is present before trying to manage ownership

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -10,8 +10,9 @@ class mysql::server::service {
   }
 
   file { $mysql::params::log_error:
-    owner => 'mysql',
-    group => 'mysql',
+    ensure => present,
+    owner  => 'mysql',
+    group  => 'mysql',
   }
 
   service { 'mysqld':


### PR DESCRIPTION
If mysql generates an error log in between puppet runs, the log's
ownership and group might not match the ownership and group set by the
file resource. This means sequential puppet runs will appear not to be
idempotent. This patch makes sure the file is there from the start so
that it doesn't have to change its ownership later.
