### PR TITLE
Improve checks for MySQL user's name.

### DIFF
--- a/lib/puppet/type/mysql_user.rb
+++ b/lib/puppet/type/mysql_user.rb
@@ -9,9 +9,13 @@ Puppet::Type.newtype(:mysql_user) do
   newparam(:name, :namevar => true) do
     desc "The name of the user. This uses the 'username@hostname' or username@hostname."
     validate do |value|
-      # https://dev.mysql.com/doc/refman/5.1/en/account-names.html
+      # http://dev.mysql.com/doc/refman/5.5/en/identifiers.html
       # Regex should problably be more like this: /^[`'"]?[^`'"]*[`'"]?@[`'"]?[\w%\.]+[`'"]?$/
-      raise(ArgumentError, "Invalid database user #{value}") unless value =~ /[\w-]*@[\w%\.:]+/
+      # If at least one special char is used, string must be quoted
+      raise(ArgumentError, "Database user #{value} must be quotted as it contains special characters") if value =~ /^[^'`"].*[^0-9a-zA-Z$_].*[^'`"]@[\w%\.:]+/
+      # If no special char, quoted is not needed, but allowed
+      # I don't see any case where this could happen, as it should be covered by previous check
+      raise(ArgumentError, "Invalid database user #{value}") unless value =~ /^['`"]?[0-9a-zA-Z$_]*['`"]?@[\w%\.:]+/
       username = value.split('@')[0]
       if username.size > 16
         raise ArgumentError, 'MySQL usernames are limited to a maximum of 16 characters'

--- a/spec/unit/puppet/type/mysql_user_spec.rb
+++ b/spec/unit/puppet/type/mysql_user_spec.rb
@@ -37,6 +37,23 @@ describe Puppet::Type.type(:mysql_user) do
     it 'should lowercase the user name' do
       expect(@user[:name]).to eq('foo@localhost')
     end
+  end
 
+  context 'using allo_wed$char@localhost' do
+    before :each do
+      @user = Puppet::Type.type(:mysql_user).new(:name => 'allo_wed$char@localhost', :password_hash => 'pass')
+    end
+
+    it 'should accept a user name' do
+      expect(@user[:name]).to eq('allo_wed$char@localhost')
+    end
+  end
+
+  context 'using in-valid@localhost' do
+    it 'should fail with an unquotted username with special char' do
+      expect {
+        Puppet::Type.type(:mysql_user).new(:name => 'in-valid@localhost', :password_hash => 'pass')
+      }.to raise_error /Database user in-valid@localhost must be quotted/
+    end
   end
 end


### PR DESCRIPTION
As per http://dev.mysql.com/doc/refman/5.5/en/identifiers.html , MySQL
allows for more than '\w-'. This commit improves the check to ensure
that:
- if username only contains [0-9a-zA-Z$_], it might be quoted. It is
  not a requirement though
- if username contains anything else, it MUST be quoted

I kept 2 checks, but the 2nd one can probably be removed (I can't find a
username which match the 2nd one but not the first.)
