### PR TITLE
remove dependency on mysql_user from /root/.my.cnf

### DIFF
--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -14,7 +14,6 @@ class mysql::server::root_password {
       content => template('mysql/my.cnf.pass.erb'),
       owner   => 'root',
       mode    => '0600',
-      require => Mysql_user['root@localhost'],
     }
   }
 


### PR DESCRIPTION
You cannot create a mysql_user until the .my.cnf file is written so this
dependency does not make sense.

Closes: MODULES-1058