### PR TITLE
Create log-bin directory if it doesn't exist

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -18,6 +18,18 @@ class mysql::server::config {
       purge   => $mysql::server::purge_conf_dir,
     }
   }
+  
+  $logbin = pick($options['mysqld']['log-bin'], $options['mysqld']['log_bin'], false)
+  
+  if $logbin {
+    $logbindir = dirname($logbin)
+    file { "$logbindir":
+      ensure  => directory,
+      mode    => '0755',
+      owner   => $options['mysqld']['user'],
+      group   => $options['mysqld']['user'],
+    }
+  }
 
   if $mysql::server::manage_config_file  {
     file { 'mysql-config-file':


### PR DESCRIPTION
It seems the MySQL doesn't like it when you use a log-bin directory that doesn't exist. If you add this before the mysql package is installed then it will fail (if the mysql user doesn't exist). If you add the directory after you run the mysql::server class then mysql will fail to start the first time, it will only be resolved on a subsequent puppet run.
