### PR TITLE
(MODULES-1804) Allow override of log-error

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -1,5 +1,6 @@
 #
 class mysql::server::service {
+  $options = $mysql::server::options
 
   if $mysql::server::real_service_manage {
     if $mysql::server::real_service_enabled {
@@ -9,7 +10,7 @@ class mysql::server::service {
     }
   }
 
-  file { $mysql::params::log_error:
+  file { $options['mysqld']['log-error']:
     ensure => present,
     owner  => 'mysql',
     group  => 'mysql',

--- a/spec/classes/mysql_server_spec.rb
+++ b/spec/classes/mysql_server_spec.rb
@@ -45,6 +45,10 @@ describe 'mysql::server' do
               })
             end
           end
+          context 'with log-error overridden' do
+            let(:params) {{ :override_options => { 'mysqld' => { 'log-error' => '/tmp/error.log' }} }}
+            it { is_expected.to contain_file('/tmp/error.log') }
+          end
         end
 
         context 'mysql::server::root_password' do


### PR DESCRIPTION
The mysqld log-error setting may be passed by override_options, but
server/service.pp was not using the overridden value. This fixes that.