### PR TITLE
Install bzip2 on RHEL 7 and Fedora hosts

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -30,6 +30,9 @@ RSpec.configure do |c|
       if fact('osfamily') == 'RedHat'
         version = fact("operatingsystemmajrelease")
         shell("yum localinstall -y http://yum.puppetlabs.com/puppetlabs-release-el-#{version}.noarch.rpm")
+        if fact('operatingsystemmajrelease') =~ /7/ || fact('operatingsystem') =~ /Fedora/
+          shell("yum install -y bzip2")
+        end
       end
 
       shell("/bin/touch #{default['puppetpath']}/hiera.yaml")


### PR DESCRIPTION
The backup script needs the bzcat command, which does not come
installed on RHEL 7 and Fedora hosts by default. This patch installs
the bzip2 package before attempting to run tests that use bzcat.
