### PR TITLE
PR 654 was incorrectly using stdlib dirname

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -22,7 +22,7 @@ class mysql::server::config {
   $logbin = pick($options['mysqld']['log-bin'], $options['mysqld']['log_bin'], false)
 
   if $logbin {
-    $logbindir = dirname($logbin)
+    $logbindir = mysql_dirname($logbin)
     
     #Stop puppet from managing directory if just a filename/prefix is specified
     if $logbindir != '.' {


### PR DESCRIPTION
puppetlabs-mysql has a dependency on stdlib 3.2.0, which does not
include the dirname function.