### PR TITLE
Remove sles 10 from metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -43,7 +43,6 @@
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "10 SP4",
         "11 SP1",
         "12"
       ]


### PR DESCRIPTION
SLES 10 has mysql 5.0.26 in its repo, and 5.0.40 is the oldest that this
module even has a hope to work on, so it has never worked.