### PR TITLE
ensure mysql-config-file and server package is in place before trying to...

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -20,6 +20,7 @@ class mysql::server::service {
     name     => $mysql::server::service_name,
     enable   => $mysql::server::real_service_enabled,
     provider => $mysql::server::service_provider,
+    require => [ File['mysql-config-file'], Package['mysql-server'] ]
   }
 
 }


### PR DESCRIPTION
... start service - to ensure it gets started with correct settings and does not try to enable service before it actually exists :)

in the hunt to get servers ready in one puppet run :)
