### PR TITLE
set show_diff to false for file with password

### DIFF
--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -13,12 +13,18 @@ class mysql::server::root_password {
 
   if $mysql::server::create_root_my_cnf == true and $mysql::server::root_password != 'UNSET' {
     file { "${::root_home}/.my.cnf":
+      ensure  => file,
       content => template('mysql/my.cnf.pass.erb'),
       owner   => 'root',
       mode    => '0600',
     }
     if $mysql::server::create_root_user == true {
       Mysql_user['root@localhost'] -> File["${::root_home}/.my.cnf"]
+    }
+    if versioncmp($::puppetversion, '3.2.0') =~ /[01]/ {
+      File["${::root_home}/.my.cnf"] {
+        show_diff => false,
+      }
     }
   }
 


### PR DESCRIPTION
It's no secure to be able to view passwords in logs or interactively.