### PR TITLE
Make sure the example is somewhat secure

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ password or `/etc/my.cnf` settings, then you must also pass in an override hash:
 
 ```puppet
 class { '::mysql::server':
-  root_password    => 'strongpassword',
-  override_options => $override_options
+  root_password           => 'strongpassword',
+  remove_default_accounts => true,
+  override_options        => $override_options
 }
 ```
 (see 'Overrides' below for examples of the hash structure for `$override_options`)


### PR DESCRIPTION
Setting a password for root@localhost, but leaving other accounts like root@127.0.0.1 unprotected leaves an false impression of security. This makes the example more secure.