### PR TITLE
mysql backup: fix regression in mysql_user call

### DIFF
--- a/manifests/backup/mysqlbackup.pp
+++ b/manifests/backup/mysqlbackup.pp
@@ -21,7 +21,6 @@ class mysql::backup::mysqlbackup (
   mysql_user { "${backupuser}@localhost":
     ensure        => $ensure,
     password_hash => mysql_password($backuppassword),
-    provider      => 'mysql',
     require       => Class['mysql::server::root_password'],
   }
 

--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -21,7 +21,6 @@ class mysql::backup::mysqldump (
   mysql_user { "${backupuser}@localhost":
     ensure        => $ensure,
     password_hash => mysql_password($backuppassword),
-    provider      => 'mysql',
     require       => Class['mysql::server::root_password'],
   }
 

--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -22,7 +22,6 @@ class mysql::backup::xtrabackup (
   mysql_user { "${backupuser}@localhost":
     ensure        => $ensure,
     password_hash => mysql_password($backuppassword),
-    provider      => 'mysql',
     require       => Class['mysql::server::root_password'],
   }
 


### PR DESCRIPTION
due to a mishappen rebase, in #649, we introduced a regression fixed
which was fixed in #655.

how come our tests don't catch this?