### PR TITLE
MODULES-1520

### DIFF
--- a/lib/puppet/type/mysql_user.rb
+++ b/lib/puppet/type/mysql_user.rb
@@ -12,8 +12,8 @@ Puppet::Type.newtype(:mysql_user) do
       # http://dev.mysql.com/doc/refman/5.5/en/identifiers.html
       # Regex should problably be more like this: /^[`'"]?[^`'"]*[`'"]?@[`'"]?[\w%\.]+[`'"]?$/
       # If at least one special char is used, string must be quoted
-      raise(ArgumentError, "Database user #{value} must be quotted as it contains special characters") if value =~ /^[^'`"].*[^0-9a-zA-Z$_].*[^'`"]@[\w%\.:]+/
-      raise(ArgumentError, "Invalid database user #{value}") unless value =~ /^(?:['`"][^'`"]*['`"]|[0-9a-zA-Z$_]*)@[\w%\.:]+/
+      raise(ArgumentError, "Database user #{value} must be quotted as it contains special characters") if value =~ /^[^'`"].*[^0-9a-zA-Z$_\-].*[^'`"]@[\w%\.:]+/
+      raise(ArgumentError, "Invalid database user #{value}") unless value =~ /^(?:['`"][^'`"]*['`"]|[0-9a-zA-Z$_\-]*)@[\w%\.:]+/
       username = value.split('@')[0]
       if not ((username =~ /['"`]*['"`]$/ and username.size <= 18) or username.size <= 16)
         raise ArgumentError, 'MySQL usernames are limited to a maximum of 16 characters'

--- a/spec/unit/puppet/type/mysql_user_spec.rb
+++ b/spec/unit/puppet/type/mysql_user_spec.rb
@@ -39,13 +39,13 @@ describe Puppet::Type.type(:mysql_user) do
     end
   end
 
-  context 'using allo_wed$char@localhost' do
+  context 'using allo_wed$-char@localhost' do
     before :each do
-      @user = Puppet::Type.type(:mysql_user).new(:name => 'allo_wed$char@localhost', :password_hash => 'pass')
+      @user = Puppet::Type.type(:mysql_user).new(:name => 'allo_wed$-char@localhost', :password_hash => 'pass')
     end
 
     it 'should accept a user name' do
-      expect(@user[:name]).to eq('allo_wed$char@localhost')
+      expect(@user[:name]).to eq('allo_wed$-char@localhost')
     end
   end
 
@@ -77,11 +77,11 @@ describe Puppet::Type.type(:mysql_user) do
     end
   end
 
-  context 'using in-valid@localhost' do
+  context 'using in#valid@localhost' do
     it 'should fail with an unquotted username with special char' do
       expect {
-        Puppet::Type.type(:mysql_user).new(:name => 'in-valid@localhost', :password_hash => 'pass')
-      }.to raise_error /Database user in-valid@localhost must be quotted/
+        Puppet::Type.type(:mysql_user).new(:name => 'in#valid@localhost', :password_hash => 'pass')
+      }.to raise_error /Database user in#valid@localhost must be quotted/
     end
   end
 end


### PR DESCRIPTION
This fix adds hyphens to the regex tests for the mysql_user type.

Without this fix you need some crazy-arse quoting to get it to work.
