### PR TITLE
MODULES-1759: Remove dependency on stdlib >=4.1.0

### DIFF
--- a/lib/puppet/parser/functions/mysql_dirname.rb
+++ b/lib/puppet/parser/functions/mysql_dirname.rb
@@ -1,0 +1,15 @@
+module Puppet::Parser::Functions
+  newfunction(:mysql_dirname, :type => :rvalue, :doc => <<-EOS
+    Returns the dirname of a path.
+    EOS
+  ) do |arguments|
+
+    raise(Puppet::ParseError, "mysql_dirname(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size < 1
+
+    path = arguments[0]
+    return File.dirname(path)
+  end
+end
+
+# vim: set ts=2 sw=2 et :

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -22,7 +22,7 @@ class mysql::server::config {
   $logbin = pick($options['mysqld']['log-bin'], $options['mysqld']['log_bin'], false)
 
   if $logbin {
-    $logbindir = dirname($logbin)
+    $logbindir = mysql_dirname($logbin)
     file { $logbindir:
       ensure => directory,
       mode   => '0755',

--- a/metadata.json
+++ b/metadata.json
@@ -76,7 +76,7 @@
   ],
   "description": "Mysql module",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.1.0 < 5.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 5.0.0"},
     {"name":"nanliu/staging","version_requirement":"1.x"}
   ]
 }


### PR DESCRIPTION
Backported dirname => mysql_dirname since updating dependency to stdlib
4.1.0 is backwards incompatible with some versions of PE.