### PR TITLE
Cosmetic: add comment managed by puppet

### DIFF
--- a/templates/my.cnf.pass.erb
+++ b/templates/my.cnf.pass.erb
@@ -1,3 +1,5 @@
+### MANAGED BY PUPPET ###
+
 [client]
 user=root
 host=localhost


### PR DESCRIPTION
Add a comment in the .my.cnf file, to show that the file is managed by puppet, as in the other templates.