### PR TITLE
there is no class called mysql anymore (to test)

### DIFF
--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,1 +1,0 @@
-include mysql


### PR DESCRIPTION
Remove tests/init.pp which seeks to test class mysql.
There is no definition for it, and so there is no need for the init.pp file in tests.