### PR TITLE
The old regex requires something after the 'host' part. Fix this.

### DIFF
--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
         # Match the munges we do in the type.
         munged_grant = grant.delete("'").delete("`")
         # Matching: GRANT (SELECT, UPDATE) PRIVILEGES ON (*.*) TO ('root')@('127.0.0.1') (WITH GRANT OPTION)
-        if match = munged_grant.match(/^GRANT\s(.+)\sON\s(.+)\sTO\s(.*)@(.*?)(\s.*)$/)
+        if match = munged_grant.match(/^GRANT\s(.+)\sON\s(.+)\sTO\s(.*)@(.*?)(\s.*)?$/)
           privileges, table, user, host, rest = match.captures
           # split on ',' if it is not a non-'('-containing string followed by a
           # closing parenthesis ')'-char - e.g. only split comma separated elements not in


### PR DESCRIPTION
Old regex is : `/^GRANT\s(.+)\sON\s(.+)\sTO\s(.*)@(.*?)(\s.*)$/` . The
last part `(\s.*)$` means "a space followed by anything". The issue is
that when user has no `GRANT` privileges, the `"SHOW GRANTS FOR #{user_string}"` returns

``` sql
GRANT SELECT ON `database`.* TO 'user'@'%'
```

which does not match `(\s.*)$` .
This small patch fixes this making last block optional (thanks to `?`).
