### PR TITLE
Support size 15 and 16 quoted usernames

### DIFF
--- a/lib/puppet/type/mysql_user.rb
+++ b/lib/puppet/type/mysql_user.rb
@@ -15,7 +15,7 @@ Puppet::Type.newtype(:mysql_user) do
       raise(ArgumentError, "Database user #{value} must be quotted as it contains special characters") if value =~ /^[^'`"].*[^0-9a-zA-Z$_].*[^'`"]@[\w%\.:]+/
       raise(ArgumentError, "Invalid database user #{value}") unless value =~ /^(?:['`"][^'`"]*['`"]|[0-9a-zA-Z$_]*)@[\w%\.:]+/
       username = value.split('@')[0]
-      if username.size > 16
+      if not ((username =~ /['"`]*['"`]$/ and username.size <= 18) or username.size <= 16)
         raise ArgumentError, 'MySQL usernames are limited to a maximum of 16 characters'
       end
     end

--- a/spec/unit/puppet/type/mysql_user_spec.rb
+++ b/spec/unit/puppet/type/mysql_user_spec.rb
@@ -49,6 +49,24 @@ describe Puppet::Type.type(:mysql_user) do
     end
   end
 
+  context 'using a quoted 16 char username' do
+    before :each do
+      @user = Puppet::Type.type(:mysql_user).new(:name => '"debian-sys-maint"@localhost', :password_hash => 'pass')
+    end
+
+    it 'should accept a user name' do
+      expect(@user[:name]).to eq('"debian-sys-maint"@localhost')
+    end
+  end
+
+  context 'using a quoted username that is too long ' do
+    it 'should fail with a size error' do
+      expect {
+        Puppet::Type.type(:mysql_user).new(:name => '"debian-sys-maint2"@localhost', :password_hash => 'pass')
+      }.to raise_error /MySQL usernames are limited to a maximum of 16 characters/
+    end
+  end
+
   context 'using `speci!al#`@localhost' do
     before :each do
       @user = Puppet::Type.type(:mysql_user).new(:name => '`speci!al#`@localhost', :password_hash => 'pass')


### PR DESCRIPTION
As usernames containing special characters must be quoted, they
may have two extra characters that are not counted against the
size limit of 16 characters. This patch adds a regex to handle
this case.
