### PR TITLE
MODULES-1981: Revoke and grant difference of old and new privileges

### DIFF
--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -96,18 +96,20 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
     exists? ? (return true) : (return false)
   end
 
-  def revoke(user, table)
+  def revoke(user, table, revoke_privileges = ['ALL'])
     user_string = self.class.cmd_user(user)
     table_string = self.class.cmd_table(table)
-
+    priv_string = self.class.cmd_privs(revoke_privileges)
     # revoke grant option needs to be a extra query, because
     # "REVOKE ALL PRIVILEGES, GRANT OPTION [..]" is only valid mysql syntax
     # if no ON clause is used.
     # It hast to be executed before "REVOKE ALL [..]" since a GRANT has to
     # exist to be executed successfully
-    query = "REVOKE GRANT OPTION ON #{table_string} FROM #{user_string}"
-    mysql([defaults_file, '-e', query].compact)
-    query = "REVOKE ALL ON #{table_string} FROM #{user_string}"
+    if revoke_privileges.include? 'ALL'
+      query = "REVOKE GRANT OPTION ON #{table_string} FROM #{user_string}"
+      mysql([defaults_file, '-e', query].compact)
+    end
+    query = "REVOKE #{priv_string} ON #{table_string} FROM #{user_string}"
     mysql([defaults_file, '-e', query].compact)
   end
 
@@ -129,11 +131,28 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
 
   mk_resource_methods
 
-  def privileges=(privileges)
-    revoke(@property_hash[:user], @property_hash[:table])
-    grant(@property_hash[:user], @property_hash[:table], privileges, @property_hash[:options])
-    @property_hash[:privileges] = privileges
+  def diff_privileges(privileges_old, privileges_new)
+    diff = {:revoke => Array.new, :grant => Array.new}
+    if privileges_new.include? 'ALL' or privileges_old.include? 'ALL'
+      diff[:revoke] = privileges_old
+      diff[:grant] = privileges_new
+    else
+      diff[:revoke] = privileges_old - privileges_new
+      diff[:grant] = privileges_new - privileges_old
+    end
+    return diff
+  end
 
+  def privileges=(privileges)
+    diff = diff_privileges(@property_hash[:privileges], privileges)
+    if not diff[:revoke].empty?
+      revoke(@property_hash[:user], @property_hash[:table], diff[:revoke])
+    end
+    if not diff[:grant].empty?
+      grant(@property_hash[:user], @property_hash[:table], diff[:grant], @property_hash[:options])
+    end
+    @property_hash[:privileges] = privileges
+    mysql([defaults_file, '-NBe', 'FLUSH PRIVILEGES'].compact)
     self.privileges
   end
 


### PR DESCRIPTION
We have 2 problems with current privileges change behaviour with puppetlabs-mysql:
1. If user doesn't have GRANT privilege, puppet will fail
2. if we want to add ALTER privilege (for example) to ['SELECT', 'INSERT'], we don't want to REVOKE SELECT, INSERT before.