### PR TITLE
mysql_install_db freebsd support

### DIFF
--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -8,22 +8,28 @@ class mysql::server::install {
   }
 
   # Build the initial databases.
-  if $mysql::server::override_options['mysqld'] and $mysql::server::override_options['mysqld']['datadir'] {
-    $mysqluser = $mysql::server::options['mysqld']['user']
-    $datadir = $mysql::server::override_options['mysqld']['datadir']
+  $mysqluser = $mysql::server::options['mysqld']['user']
+  $datadir = $mysql::server::options['mysqld']['datadir']
+  $basedir = $mysql::server::options['mysqld']['basedir']
+  $config_file = $mysql::server::config_file
 
-    exec { 'mysql_install_db':
-      command   => "mysql_install_db --datadir=${datadir} --user=${mysqluser}",
-      creates   => "${datadir}/mysql",
-      logoutput => on_failure,
-      path      => '/bin:/sbin:/usr/bin:/usr/sbin',
-      require   => Package['mysql-server'],
-    }
+  if $mysql::server::manage_config_file {
+    $install_db_args = "--basedir=${basedir} --defaults-extra-file=${config_file} --datadir=${datadir} --user=${mysqluser}"
+  } else {
+    $install_db_args = "--basedir=${basedir} --datadir=${datadir} --user=${mysqluser}"
+  }
 
-    if $mysql::server::restart {
-      Exec['mysql_install_db'] {
-        notify => Class['mysql::server::service'],
-      }
+  exec { 'mysql_install_db':
+    command   => "mysql_install_db ${install_db_args}",
+    creates   => "${datadir}/mysql",
+    logoutput => on_failure,
+    path      => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
+    require   => Package['mysql-server'],
+  }
+
+  if $mysql::server::restart {
+    Exec['mysql_install_db'] {
+      notify => Class['mysql::server::service'],
     }
   }
 


### PR DESCRIPTION
- FreeBSD mysql_install_db location to '/usr/local/bin'.
- basedir location to '/usr/local'
- check $mysql::server:manage_config_file to install_db_args
- not datadir always execute mysql_install_db
