### PR TITLE
Proper containment for mysql::client in mysql::db

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -25,6 +25,10 @@ define mysql::db (
 
   include '::mysql::client'
 
+  anchor{"mysql::db_${name}::begin": }->
+  Class['::mysql::client']->
+  anchor{"mysql::db_${name}::end": }
+
   $db_resource = {
     ensure   => $ensure,
     charset  => $charset,


### PR DESCRIPTION
This is to ensure that mysql::client is not floating around.

I had a problem where the installation of mysql-client package was failing because the apt-get update that was suppose to come first in one of my role was not yet executed.
Adding the anchor and the Class reference, fixed the issue.
