### PR TITLE
Added $onlyif_empty to db.pp to facilitate once-only import of sql datab...

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -70,7 +70,7 @@ define mysql::db (
         timeout     => $import_timeout,
         onlyif      => $onlyif_empty ? {
           true    => "test $(mysql ${dbname} -e 'show tables' |wc -l ) -eq 0",
-          default => "false",
+          default => "test $(false)",
         }
       }
     }


### PR DESCRIPTION
...ase file, rather than import at every puppet run.

I modified db.pp to conditionally check if there are any existing tables in the database, if the schema already has tables then we may not wish to import the specified sql flat file.