### PR TITLE
Split package installation and database install

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -51,6 +51,7 @@ class mysql::server (
 
   include '::mysql::server::install'
   include '::mysql::server::config'
+  include '::mysql::server::installdb'
   include '::mysql::server::service'
   include '::mysql::server::root_password'
   include '::mysql::server::providers'
@@ -65,24 +66,18 @@ class mysql::server (
   anchor { 'mysql::server::end': }
 
   if $restart {
-    Anchor['mysql::server::start'] ->
-    Class['mysql::server::install'] ->
-    # Only difference between the blocks is that we use ~> to restart if
-    # restart is set to true.
     Class['mysql::server::config'] ~>
-    Class['mysql::server::service'] ->
-    Class['mysql::server::root_password'] ->
-    Class['mysql::server::providers'] ->
-    Anchor['mysql::server::end']
-  } else {
-    Anchor['mysql::server::start'] ->
-    Class['mysql::server::install'] ->
-    Class['mysql::server::config'] ->
-    Class['mysql::server::service'] ->
-    Class['mysql::server::root_password'] ->
-    Class['mysql::server::providers'] ->
-    Anchor['mysql::server::end']
+    Class['mysql::server::service']
   }
+
+  Anchor['mysql::server::start'] ->
+  Class['mysql::server::install'] ->
+  Class['mysql::server::config'] ->
+  Class['mysql::server::installdb'] ->
+  Class['mysql::server::service'] ->
+  Class['mysql::server::root_password'] ->
+  Class['mysql::server::providers'] ->
+  Anchor['mysql::server::end']
 
 
 }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -8,32 +8,6 @@ class mysql::server::install {
       install_options => $mysql::server::install_options,
       name            => $mysql::server::package_name,
     }
-
-    # Build the initial databases.
-    $mysqluser = $mysql::server::options['mysqld']['user']
-    $datadir = $mysql::server::options['mysqld']['datadir']
-    $basedir = $mysql::server::options['mysqld']['basedir']
-    $config_file = $mysql::server::config_file
-
-    if $mysql::server::manage_config_file {
-      $install_db_args = "--basedir=${basedir} --defaults-extra-file=${config_file} --datadir=${datadir} --user=${mysqluser}"
-    } else {
-      $install_db_args = "--basedir=${basedir} --datadir=${datadir} --user=${mysqluser}"
-    }
-
-    exec { 'mysql_install_db':
-      command   => "mysql_install_db ${install_db_args}",
-      creates   => "${datadir}/mysql",
-      logoutput => on_failure,
-      path      => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
-      require   => Package['mysql-server'],
-    }
-
-    if $mysql::server::restart {
-      Exec['mysql_install_db'] {
-        notify => Class['mysql::server::service'],
-      }
-    }
   }
 
 }

--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -1,0 +1,33 @@
+#
+class mysql::server::installdb {
+
+  if $mysql::server::package_manage {
+
+    # Build the initial databases.
+    $mysqluser = $mysql::server::options['mysqld']['user']
+    $datadir = $mysql::server::options['mysqld']['datadir']
+    $basedir = $mysql::server::options['mysqld']['basedir']
+    $config_file = $mysql::server::config_file
+
+    if $mysql::server::manage_config_file {
+      $install_db_args = "--basedir=${basedir} --defaults-extra-file=${config_file} --datadir=${datadir} --user=${mysqluser}"
+    } else {
+      $install_db_args = "--basedir=${basedir} --datadir=${datadir} --user=${mysqluser}"
+    }
+
+    exec { 'mysql_install_db':
+      command   => "mysql_install_db ${install_db_args}",
+      creates   => "${datadir}/mysql",
+      logoutput => on_failure,
+      path      => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
+      require   => Package['mysql-server'],
+    }
+
+    if $mysql::server::restart {
+      Exec['mysql_install_db'] {
+        notify => Class['mysql::server::service'],
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
The current install pattern used by this module is the following:
1. Install package
2. Install the DB
3. Make the config files

In some cases this prevents MySQL to start, because some variables in
the config file have an impact on the DB installation.

Example with a custom innodb_data_file_path:
[ERROR] InnoDB: space header page consists of zero bytes in data file
/var/lib/mysql/ibdata

This commit changes the order to do:
1. Install package
2. Make the config files
3. Install the DB