### PR TITLE
Fix rake lint error in examples/server/config.php

### DIFF
--- a/examples/server/config.pp
+++ b/examples/server/config.pp
@@ -1,3 +1,3 @@
 mysql::server::config { 'testfile':
-  
+
 }


### PR DESCRIPTION
```
examples/server/config.pp - ERROR: trailing whitespace found on line 2
```