### PR TITLE
fix Evaluation Error with future parser

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -12,7 +12,7 @@ class mysql::server::service {
     $service_ensure = undef
   }
 
-  if $mysql::server::override_options['mysqld'] and $mysql::server::override_options['mysqld']['user'] {
+  if $mysql::server::override_options and $mysql::server::override_options['mysqld'] and $mysql::server::override_options['mysqld']['user'] {
     $mysqluser = $mysql::server::override_options['mysqld']['user']
   } else {
     $mysqluser = $options['mysqld']['user']


### PR DESCRIPTION
With parser = future this fails with
```Error: Evaluation Error: Operator '[]' is not applicable to a Nil Object.```
We need to first check if $mysql::server::override_options is set to prevent this problem.