### PR TITLE
Fix escaped backslashes in grants

### DIFF
--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -29,6 +29,8 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
         # Matching: GRANT (SELECT, UPDATE) PRIVILEGES ON (*.*) TO ('root')@('127.0.0.1') (WITH GRANT OPTION)
         if match = munged_grant.match(/^GRANT\s(.+)\sON\s(.+)\sTO\s(.*)@(.*?)(\s.*)?$/)
           privileges, table, user, host, rest = match.captures
+          table.gsub!('\\\\', '\\')
+
           # split on ',' if it is not a non-'('-containing string followed by a
           # closing parenthesis ')'-char - e.g. only split comma separated elements not in
           # parentheses


### PR DESCRIPTION
- Mysql uses the underscore character to represent a single character
  wildcard.
- A grant on table `the_database`.\* would match `theAdatabase`.*, so
  underscores must be escaped to avoid this match.
- The output from mysql escapes special characters (\n, \t, \0, and \),
  but the input does not need to be escaped.
- In order for the provider to compare the tables, the output of
  mysql -NBe <query> must have \ substituted with .
