### PR TITLE
(MODULES-1685) permit use of mysql::db without mysql::server

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,21 @@ replicate-do-db = base2
 To add custom MySQL configuration, drop additional files into
 `/etc/mysql/conf.d/`. Dropping files into conf.d allows you to override settings or add additional ones, which is helpful if you choose not to use `override_options` in `mysql::server`. The conf.d location is hardcoded into the my.cnf template file.
 
+###Working with an existing server
+
+It is possible to use the MySQL module to instantiate databases and
+users on an existing MySQL server.  For this to work, you will need an
+appropriate `.my.cnf` in `root`'s home directory containing the remote
+server address and credentials.  For example:
+
+    [client]
+    user=root
+    host=localhost
+    password=secret
+
+When working with a remote server, you will *not* use the
+`mysql::server` class in your Puppet manifests.
+
 ##Reference
 
 ###Classes

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -23,7 +23,7 @@ define mysql::db (
     charset  => $charset,
     collate  => $collate,
     provider => 'mysql',
-    require  => [ Class['mysql::server'], Class['mysql::client'] ],
+    require  => [ Class['mysql::client'] ],
   }
   ensure_resource('mysql_database', $dbname, $db_resource)
 
@@ -31,7 +31,6 @@ define mysql::db (
     ensure        => $ensure,
     password_hash => mysql_password($password),
     provider      => 'mysql',
-    require       => Class['mysql::server'],
   }
   ensure_resource('mysql_user', "${user}@${host}", $user_resource)
 
@@ -41,7 +40,10 @@ define mysql::db (
       provider   => 'mysql',
       user       => "${user}@${host}",
       table      => $table,
-      require    => [Mysql_database[$dbname], Mysql_user["${user}@${host}"], Class['mysql::server'] ],
+      require    => [
+        Mysql_database[$dbname],
+        Mysql_user["${user}@${host}"],
+      ],
     }
 
     $refresh = ! $enforce_sql

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -78,5 +78,8 @@ class mysql::server (
     Anchor['mysql::server::end']
   }
 
-
+Class['mysql::server'] -> Mysql_database <||>
+Class['mysql::server'] -> Mysql_user <||>
 }
+
+


### PR DESCRIPTION
This removes the hard dependencies on mysql::server from manifests/db.pp.  This permits one to use this module to manage databases in an existing server, possibly located on a remote host (with a properly configured /root/.my.cnf).

The dependencies are instead placed in mysql/server.pp and are implemented using collectors, so that the dependencies are only created if `mysql::server` is realized.