### PR TITLE
(maint) Package was renamed in server::install  - As a result of rename several underlying dependencies broke   this is to update the require dependencies

### DIFF
--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -19,7 +19,7 @@ class mysql::server::installdb {
       creates   => "${datadir}/mysql",
       logoutput => on_failure,
       path      => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
-      require   => Package[$mysql::server::package_name],
+      require   => Package['mysql-server'],
     }
 
     if $mysql::server::restart {

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -31,7 +31,7 @@ class mysql::server::service {
     name     => $mysql::server::service_name,
     enable   => $mysql::server::real_service_enabled,
     provider => $mysql::server::service_provider,
-    require  => Package[$mysql::server::package_name],
+    require  => Package['mysql-server'],
   }
 
   # only establish ordering between config file and service if


### PR DESCRIPTION
Change was located here, https://github.com/puppetlabs/puppetlabs-mysql/commit/f5a693b82628983b80a33c0dfc25d633c41001c8 