### PR TITLE
Only set up ordering between the config file and the service if we're managing the config file.

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -20,7 +20,13 @@ class mysql::server::service {
     name     => $mysql::server::service_name,
     enable   => $mysql::server::real_service_enabled,
     provider => $mysql::server::service_provider,
-    require  => [ File['mysql-config-file'], Package['mysql-server'] ]
+    require  => Package['mysql-server'],
+  }
+
+  # only establish ordering between config file and service if
+  # we're managing the config file.
+  if $mysql::server::manage_config_file {
+    File['mysql-config-file'] -> Service['mysqld']
   }
 
 }


### PR DESCRIPTION
With latest (3.2.0), if you try use manage_config_file => false, you get an undefined resource for File['mysql-config-file'].

This is because mysql::server::config is conditionally defining that resource, but mysql::server::service is always requiring it.

A different approach to fixing this issue, which arguably has a bit more flexibility for the module end user, would be to leave the code in mysql::server::service as-is, and instead change mysql::server::config so that it always defines a File resource for mysql-config-file, but if manage_config_file is false, it doesn't set any attributes for the File.  That allows people to use manage_config_file => false and potentially manage their config some other way, but still have the right ordering for the file and the service resources.

