### PR TITLE
Return an empty string for an empty input.

### DIFF
--- a/lib/puppet/parser/functions/mysql_password.rb
+++ b/lib/puppet/parser/functions/mysql_password.rb
@@ -10,6 +10,7 @@ module Puppet::Parser::Functions
     raise(Puppet::ParseError, 'mysql_password(): Wrong number of arguments ' +
       "given (#{args.size} for 1)") if args.size != 1
 
+    return '' if args[0].empty?
     '*' + Digest::SHA1.hexdigest(Digest::SHA1.digest(args[0])).upcase
   end
 end

--- a/lib/puppet/type/mysql_user.rb
+++ b/lib/puppet/type/mysql_user.rb
@@ -37,7 +37,7 @@ Puppet::Type.newtype(:mysql_user) do
 
   newproperty(:password_hash) do
     desc 'The password hash of the user. Use mysql_password() for creating such a hash.'
-    newvalue(/\w+/)
+    newvalue(/\w*/)
   end
 
   newproperty(:max_user_connections) do

--- a/spec/unit/puppet/functions/mysql_password_spec.rb
+++ b/spec/unit/puppet/functions/mysql_password_spec.rb
@@ -23,5 +23,10 @@ describe 'the mysql_password function' do
     result = scope.function_mysql_password(%w(password))
     expect(result).to(eq('*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19'))
   end
+  
+  it 'should convert an empty password into a empty string' do
+    result = scope.function_mysql_password([""])
+    expect(result).to(eq(''))
+  end
 
 end


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/MODULES-1676

This is identical to what PASSWORD('') in MySQL does:

```
5.6.22-debug-log> CREATE USER 'testpwd'@'localhost' IDENTIFIED BY 'foo';
Query OK, 0 rows affected (0.03 sec)

5.6.22-debug-log> SELECT User,Host,Password FROM mysql.user WHERE
User='testpwd';
+---------+-----------+-------------------------------------------+
| User    | Host      | Password                                  |
+---------+-----------+-------------------------------------------+
| testpwd | localhost | *F3A2A51A9B0F2BE2468926B4132313728C250DBF |
+---------+-----------+-------------------------------------------+
1 row in set (0.01 sec)

5.6.22-debug-log> SET PASSWORD FOR 'testpwd'@'localhost' = PASSWORD('');
Query OK, 0 rows affected (0.00 sec)

5.6.22-debug-log> SELECT User,Host,Password FROM mysql.user WHERE
User='testpwd';
+---------+-----------+----------+
| User    | Host      | Password |
+---------+-----------+----------+
| testpwd | localhost |          |
+---------+-----------+----------+
1 row in set (0.00 sec)
```