### PR TITLE
Prior to this there was generic :test group.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,16 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-group :development, :test do
+group :development, :unit_tests do
   gem 'rake',                    :require => false
   gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
-  gem 'serverspec',              :require => false
   gem 'puppet-lint',             :require => false
-  gem 'beaker-rspec',            :require => false
   gem 'puppet_facts',            :require => false
+end
+
+group :system_tests do
+  gem 'beaker-rspec',            :require => false
+  gem 'serverspec',              :require => false
 end
 
 if facterversion = ENV['FACTER_GEM_VERSION']


### PR DESCRIPTION
Unfortunately Beaker will be EOL-ing support for Ruby 1.8 (a number of
Beaker's dependencies already have and pinning to older versions is
becoming costly). Once Beaker does this it will cause failures whenever
running `bundle install`.

To avoid this failure we can segregate the system testing gems, allowing
unit, lint and development to continue with
`bundle install --without system_tests.`
