### PR TITLE
Fix regression in username validation

### DIFF
--- a/lib/puppet/type/mysql_user.rb
+++ b/lib/puppet/type/mysql_user.rb
@@ -13,9 +13,7 @@ Puppet::Type.newtype(:mysql_user) do
       # Regex should problably be more like this: /^[`'"]?[^`'"]*[`'"]?@[`'"]?[\w%\.]+[`'"]?$/
       # If at least one special char is used, string must be quoted
       raise(ArgumentError, "Database user #{value} must be quotted as it contains special characters") if value =~ /^[^'`"].*[^0-9a-zA-Z$_].*[^'`"]@[\w%\.:]+/
-      # If no special char, quoted is not needed, but allowed
-      # I don't see any case where this could happen, as it should be covered by previous check
-      raise(ArgumentError, "Invalid database user #{value}") unless value =~ /^['`"]?[0-9a-zA-Z$_]*['`"]?@[\w%\.:]+/
+      raise(ArgumentError, "Invalid database user #{value}") unless value =~ /^(?:['`"][^'`"]*['`"]|[0-9a-zA-Z$_]*)@[\w%\.:]+/
       username = value.split('@')[0]
       if username.size > 16
         raise ArgumentError, 'MySQL usernames are limited to a maximum of 16 characters'

--- a/spec/unit/puppet/type/mysql_user_spec.rb
+++ b/spec/unit/puppet/type/mysql_user_spec.rb
@@ -49,6 +49,16 @@ describe Puppet::Type.type(:mysql_user) do
     end
   end
 
+  context 'using `speci!al#`@localhost' do
+    before :each do
+      @user = Puppet::Type.type(:mysql_user).new(:name => '`speci!al#`@localhost', :password_hash => 'pass')
+    end
+
+    it 'should accept a quoted user name with special chatracters' do
+      expect(@user[:name]).to eq('`speci!al#`@localhost')
+    end
+  end
+
   context 'using in-valid@localhost' do
     it 'should fail with an unquotted username with special char' do
       expect {


### PR DESCRIPTION
Commit cdd7132ff9c3a8ac63621899f1e82bdd0ec58974 added logic to catch invalid database usernames,
but the regex it uses fails to match usernames with special characters that are properly quoted,
causing errors with usernames that used to work in versions < 3.0.0. This fixes the regex so that
if the username is quoted, anything is allowed between the quotes.

From the docs (http://dev.mysql.com/doc/refman/5.5/en/identifiers.html):
"Permitted characters in quoted identifiers include the full Unicode Basic Multilingual Plane (BMP),
except U+0000"
