### PR TITLE
Fixed for mariadb

### DIFF
--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -11,8 +11,7 @@ class mysql::server::installdb {
 
     if $mysql::server::manage_config_file {
       $install_db_args = "--basedir=${basedir} --defaults-extra-file=${config_file} --datadir=${datadir} --user=${mysqluser}"
-    } else {
-      $install_db_args = "--basedir=${basedir} --datadir=${datadir} --user=${mysqluser}"
+
     }
 
     exec { 'mysql_install_db':
@@ -20,7 +19,7 @@ class mysql::server::installdb {
       creates   => "${datadir}/mysql",
       logoutput => on_failure,
       path      => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
-      require   => Package['mysql-server'],
+      require   => Package[$mysql::params::server_package_name],
     }
 
     if $mysql::server::restart {

--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -19,7 +19,7 @@ class mysql::server::installdb {
       creates   => "${datadir}/mysql",
       logoutput => on_failure,
       path      => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
-      require   => Package[$mysql::params::server_package_name],
+      require   => Package[$mysql::server::package_name],
     }
 
     if $mysql::server::restart {

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -31,7 +31,7 @@ class mysql::server::service {
     name     => $mysql::server::service_name,
     enable   => $mysql::server::real_service_enabled,
     provider => $mysql::server::service_provider,
-    require  => Package['mysql-server'],
+    require  => Package[$mysql::params::server_package_name],
   }
 
   # only establish ordering between config file and service if

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -31,7 +31,7 @@ class mysql::server::service {
     name     => $mysql::server::service_name,
     enable   => $mysql::server::real_service_enabled,
     provider => $mysql::server::service_provider,
-    require  => Package[$mysql::params::server_package_name],
+    require  => Package[$mysql::server::service_name],
   }
 
   # only establish ordering between config file and service if


### PR DESCRIPTION
There were 2 hardcoded service['mysql-server'] that were replaced with the variable, making this module compatible with mariadb on centos7.