### PR TITLE
(maint) don't print diff root password in diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ spec/fixtures/
 coverage/
 .idea/
 *.iml
+log/

--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -17,6 +17,10 @@ class mysql::server::root_password {
       owner   => 'root',
       mode    => '0600',
     }
+    # show_diff was added with puppet 3.0
+    if versioncmp($::puppetversion, '3.0') <= 0 {
+      File["${::root_home}/.my.cnf"] { show_diff => false }
+    }
     if $mysql::server::create_root_user == true {
       Mysql_user['root@localhost'] -> File["${::root_home}/.my.cnf"]
     }


### PR DESCRIPTION
For puppet versions that support it, suppress diffing root's password.