### PR TITLE
Bugfix on Xtrabackup crons

### DIFF
--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -19,27 +19,23 @@ class mysql::backup::xtrabackup (
   $execpath           = '/usr/bin:/usr/sbin:/bin:/sbin',
 ) {
 
-  mysql_user { "${backupuser}@localhost":
-    ensure        => $ensure,
-    password_hash => mysql_password($backuppassword),
-    require       => Class['mysql::server::root_password'],
-  }
-
   package{ 'percona-xtrabackup':
     ensure  => $ensure,
   }
+
   cron { 'xtrabackup-weekly':
     ensure  => $ensure,
-    command => 'innobackupex $backupdir',
+    command => "innobackupex ${backupdir}",
     user    => 'root',
     hour    => $time[0],
     minute  => $time[1],
     weekday => 0,
     require => Package['percona-xtrabackup'],
   }
+
   cron { 'xtrabackup-daily':
     ensure  => $ensure,
-    command => 'innobackupex --incremental $backupdir',
+    command => "innobackupex --incremental ${backupdir}",
     user    => 'root',
     hour    => $time[0],
     minute  => $time[1],
@@ -54,5 +50,4 @@ class mysql::backup::xtrabackup (
     owner  => $backupdirowner,
     group  => $backupdirgroup,
   }
-
 }


### PR DESCRIPTION
I did a simple modification in order to correctly retrieve the value of $backupdir into the crontab definition.