### PR TITLE
MODULES-1520 - update username validation

### DIFF
--- a/lib/puppet/type/mysql_grant.rb
+++ b/lib/puppet/type/mysql_grant.rb
@@ -70,9 +70,9 @@ Puppet::Type.newtype(:mysql_grant) do
       elsif matches = /^([0-9a-zA-Z$_]*)@([\w%\.:\-]+)/.match(value)
         user_part = matches[1]
         host_part = matches[2]
-      elsif matches = /^(?:(?!['`"]).*)([^0-9a-zA-Z$_]).*@.+$/.match(value)
-        # does not start with a quote, but contains a special character
-        raise(ArgumentError, "Database user #{value} must be properly quoted, invalid character: '#{matches[1]}'")
+      elsif matches = /^((?!['`"]).*[^0-9a-zA-Z$_].*)@(.+)$/.match(value)
+        user_part = matches[1]
+        host_part = matches[2]
       else
         raise(ArgumentError, "Invalid database user #{value}")
       end

--- a/lib/puppet/type/mysql_user.rb
+++ b/lib/puppet/type/mysql_user.rb
@@ -19,9 +19,9 @@ Puppet::Type.newtype(:mysql_user) do
       elsif matches = /^([0-9a-zA-Z$_]*)@([\w%\.:\-]+)/.match(value)
         user_part = matches[1]
         host_part = matches[2]
-      elsif matches = /^(?:(?!['`"]).*)([^0-9a-zA-Z$_]).*@.+$/.match(value)
-        # does not start with a quote, but contains a special character
-        raise(ArgumentError, "Database user #{value} must be properly quoted, invalid character: '#{matches[1]}'")
+      elsif matches = /^((?!['`"]).*[^0-9a-zA-Z$_].*)@(.+)$/.match(value)
+        user_part = matches[1]
+        host_part = matches[2]
       else
         raise(ArgumentError, "Invalid database user #{value}")
       end

--- a/spec/acceptance/types/mysql_grant_spec.rb
+++ b/spec/acceptance/types/mysql_grant_spec.rb
@@ -70,6 +70,28 @@ describe 'mysql_grant' do
     end
   end
 
+  describe 'adding privileges with special character in name' do
+    it 'should work without errors' do
+      pp = <<-EOS
+        mysql_grant { 'test-2@tester/test.*':
+          ensure     => 'present',
+          table      => 'test.*',
+          user       => 'test-2@tester',
+          privileges => ['SELECT', 'UPDATE'],
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    it 'should find the user' do
+      shell("mysql -NBe \"SHOW GRANTS FOR 'test-2'@tester\"") do |r|
+        expect(r.stdout).to match(/GRANT SELECT, UPDATE.*TO 'test-2'@'tester'/)
+        expect(r.stderr).to be_empty
+      end
+    end
+  end
+
   describe 'adding privileges with invalid name' do
     it 'should fail' do
       pp = <<-EOS

--- a/spec/acceptance/types/mysql_user_spec.rb
+++ b/spec/acceptance/types/mysql_user_spec.rb
@@ -32,6 +32,27 @@ describe 'mysql_user' do
     end
   end
 
+  context 'using ashp-dash@localhost' do
+    describe 'adding user' do
+      it 'should work without errors' do
+        pp = <<-EOS
+          mysql_user { 'ashp-dash@localhost':
+            password_hash => '6f8c114b58f2ce9e',
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+      end
+
+      it 'should find the user' do
+        shell("mysql -NBe \"select '1' from mysql.user where CONCAT(user, '@', host) = 'ashp-dash@localhost'\"") do |r|
+          expect(r.stdout).to match(/^1$/)
+          expect(r.stderr).to be_empty
+        end
+      end
+    end
+  end
+
   context 'using ashp@LocalHost' do
     describe 'adding user' do
       it 'should work without errors' do

--- a/spec/unit/puppet/type/mysql_user_spec.rb
+++ b/spec/unit/puppet/type/mysql_user_spec.rb
@@ -49,6 +49,16 @@ describe Puppet::Type.type(:mysql_user) do
     end
   end
 
+  context 'ensure the default \'debian-sys-main\'@localhost user can be parsed' do
+    before :each do
+      @user = Puppet::Type.type(:mysql_user).new(:name => '\'debian-sys-maint\'@localhost', :password_hash => 'pass')
+    end
+
+    it 'should accept a user name' do
+      expect(@user[:name]).to eq('\'debian-sys-maint\'@localhost')
+    end
+  end
+
   context 'using a quoted 16 char username' do
     before :each do
       @user = Puppet::Type.type(:mysql_user).new(:name => '"debian-sys-maint"@localhost', :password_hash => 'pass')
@@ -78,10 +88,12 @@ describe Puppet::Type.type(:mysql_user) do
   end
 
   context 'using in-valid@localhost' do
-    it 'should fail with an unquotted username with special char' do
-      expect {
-        Puppet::Type.type(:mysql_user).new(:name => 'in-valid@localhost', :password_hash => 'pass')
-      }.to raise_error /Database user in-valid@localhost must be properly quoted, invalid character: '-'/
+    before :each do
+      @user = Puppet::Type.type(:mysql_user).new(:name => 'in-valid@localhost', :password_hash => 'pass')
+    end
+
+    it 'should accept a user name with special chatracters' do
+      expect(@user[:name]).to eq('in-valid@localhost')
     end
   end
 


### PR DESCRIPTION
Don't fail on validation where the user isn't quoted with special
characters. The providers quote these strings by default.