### PR TITLE
Do the right thing when fqdn==localhost

### DIFF
--- a/manifests/server/account_security.pp
+++ b/manifests/server/account_security.pp
@@ -1,18 +1,34 @@
 class mysql::server::account_security {
   mysql_user {
-    [ "root@${::fqdn}",
-      'root@127.0.0.1',
+    [ 'root@127.0.0.1',
       'root@::1',
-      "@${::fqdn}",
       '@localhost',
       '@%']:
     ensure  => 'absent',
     require => Anchor['mysql::server::end'],
   }
-  if ($::fqdn != $::hostname) {
-    mysql_user { ["root@${::hostname}", "@${::hostname}"]:
+  if ($::fqdn != 'localhost.localdomain') {
+    mysql_user {
+      [ "root@localhost.localdomain",
+        "@localhost.localdomain"]:
       ensure  => 'absent',
       require => Anchor['mysql::server::end'],
+    }
+  }
+  if ($::fqdn != 'localhost') {
+    mysql_user {
+      [ "root@${::fqdn}",
+        "@${::fqdn}"]:
+      ensure  => 'absent',
+      require => Anchor['mysql::server::end'],
+    }
+  }
+  if ($::fqdn != $::hostname) {
+    if ($::hostname != 'localhost') {
+      mysql_user { ["root@${::hostname}", "@${::hostname}"]:
+        ensure  => 'absent',
+        require => Anchor['mysql::server::end'],
+      }
     }
   }
   mysql_database { 'test':

--- a/spec/classes/mysql_server_account_security_spec.rb
+++ b/spec/classes/mysql_server_account_security_spec.rb
@@ -13,7 +13,7 @@ describe 'mysql::server::account_security' do
           '@localhost',
           '@%',
         ].each do |user|
-          it 'removes Mysql_User[#{user}]' do
+          it "removes Mysql_User[#{user}]" do
             is_expected.to contain_mysql_user(user).with_ensure('absent')
           end
         end
@@ -22,13 +22,45 @@ describe 'mysql::server::account_security' do
         # We don't need to test the inverse as when they match they are
         # covered by the above list.
         [ 'root@myhost', '@myhost' ].each do |user|
-          it 'removes Mysql_User[#{user}]' do
+          it "removes Mysql_User[#{user}]" do
             is_expected.to contain_mysql_user(user).with_ensure('absent')
           end
         end
 
         it 'should remove Mysql_database[test]' do
           is_expected.to contain_mysql_database('test').with_ensure('absent')
+        end
+      end
+
+      describe "on #{pe_version} #{pe_platform} with fqdn==localhost" do
+        let(:facts) { facts.merge({:fqdn => 'localhost', :hostname => 'localhost'}) }
+
+        [ 'root@127.0.0.1',
+          'root@::1',
+          '@localhost',
+          'root@localhost.localdomain',
+          '@localhost.localdomain',
+          '@%',
+        ].each do |user|
+          it "removes Mysql_User[#{user}]" do
+            is_expected.to contain_mysql_user(user).with_ensure('absent')
+          end
+        end
+      end
+
+      describe "on #{pe_version} #{pe_platform} with fqdn==localhost.localdomain" do
+        let(:facts) { facts.merge({:fqdn => 'localhost.localdomain', :hostname => 'localhost'}) }
+
+        [ 'root@127.0.0.1',
+          'root@::1',
+          '@localhost',
+          'root@localhost.localdomain',
+          '@localhost.localdomain',
+          '@%',
+        ].each do |user|
+          it "removes Mysql_User[#{user}]" do
+            is_expected.to contain_mysql_user(user).with_ensure('absent')
+          end
         end
       end
     end


### PR DESCRIPTION
Make sure not to declare root@localhost and @localhost if the fqdn is 'localhost'

```
Error: Duplicate declaration: Mysql_user[root@localhost] is already declared in file /etc/puppet/modules/mysql/manifests/server/root_password.pp:11; cannot redeclare at /etc/puppet/modules/mysql/manifests/server/account_security.pp:11 on node localhost
Error: Duplicate declaration: Mysql_user[root@localhost] is already declared in file /etc/puppet/modules/mysql/manifests/server/root_password.pp:11; cannot redeclare at /etc/puppet/modules/mysql/manifests/server/account_security.pp:11 on node localhost
```

Also remove root@localhost.localdomain and @localhost.localdomain in that case