### PR TITLE
Fix regression introduced by adding OpenBSD support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,10 @@ Whether the service should be restarted when things change. Valid values are 'tr
 
 The name of the group used for root. Can be a group name or a group ID. See more about the [`group` file attribute](https://docs.puppetlabs.com/references/latest/type.html#file-attribute-group).
 
+#####`mysql_group`
+
+The name of the group of the mysql daemon user. Can be a group name or a group ID. See more about the [`group` file attribute](https://docs.puppetlabs.com/references/latest/type.html#file-attribute-group).
+
 #####`package_ensure`
 
 Whether the package exists or should be a specific version. Valid values are 'present', 'absent', or 'x.y.z'. Defaults to 'present'.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -76,6 +76,7 @@ class mysql::params {
       $basedir                 = '/usr'
       $datadir                 = '/var/lib/mysql'
       $root_group              = 'root'
+      $mysql_group             = 'mysql'
       $socket                  = '/var/lib/mysql/mysql.sock'
       $ssl_ca                  = '/etc/mysql/cacert.pem'
       $ssl_cert                = '/etc/mysql/server-cert.pem'
@@ -125,6 +126,7 @@ class mysql::params {
         /(SLES|SLED)/      => '/var/lib/mysql/mysqld.pid',
       }
       $root_group          = 'root'
+      $mysql_group         = 'mysql'
       $server_service_name = 'mysql'
       $socket              = $::operatingsystem ? {
         /OpenSuSE/         => '/var/run/mysql/mysql.sock',
@@ -158,6 +160,7 @@ class mysql::params {
       $log_error               = '/var/log/mysql/error.log'
       $pidfile                 = '/var/run/mysqld/mysqld.pid'
       $root_group              = 'root'
+      $mysql_group             = 'mysql'
       $server_service_name     = 'mysql'
       $socket                  = '/var/run/mysqld/mysqld.sock'
       $ssl_ca                  = '/etc/mysql/cacert.pem'
@@ -187,6 +190,7 @@ class mysql::params {
       $log_error           = '/var/log/mysqld.log'
       $pidfile             = '/var/run/mysqld/mysqld.pid'
       $root_group          = 'root'
+      $mysql_group         = 'mysql'
       $server_service_name = 'mysqld'
       $socket              = '/var/lib/mysql/mysql.sock'
       $ssl_ca              = '/etc/mysql/cacert.pem'
@@ -210,6 +214,7 @@ class mysql::params {
       $log_error           = '/var/log/mysql/mysqld.err'
       $pidfile             = '/run/mysqld/mysqld.pid'
       $root_group          = 'root'
+      $mysql_group         = 'mysql'
       $server_service_name = 'mysql'
       $socket              = '/run/mysqld/mysqld.sock'
       $ssl_ca              = '/etc/mysql/cacert.pem'
@@ -234,6 +239,7 @@ class mysql::params {
       $log_error           = "/var/db/mysql/${::hostname}.err"
       $pidfile             = '/var/db/mysql/mysql.pid'
       $root_group          = 'wheel'
+      $mysql_group         = 'mysql'
       $server_service_name = 'mysql-server'
       $socket              = '/tmp/mysql.sock'
       $ssl_ca              = undef
@@ -261,6 +267,7 @@ class mysql::params {
       $log_error           = "/var/mysql/${::hostname}.err"
       $pidfile             = '/var/mysql/mysql.pid'
       $root_group          = 'wheel'
+      $mysql_group         = '_mysql'
       $server_service_name = 'mysqld'
       $socket              = '/var/run/mysql/mysql.sock'
       $ssl_ca              = undef
@@ -290,6 +297,7 @@ class mysql::params {
           $log_error           = '/var/log/mysqld.log'
           $pidfile             = '/var/run/mysqld/mysqld.pid'
           $root_group          = 'root'
+          $mysql_group         = 'mysql'
           $server_service_name = 'mysqld'
           $socket              = '/var/lib/mysql/mysql.sock'
           $ssl_ca              = '/etc/mysql/cacert.pem'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -13,6 +13,7 @@ class mysql::server (
   $remove_default_accounts = false,
   $restart                 = $mysql::params::restart,
   $root_group              = $mysql::params::root_group,
+  $mysql_group             = $mysql::params::mysql_group,
   $root_password           = $mysql::params::root_password,
   $service_enabled         = $mysql::params::server_service_enabled,
   $service_manage          = $mysql::params::server_service_manage,

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -21,7 +21,7 @@ class mysql::server::service {
   file { $options['mysqld']['log-error']:
     ensure => present,
     owner  => $mysqluser,
-    group  => $::mysql::server::root_group,
+    group  => $::mysql::server::mysql_group,
   }
 
   service { 'mysqld':


### PR DESCRIPTION
The pull request referring to was #567 

Add a $mysql_group parameter, and use that instead of the $root_group
parameter to define the group membership of the mysql error log file.

For all OS but OpenBSD, the value is set to 'mysql', which was hardcoded
in manifests/server/service.pp before, for OpenBSD, it's set to '_mysql'.

Should bring back old behavior on non-OpenBSD, and some tests showed, 
no problems on OpenBSD.