### PR TITLE
under Debian 8 package name for ruby mysql biding is called ruby-mysql, ...

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -167,7 +167,7 @@ class mysql::params {
       $python_package_name = 'python-mysqldb'
       $ruby_package_name   = $::lsbdistcodename ? {
         'trusty'           => 'ruby-mysql',
-        'jessie'           => 'ruby-mysql',        
+        'jessie'           => 'ruby-mysql',
         default            => 'libmysql-ruby',
       }
       $client_dev_package_name = 'libmysqlclient-dev'


### PR DESCRIPTION
...just like trusty.
