### PR TITLE
make user and table parameter of mysql_grant() optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,6 @@ grants => {
     ensure     => 'present',
     options    => ['GRANT'],
     privileges => ['SELECT', 'INSERT', 'UPDATE', 'DELETE'],
-    table      => 'somedb.*',
-    user       => 'someuser@localhost',
   },
 }
 ```
@@ -523,8 +521,6 @@ mysql_grant { 'root@localhost/*.*':
   ensure     => 'present',
   options    => ['GRANT'],
   privileges => ['ALL'],
-  table      => '*.*',
-  user       => 'root@localhost',
 }
 ```
 
@@ -533,9 +529,18 @@ It is possible to specify privileges down to the column level:
 mysql_grant { 'root@localhost/mysql.user':
   ensure     => 'present',
   privileges => ['SELECT (Host, User)'],
-  table      => 'mysql.user',
-  user       => 'root@localhost',
 }
+```
+
+It is possible to specify multiple privileges by passing an 
+array to the ensure_resource function:
+```puppet
+$user_grant = {
+  ensure     => 'present',
+  options    => ['GRANT'],
+  privileges => ['ALL'],
+}
+ensure_resource('mysql_grant', ['a@localhost/*.*', 'b@localhost/*.*'], $user_grant)
 ```
 
 ##Limitations
@@ -575,4 +580,3 @@ This module is based on work by David Schmitt. The following contributors have c
 * William Van Hevelingen
 * Michael Arnold
 * Chris Weyl
-

--- a/lib/puppet/type/mysql_grant.rb
+++ b/lib/puppet/type/mysql_grant.rb
@@ -49,7 +49,7 @@ Puppet::Type.newtype(:mysql_grant) do
 
   newproperty(:table) do
     desc 'Table to apply privileges to.'
-
+    defaultto { @resource[:name].match("/").post_match }
     munge do |value|
       value.delete("`")
     end
@@ -59,6 +59,7 @@ Puppet::Type.newtype(:mysql_grant) do
 
   newproperty(:user) do
     desc 'User to operate on.'
+    defaultto { @resource[:name].match("/").pre_match }
     validate do |value|
       # https://dev.mysql.com/doc/refman/5.1/en/account-names.html
       # Regex should problably be more like this: /^[`'"]?[^`'"]*[`'"]?@[`'"]?[\w%\.]+[`'"]?$/

--- a/spec/acceptance/types/mysql_grant_spec.rb
+++ b/spec/acceptance/types/mysql_grant_spec.rb
@@ -31,7 +31,7 @@ describe 'mysql_grant' do
   end
 
   describe 'missing table for user' do
-    it 'should fail' do
+    it 'should work without errors' do
       pp = <<-EOS
         mysql_grant { 'atest@tester/test.*':
           ensure => 'present',
@@ -40,11 +40,11 @@ describe 'mysql_grant' do
         }
       EOS
 
-      apply_manifest(pp, :expect_failures => true)
+      apply_manifest(pp, :expect_failures => false)
     end
 
-    it 'should not find the user' do
-      expect(shell("mysql -NBe \"SHOW GRANTS FOR atest@tester\"", {:acceptable_exit_codes => 1}).stderr).to match(/There is no such grant defined for user 'atest' on host 'tester'/)
+    it 'should find the user' do
+      shell("mysql -NBe \"SHOW GRANTS FOR atest@tester\"", {:acceptable_exit_codes => 0})
     end
   end
 
@@ -109,7 +109,7 @@ describe 'mysql_grant' do
   end
 
   describe 'adding all privileges without table' do
-    it 'should fail' do
+    it 'should work without errors' do
       pp = <<-EOS
         mysql_grant { 'test4@tester/test.*':
           ensure     => 'present',
@@ -119,7 +119,7 @@ describe 'mysql_grant' do
         }
       EOS
 
-      expect(apply_manifest(pp, :expect_failures => true).stderr).to match(/table parameter is required./)
+      apply_manifest(pp, :expect_failures => false)
     end
   end
 


### PR DESCRIPTION
Because name must match user and table parameters,
extract user and table defaults from name.

Struggled on this while trying to grant several users once using ensure_resource.

This will now work:

    $user_grant = {
      privileges => [ ... ],
      provider   => 'mysql',
    }
    $users = [ 'me@localhost/table.*', 'me@10.10.%/table.*' ]
    ensure_resource('mysql_grant', $users, $user_grant)