### PR TITLE
Support defining `log_error` in mysql::server

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -2,6 +2,7 @@
 class mysql::server (
   $config_file             = $mysql::params::config_file,
   $includedir              = $mysql::params::includedir,
+  $log_error               = $mysql::params::log_error,
   $install_options         = undef,
   $manage_config_file      = $mysql::params::manage_config_file,
   $old_root_password       = $mysql::params::old_root_password,

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -9,7 +9,7 @@ class mysql::server::service {
     }
   }
 
-  file { $mysql::params::log_error:
+  file { $mysql::server::log_error:
     ensure => present,
     owner  => 'mysql',
     group  => 'mysql',


### PR DESCRIPTION
On RedHat 7 the default provider has been set to `mariadb`. However, when one uses MySQL instead, the error log file is still enforced to MariaDB's default (/var/log/mariadb/mariadb.log) which parent folder is obviously not created by MySQL packages, and Puppet fails.

This commit allows setting the path to the error log file to avoid the failure.