### PR TITLE
Update version dependency on stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -76,7 +76,7 @@
   ],
   "description": "Mysql module",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.1.0"},
     {"name":"nanliu/staging","version_requirement":"1.x"}
   ]
 }


### PR DESCRIPTION
mysql::server::config uses the dirname function from stdlib, which appeared in 4.1.0.

This isn't a problem if you install from the forge but my manual validation led me to belive I didn't have to update my existing stdlib.