### PR TITLE
Support for more backup methods

### DIFF
--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -3,6 +3,7 @@ class mysql::server::backup (
   $backupuser,
   $backuppassword,
   $backupdir,
+  $backupmethod = 'mysqldump',
   $backupdirmode = '0700',
   $backupdirowner = 'root',
   $backupdirgroup = 'root',
@@ -25,30 +26,107 @@ class mysql::server::backup (
     require       => Class['mysql::server::root_password'],
   }
 
-  mysql_grant { "${backupuser}@localhost/*.*":
-    ensure     => $ensure,
-    user       => "${backupuser}@localhost",
-    table      => '*.*',
-    privileges => [ 'SELECT', 'RELOAD', 'LOCK TABLES', 'SHOW VIEW', 'PROCESS' ],
-    require    => Mysql_user["${backupuser}@localhost"],
-  }
+  case $backupmethod {
+    'mysqlbackup': {
+      package { 'meb':
+        ensure    => $ensure,
+      }
 
-  cron { 'mysql-backup':
-    ensure  => $ensure,
-    command => '/usr/local/sbin/mysqlbackup.sh',
-    user    => 'root',
-    hour    => $time[0],
-    minute  => $time[1],
-    require => File['mysqlbackup.sh'],
-  }
+      # http://dev.mysql.com/doc/mysql-enterprise-backup/3.11/en/mysqlbackup.privileges.html
+      mysql_grant { "${backupuser}@localhost/*.*":
+        ensure     => $ensure,
+        user       => "${backupuser}@localhost",
+        table      => '*.*',
+        privileges => [ 'RELOAD', 'SUPER', 'REPLICATION CLIENT' ],
+        require    => Mysql_user["${backupuser}@localhost"],
+      }
 
-  file { 'mysqlbackup.sh':
-    ensure  => $ensure,
-    path    => '/usr/local/sbin/mysqlbackup.sh',
-    mode    => '0700',
-    owner   => 'root',
-    group   => 'root',
-    content => template('mysql/mysqlbackup.sh.erb'),
+      mysql_grant { "${backupuser}@localhost/mysql.backup_progress":
+        ensure     => $ensure,
+        user       => "${backupuser}@localhost",
+        table      => 'mysql.backup_progress',
+        privileges => [ 'CREATE', 'INSERT', 'DROP', 'UPDATE' ],
+        require    => Mysql_user["${backupuser}@localhost"],
+      }
+
+      mysql_grant { "${backupuser}@localhost/mysql.backup_history":
+        ensure     => $ensure,
+        user       => "${backupuser}@localhost",
+        table      => 'mysql.backup_history',
+        privileges => [ 'CREATE', 'INSERT', 'SELECT', 'DROP', 'UPDATE' ],
+        require    => Mysql_user["${backupuser}@localhost"],
+      }
+
+      cron { 'mysqlbackup-weekly':
+        ensure  => $ensure,
+        command => 'mysqlbackup backup',
+        user    => 'root',
+        hour    => $time[0],
+        minute  => $time[1],
+        weekday => 0,
+        require => Package['meb'],
+      }
+
+      cron { 'mysqlbackup-daily':
+        ensure  => $ensure,
+        command => 'mysqlbackup --incremental backup',
+        user    => 'root',
+        hour    => $time[0],
+        minute  => $time[1],
+        weekday => 1-6,
+        require => Package['meb'],
+      }
+    }
+    'xtrabackup': {
+      package{ 'percona-xtrabackup':
+        ensure  => $ensure,
+      }
+      cron { 'xtrabackup-weekly':
+        ensure  => $ensure,
+        command => 'innobackupex $backupdir',
+        user    => 'root',
+        hour    => $time[0],
+        minute  => $time[1],
+        weekday => 0,
+        require => Package['percona-xtrabackup'],
+      }
+      cron { 'xtrabackup-daily':
+        ensure  => $ensure,
+        command => 'innobackupex --incremental $backupdir',
+        user    => 'root',
+        hour    => $time[0],
+        minute  => $time[1],
+        weekday => 1-6,
+        require => Package['percona-xtrabackup'],
+      }
+    }
+    default: {
+      mysql_grant { "${backupuser}@localhost/*.*":
+        ensure     => $ensure,
+        user       => "${backupuser}@localhost",
+        table      => '*.*',
+        privileges => [ 'SELECT', 'RELOAD', 'LOCK TABLES', 'SHOW VIEW', 'PROCESS' ],
+        require    => Mysql_user["${backupuser}@localhost"],
+      }
+
+      cron { 'mysql-backup':
+        ensure  => $ensure,
+        command => '/usr/local/sbin/mysqlbackup.sh',
+        user    => 'root',
+        hour    => $time[0],
+        minute  => $time[1],
+        require => File['mysqlbackup.sh'],
+      }
+
+      file { 'mysqlbackup.sh':
+        ensure  => $ensure,
+        path    => '/usr/local/sbin/mysqlbackup.sh',
+        mode    => '0700',
+        owner   => 'root',
+        group   => 'root',
+        content => template('mysql/mysqlbackup.sh.erb'),
+      }
+    }
   }
 
   file { 'mysqlbackupdir':


### PR DESCRIPTION
Add support for logical backups with:
 * MySQL Enteprise Backup
 * Percona XtraBackup

Possible Issues:
* There is no apt/deb for the meb package: https://bugs.mysql.com/bug.php?id=75633&thanks=sub
* The meb rpm must be downloaded for Oracle https://edelivery.oracle.com https://support.oracle.com