### PR TITLE
fix for #718: used service_name instead package_name

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -31,7 +31,7 @@ class mysql::server::service {
     name     => $mysql::server::service_name,
     enable   => $mysql::server::real_service_enabled,
     provider => $mysql::server::service_provider,
-    require  => Package[$mysql::server::service_name],
+    require  => Package[$mysql::server::package_name],
   }
 
   # only establish ordering between config file and service if


### PR DESCRIPTION
fix a mistake introduced in #718.