### PR TITLE
Add Solaris support to MySQL module

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,6 +804,7 @@ This module has been tested on:
 * Ubuntu 10.04, 12.04, 14.04
 * Scientific Linux 5, 6
 * SLES 11
+* Solaris 11.2, 11.3, 12.0
 
 Testing on other platforms has been minimal and cannot be guaranteed.
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -284,6 +284,32 @@ class mysql::params {
       $daemon_dev_package_name     = undef
     }
 
+    'Solaris': {
+      $client_package_name = 'database/mysql-55/client'
+      $server_package_name = 'database/mysql-55'
+      $basedir             = undef
+      $config_file         = '/etc/mysql/5.5/my.cnf'
+      $datadir             = '/var/mysql/5.5/data'
+      $log_error           = "/var/mysql/5.5/data/${::hostname}.err"
+      $pidfile             = "/var/mysql/5.5/data/${::hostname}.pid"
+      $root_group          = 'bin'
+      $server_service_name = 'application/database/mysql:version_55'
+      $socket              = '/tmp/mysql.sock'
+      $ssl_ca              = undef
+      $ssl_cert            = undef
+      $ssl_key             = undef
+      $tmpdir              = '/tmp'
+      # mysql::bindings
+      $java_package_name   = undef
+      $perl_package_name   = undef
+      $php_package_name    = 'web/php-53/extension/php-mysql'
+      $python_package_name = 'library/python/python-mysql'
+      $ruby_package_name   = undef
+      # The libraries installed by these packages are included in client and server packages, no installation required.
+      $client_dev_package_name     = undef
+      $daemon_dev_package_name     = undef
+    }
+
     default: {
       case $::operatingsystem {
         'Amazon': {

--- a/metadata.json
+++ b/metadata.json
@@ -62,6 +62,14 @@
         "12.04",
         "14.04"
       ]
+    },
+    {
+      "operatingsystem": "Solaris",
+      "operatingsystemrelease": [
+        "11.2",
+        "11.3",
+        "12.0"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
This adds support for Solaris 11.2, 11.3 and 12.0 to the puppetlabs-mysql module.