### PR TITLE
length check for usernames should take mysql version into consideration

### DIFF
--- a/lib/puppet/type/mysql_grant.rb
+++ b/lib/puppet/type/mysql_grant.rb
@@ -78,7 +78,14 @@ Puppet::Type.newtype(:mysql_grant) do
         raise(ArgumentError, "Invalid database user #{value}")
       end
 
-      raise(ArgumentError, 'MySQL usernames are limited to a maximum of 16 characters') unless user_part.size <= 16
+      mysql_version = Facter.value(:mysql_version)
+      unless mysql_version.nil?
+        if Puppet::Util::Package.versioncmp(mysql_version, '10.0.0') < 0 and user_part.size > 16
+          raise(ArgumentError, 'MySQL usernames are limited to a maximum of 16 characters')
+        elsif Puppet::Util::Package.versioncmp(mysql_version, '10.0.0') > 0 and user_part.size > 80
+          raise(ArgumentError, 'MySQL usernames are limited to a maximum of 80 characters')
+        end
+      end
     end
   end
 

--- a/lib/puppet/type/mysql_user.rb
+++ b/lib/puppet/type/mysql_user.rb
@@ -26,7 +26,14 @@ Puppet::Type.newtype(:mysql_user) do
         raise(ArgumentError, "Invalid database user #{value}")
       end
 
-      raise(ArgumentError, 'MySQL usernames are limited to a maximum of 16 characters') if user_part.size > 16
+      mysql_version = Facter.value(:mysql_version)
+      unless mysql_version.nil?
+        if Puppet::Util::Package.versioncmp(mysql_version, '10.0.0') < 0 and user_part.size > 16
+          raise(ArgumentError, 'MySQL usernames are limited to a maximum of 16 characters')
+        elsif Puppet::Util::Package.versioncmp(mysql_version, '10.0.0') > 0 and user_part.size > 80
+          raise(ArgumentError, 'MySQL usernames are limited to a maximum of 80 characters')
+        end
+      end
     end
 
     munge do |value|

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -34,6 +34,7 @@ usvn_user@localhost
   before :each do
     # Set up the stubs for an instances call.
     Facter.stubs(:value).with(:root_home).returns('/root')
+    Facter.stubs(:value).with(:mysql_version).returns('5.6.24')
     Puppet::Util.stubs(:which).with('mysql').returns('/usr/bin/mysql')
     File.stubs(:file?).with('/root/.my.cnf').returns(true)
     provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns('joe@localhost')

--- a/spec/unit/puppet/type/mysql_user_spec.rb
+++ b/spec/unit/puppet/type/mysql_user_spec.rb
@@ -2,10 +2,22 @@ require 'puppet'
 require 'puppet/type/mysql_user'
 describe Puppet::Type.type(:mysql_user) do
 
-  it 'should fail with a long user name' do
-    expect {
-      Puppet::Type.type(:mysql_user).new({:name => '12345678901234567@localhost', :password_hash => 'pass'})
-    }.to raise_error /MySQL usernames are limited to a maximum of 16 characters/
+  context "On MySQL 5.x" do
+    let(:facts) {{ :mysql_version => '5.6.24' }}
+    it 'should fail with a long user name' do
+      expect {
+        Puppet::Type.type(:mysql_user).new({:name => '12345678901234567@localhost', :password_hash => 'pass'})
+      }.to raise_error /MySQL usernames are limited to a maximum of 16 characters/
+    end
+  end
+
+  context "On MariaDB 10.0.0+" do
+    let(:facts) {{ :mysql_version => '10.0.19' }}
+    it 'should succeed with a long user name on MariaDB' do
+      expect {
+        Puppet::Type.type(:mysql_user).new({:name => '12345678901234567@localhost', :password_hash => 'pass'})
+      }.to raise_error /MySQL usernames are limited to a maximum of 16 characters/
+    end
   end
 
   it 'should require a name' do
@@ -60,6 +72,7 @@ describe Puppet::Type.type(:mysql_user) do
   end
 
   context 'using a quoted 16 char username' do
+    let(:facts) {{ :mysql_version => '5.6.24' }}
     before :each do
       @user = Puppet::Type.type(:mysql_user).new(:name => '"debian-sys-maint"@localhost', :password_hash => 'pass')
     end
@@ -70,6 +83,7 @@ describe Puppet::Type.type(:mysql_user) do
   end
 
   context 'using a quoted username that is too long ' do
+    let(:facts) {{ :mysql_version => '5.6.24' }}
     it 'should fail with a size error' do
       expect {
         Puppet::Type.type(:mysql_user).new(:name => '"debian-sys-maint2"@localhost', :password_hash => 'pass')


### PR DESCRIPTION
Starting MariaDB 10.0.0, usernames are now 80 long.
Our mysql_user and mysql_grant types now take that into consideration.