### PR TITLE
spec_helper_acceptance: Remove conflicting yum install

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -20,7 +20,6 @@ RSpec.configure do |c|
       # Required for binding tests.
       if fact('osfamily') == 'RedHat'
         version = fact("operatingsystemmajrelease")
-        shell("yum localinstall -y http://yum.puppetlabs.com/puppetlabs-release-el-#{version}.noarch.rpm")
         if fact('operatingsystemmajrelease') =~ /7/ || fact('operatingsystem') =~ /Fedora/
           shell("yum install -y bzip2")
         end


### PR DESCRIPTION
puppetlabs-release is not required anymore. run_puppet_install_helper
takes care of all that.