### PR TITLE
Manage service only if managed

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -8,6 +8,8 @@ class mysql::server::service {
     } else {
       $service_ensure = 'stopped'
     }
+  } else {
+    $service_ensure = undef
   }
 
   if $mysql::server::override_options['mysqld'] and $mysql::server::override_options['mysqld']['user'] {


### PR DESCRIPTION
In the case of an unmanaged mysql service, defined with:
```puppet
class {'::mysql::server':
[...]
  service_manage => false,
[...]
}
```
We have the following error:
```
Undefined variable "service_ensure"
```
In this case, we don't want to have it "started" nor "stopped", as it is managed by another application (in our case by pacemaker).

This patch resolve this issue, by setting `service_ensure` to `undef`, in the case of an unmanaged service.