### PR TITLE
Remove default install root password if set

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@ class mysql::params {
   $purge_conf_dir         = false
   $restart                = false
   $root_password          = 'UNSET'
+  $install_secret_file    = '/.mysql_secret'
   $server_package_ensure  = 'present'
   $server_package_manage  = true
   $server_service_manage  = true

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -3,6 +3,7 @@ class mysql::server (
   $config_file             = $mysql::params::config_file,
   $includedir              = $mysql::params::includedir,
   $install_options         = undef,
+  $install_secret_file     = $mysql::params::install_secret_file,
   $manage_config_file      = $mysql::params::manage_config_file,
   $old_root_password       = $mysql::params::old_root_password,
   $override_options        = {},

--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -2,12 +2,28 @@
 class mysql::server::root_password {
 
   $options = $mysql::server::options
+  $secret_file = $mysql::server::install_secret_file
+
+  # New installations of MySQL will configure a default random password for the root user
+  # with an expiration. No actions can be performed until this password is changed. The
+  # below exec will remove this default password. If the user has supplied a root
+  # password it will be set further down with the mysql_user resource.
+  $rm_pass_cmd = join([
+    "mysqladmin -u root --password=\$(grep -o '[^ ]\\+\$' ${secret_file}) password ''",
+    "rm -f ${secret_file}"
+  ], ' && ')
+  exec { 'remove install pass':
+    command => $rm_pass_cmd,
+    onlyif  => "test -f ${secret_file}",
+    path    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin'
+  }
 
   # manage root password if it is set
   if $mysql::server::create_root_user == true and $mysql::server::root_password != 'UNSET' {
     mysql_user { 'root@localhost':
       ensure        => present,
       password_hash => mysql_password($mysql::server::root_password),
+      require       => Exec['remove install pass']
     }
   }
 

--- a/spec/classes/mysql_server_spec.rb
+++ b/spec/classes/mysql_server_spec.rb
@@ -61,6 +61,13 @@ describe 'mysql::server' do
 
         context 'mysql::server::root_password' do
           describe 'when defaults' do
+            it {
+               is_expected.to contain_exec('remove install pass').with(
+                 :command => 'mysqladmin -u root --password=$(grep -o \'[^ ]\\+$\' /.mysql_secret) password \'\' && rm -f /.mysql_secret',
+                 :onlyif  => 'test -f /.mysql_secret',
+                 :path    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin'
+               )
+             }
             it { is_expected.not_to contain_mysql_user('root@localhost') }
             it { is_expected.not_to contain_file('/root/.my.cnf') }
           end
@@ -84,6 +91,15 @@ describe 'mysql::server' do
             it { is_expected.not_to contain_mysql_user('root@localhost') }
             it { is_expected.not_to contain_file('/root/.my.cnf') }
           end
+          describe 'when install_secret_file set to /root/.mysql_secret' do
+            let(:params) {{ :install_secret_file => '/root/.mysql_secret' }}
+            it {
+              is_expected.to contain_exec('remove install pass').with(
+                 :command => 'mysqladmin -u root --password=$(grep -o \'[^ ]\\+$\' /root/.mysql_secret) password \'\' && rm -f /root/.mysql_secret',
+                 :onlyif  => 'test -f /root/.mysql_secret'
+              )
+            }
+          end 
         end
 
         context 'mysql::server::providers' do


### PR DESCRIPTION
I haven't written any tests for this PR b/c I wasn't sure you'd be willing to merge it. If you're OK with this approach, I will write tests. If you're not, please provide some feedback on an alternate way to address this "feature".

New installations of MySQL will configure a default random password for the root user with an expiration. See http://datacharmer.blogspot.com/2012/11/mysql-568-broken-compatibility-ahead.html. Until the root password is changed, no actions can be performed. This PR adds detection of the mysql_secret file and removes this password. If the user desires to set a password it will be configured by the mysql_user resource further down in the mysql::server::root_password class.