### PR TITLE
Remove mime-types from .sync.yml

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,7 +1,3 @@
 ---
-Gemfile:
-  optional:
-    - gem: mime-types
-      version: '<2.0'
 spec/spec_helper.rb:
   unmanaged: true


### PR DESCRIPTION
Gemfile no longer needs mime-types so it does not need to be
modulesynced separately.
