### PR TITLE
Remove references to old_root_password (cleanup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,11 @@ The MySQL root password. Puppet attempts to set the root password and update `/r
 
 This is required if `create_root_user` or `create_root_my_cnf` are 'true'. If `root_password` is 'UNSET', then `create_root_user` and `create_root_my_cnf` are assumed to be false --- that is, the MySQL root user and `/root/.my.cnf` are not created.
 
-#####`old_root_password`
+Password changes are supported however the old password must be set in `/root/.my.cnf`. Effectively, Puppet uses the old password, configured in `/root/my.cnf`, to set the new password in MySQL, then updates `/root/.my.cnf` with the new password. 
 
-The previous root password. Required if you want to change the root password via Puppet.
+####`old_root_password`
+
+This parameter no longer does anything. It exists only for backwards compatibility. See the `root_password` parameter for details on changing the root password.
 
 #####`override_options`
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,6 @@
 class mysql::params {
 
   $manage_config_file     = true
-  $old_root_password      = ''
   $purge_conf_dir         = false
   $restart                = false
   $root_password          = 'UNSET'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -4,7 +4,6 @@ class mysql::server (
   $includedir              = $mysql::params::includedir,
   $install_options         = undef,
   $manage_config_file      = $mysql::params::manage_config_file,
-  $old_root_password       = $mysql::params::old_root_password,
   $override_options        = {},
   $package_ensure          = $mysql::params::server_package_ensure,
   $package_manage          = $mysql::params::server_package_manage,
@@ -26,7 +25,8 @@ class mysql::server (
 
   # Deprecated parameters
   $enabled                 = undef,
-  $manage_service          = undef
+  $manage_service          = undef,
+  $old_root_password       = undef
 ) inherits mysql::params {
 
   # Deprecated parameters.
@@ -41,6 +41,9 @@ class mysql::server (
     $real_service_manage = $manage_service
   } else {
     $real_service_manage = $service_manage
+  }
+  if $old_root_password {
+    warning('old_root_password is no longer used and will be removed in a future release')
   }
 
   # Create a merged together set of options.  Rightmost hashes win over left.


### PR DESCRIPTION
As far as I could tell this parameter is not used anywhere.