### PR TITLE
(#MODULES-1058) root_password.pp cannot create /root/.my.cnf due to depe...

### DIFF
--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -14,7 +14,6 @@ class mysql::server::root_password {
       content => template('mysql/my.cnf.pass.erb'),
       owner   => 'root',
       mode    => '0600',
-      require => Mysql_user['root@localhost'],
     }
   }
 


### PR DESCRIPTION
...ndency

The dependency of creating the root .my.cnf file is a command which requires
the .my.cnf file. This patch removes that dependency. Without removing the
dependency, if a user already has a mysql server installed with a root password
and no root .my.cnf file, the module application will fail.