### PR TITLE
fix FreeBSD support for backups

### DIFF
--- a/manifests/backup/mysqlbackup.pp
+++ b/manifests/backup/mysqlbackup.pp
@@ -5,7 +5,7 @@ class mysql::backup::mysqlbackup (
   $backupdir,
   $backupdirmode = '0700',
   $backupdirowner = 'root',
-  $backupdirgroup = 'root',
+  $backupdirgroup = $mysql::params::root_group,
   $backupcompress = true,
   $backuprotate = 30,
   $ignore_events = true,

--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -5,7 +5,7 @@ class mysql::backup::mysqldump (
   $backupdir,
   $backupdirmode = '0700',
   $backupdirowner = 'root',
-  $backupdirgroup = 'root',
+  $backupdirgroup = $mysql::params::root_group,
   $backupcompress = true,
   $backuprotate = 30,
   $ignore_events = true,
@@ -47,7 +47,7 @@ class mysql::backup::mysqldump (
     path    => '/usr/local/sbin/mysqlbackup.sh',
     mode    => '0700',
     owner   => 'root',
-    group   => 'root',
+    group   => $mysql::params::root_group,
     content => template('mysql/mysqlbackup.sh.erb'),
   }
 

--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -6,7 +6,7 @@ class mysql::backup::xtrabackup (
   $backupmethod = 'mysqldump',
   $backupdirmode = '0700',
   $backupdirowner = 'root',
-  $backupdirgroup = 'root',
+  $backupdirgroup = $mysql::params::root_group,
   $backupcompress = true,
   $backuprotate = 30,
   $ignore_events = true,

--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -1,4 +1,8 @@
+<%- if @kernel == 'Linux' -%>
 #!/bin/bash
+<%- else -%>
+#!/bin/sh
+<%- end -%>
 #
 # MySQL Backup Script
 #  Dumps mysql databases to a file for another backup tool to pick up.
@@ -27,7 +31,9 @@ PATH=<%= @execpath %>
 
 
 
+<%- if @kernel == 'Linux' -%>
 set -o pipefail
+<%- end -%>
 
 cleanup()
 {


### PR DESCRIPTION
The `mysql::backup::*` classes still use the hardcoded group name `root`, which is not available on FreeBSD systems. This patch changes this to use the param `mysql::params::root_group` instead. Besides that it utilizes `/bin/sh` instead of `/bin/bash` on systems other than Linux.