### PR TITLE
fix dealing with empty passwords

### DIFF
--- a/lib/puppet/provider/mysql_user/mysql.rb
+++ b/lib/puppet/provider/mysql_user/mysql.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:mysql_user).provide(:mysql, :parent => Puppet::Provider::Mysq
 
       new(:name                     => name,
           :ensure                   => :present,
-          :password_hash            => @password,
+          :password_hash            => @password.to_s,
           :max_user_connections     => @max_user_connections,
           :max_connections_per_hour => @max_connections_per_hour,
           :max_queries_per_hour     => @max_queries_per_hour,

--- a/lib/puppet/type/mysql_user.rb
+++ b/lib/puppet/type/mysql_user.rb
@@ -26,7 +26,7 @@ Puppet::Type.newtype(:mysql_user) do
 
   newproperty(:password_hash) do
     desc 'The password hash of the user. Use mysql_password() for creating such a hash.'
-    newvalue(/\w+/)
+    newvalue(/\w*/)
   end
 
   newproperty(:max_user_connections) do

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -34,7 +34,7 @@ define mysql::db (
   }
   $user_resource = {
     ensure        => $ensure,
-    password_hash => mysql_password($password_hash),
+    password_hash => $password_hash,
     provider      => 'mysql',
     require       => Class['mysql::server'],
   }

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -28,9 +28,13 @@ define mysql::db (
   }
   ensure_resource('mysql_database', $dbname, $db_resource)
 
+  case empty($password) {
+    true  : { $password_hash = '' }
+    false : { $password_hash = mysql_password($password) }
+  }
   $user_resource = {
     ensure        => $ensure,
-    password_hash => mysql_password($password),
+    password_hash => mysql_password($password_hash),
     provider      => 'mysql',
     require       => Class['mysql::server'],
   }

--- a/spec/acceptance/mysql_db_spec.rb
+++ b/spec/acceptance/mysql_db_spec.rb
@@ -68,4 +68,28 @@ describe 'mysql::db define' do
       expect(shell("mysql -e 'show databases;'|grep realdb").exit_code).to be_zero
     end
   end
+
+  describe 'creating a database with empty user password' do
+    # Using puppet_apply as a helper
+    it 'should work with no errors' do
+      pp = <<-EOS
+        class { 'mysql::server': override_options => { 'root_password' => 'password' } }
+        mysql::db { 'spec3':
+          user     => 'root3',
+          password => '',
+        }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    it 'should have an empty password' do
+      shell("mysql -NBe \"show grants for root3@localhost\"") do |r|
+        expect(r.stdout).not_to match(/IDENTIFIED BY/)
+        expect(r.stderr).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
Empty passwords ("") are passed to mysql_password("") which results in
hash: *BE1BDEC0AA74B4DCB079943E70528096CCA985F8

Expected value for password is NULL