### PR TITLE
Bugfix: increase minimum stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -76,7 +76,7 @@
   ],
   "description": "Mysql module",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.1.0 < 5.0.0"},
     {"name":"nanliu/staging","version_requirement":"1.x"}
   ]
 }


### PR DESCRIPTION
Mysql 3.1.0 included 08a66b7 which uses dirname() which was released in
stdlib 4.1.0. This change bumps the minimum stdlib up to 4.1.0