### PR TITLE
Fix bug in 578

### DIFF
--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -16,7 +16,9 @@ class mysql::server::root_password {
       content => template('mysql/my.cnf.pass.erb'),
       owner   => 'root',
       mode    => '0600',
-      require => Mysql_user['root@localhost'],
+    }
+    if $mysql::server::create_root_user == true {
+      Mysql_user['root@localhost'] -> File["${::root_home}/.my.cnf"]
     }
   }
 

--- a/spec/classes/mysql_server_spec.rb
+++ b/spec/classes/mysql_server_spec.rb
@@ -55,7 +55,7 @@ describe 'mysql::server' do
           describe 'when root_password set' do
             let(:params) {{:root_password => 'SET' }}
             it { is_expected.to contain_mysql_user('root@localhost') }
-            it { is_expected.to contain_file('/root/.my.cnf') }
+            it { is_expected.to contain_file('/root/.my.cnf').that_requires('Mysql_user[root@localhost]') }
           end
           describe 'when root_password set, create_root_user set to false' do
             let(:params) {{ :root_password => 'SET', :create_root_user => false }}


### PR DESCRIPTION
the recently added feature to support galera by allowing independent
creation of the root@localhost user in the DB and the /root/.my.cnf
file contains a bug.

specifically the .my.cnf file resource still requires the root@localhost
resource, even when it is not available.

this fixes the issue by making the dependency optional.