### PR TITLE
Don't explode if macaddress isn't set

### DIFF
--- a/lib/facter/mysql_server_id.rb
+++ b/lib/facter/mysql_server_id.rb
@@ -4,6 +4,6 @@ end
 
 Facter.add("mysql_server_id") do
   setcode do
-    get_mysql_id
+    get_mysql_id rescue nil
   end
 end


### PR DESCRIPTION
Sometimes the macaddress fact fails, for example sometimes in a Docker
container. We shouldn't clutter up reports with spurious warnings in
that case.