### PR TITLE
Generate configuration file before the package installation

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -153,6 +153,7 @@ class mysql::params {
       $server_package_name     = 'mysql-server'
 
       $basedir                 = '/usr'
+      $config_dir	       = '/etc/mysql'
       $config_file             = '/etc/mysql/my.cnf'
       $includedir              = '/etc/mysql/conf.d'
       $datadir                 = '/var/lib/mysql'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,5 +1,6 @@
 # Class: mysql::server:  See README.md for documentation.
 class mysql::server (
+  $config_dir		   = $mysql::params::config_dir,
   $config_file             = $mysql::params::config_file,
   $includedir              = $mysql::params::includedir,
   $install_options         = undef,
@@ -62,6 +63,12 @@ class mysql::server (
   if $remove_default_accounts {
     class { '::mysql::server::account_security':
       require => Anchor['mysql::server::end'],
+    }
+  }
+
+  if $::osfamily == 'Debian' {
+    file { $config_dir:
+      ensure => directory,
     }
   }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -74,8 +74,8 @@ class mysql::server (
   }
 
   Anchor['mysql::server::start'] ->
-  Class['mysql::server::install'] ->
   Class['mysql::server::config'] ->
+  Class['mysql::server::install'] ->
   Class['mysql::server::installdb'] ->
   Class['mysql::server::service'] ->
   Class['mysql::server::root_password'] ->


### PR DESCRIPTION
Hi.
The Ubuntu (I use 14.04) runs dpkg-reconfigure mysql-server-5.x after package installation. After that mysql::server module writes configuration file and if you change the innodb_data_file_path, you can't start mysql server anymore.

The current install pattern used by this module is the following:
1. Install package
2. Make the config files
3. Install the DB

I think for Debian/Ubuntu installation order should be like this one:
1. Make the config files
2. Install package
3. Install the DB