### PR TITLE
MODULES-1928 - allow log-error to be undef

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -18,10 +18,12 @@ class mysql::server::service {
     $mysqluser = $options['mysqld']['user']
   }
 
-  file { $options['mysqld']['log-error']:
-    ensure => present,
-    owner  => $mysqluser,
-    group  => $::mysql::server::mysql_group,
+  if $options['mysqld']['log-error'] {
+    file { $options['mysqld']['log-error']:
+      ensure => present,
+      owner  => $mysqluser,
+      group  => $::mysql::server::mysql_group,
+    }
   }
 
   service { 'mysqld':

--- a/spec/acceptance/mysql_server_spec.rb
+++ b/spec/acceptance/mysql_server_spec.rb
@@ -51,5 +51,18 @@ describe 'mysql class' do
       apply_manifest(pp, :catch_changes => true)
     end
   end
+
+  describe 'configuration needed for syslog' do
+    it 'should work with no errors' do
+      pp = <<-EOS
+        class { 'mysql::server':
+          override_options => { 'mysqld' => { 'log-error' => undef }, 'mysqld_safe' => { 'log-error' => false, 'syslog' => true }},
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+  end
 end
 


### PR DESCRIPTION
Wrap the file resource so that this doesn't explode if log-error is
undef. This is required for syslogging.