### PR TITLE
[#puppethack] do not require mysql::server when using mysql::db

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,21 @@ mysql::db { 'mydb':
 To add custom MySQL configuration, drop additional files into
 `includedir`. Dropping files into `includedir` allows you to override settings or add additional ones, which is helpful if you choose not to use `override_options` in `mysql::server`. The `includedir` location is by default set to /etc/mysql/conf.d.
 
+###Working with an existing server
+
+It is possible to use the MySQL module to instantiate databases and
+users on an existing MySQL server.  For this to work, you will need an
+appropriate `.my.cnf` in `root`'s home directory containing the remote
+server address and credentials.  For example:
+
+    [client]
+    user=root
+    host=localhost
+    password=secret
+
+When working with a remote server, you will *not* use the
+`mysql::server` class in your Puppet manifests.
+
 ##Reference
 
 ###Classes

--- a/lib/puppet/type/mysql_database.rb
+++ b/lib/puppet/type/mysql_database.rb
@@ -4,6 +4,7 @@ Puppet::Type.newtype(:mysql_database) do
   ensurable
 
   autorequire(:file) { '/root/.my.cnf' }
+  autorequire(:class) { 'mysql::server' }
 
   newparam(:name, :namevar => true) do
     desc 'The name of the MySQL database to manage.'

--- a/lib/puppet/type/mysql_user.rb
+++ b/lib/puppet/type/mysql_user.rb
@@ -5,6 +5,7 @@ Puppet::Type.newtype(:mysql_user) do
   ensurable
 
   autorequire(:file) { '/root/.my.cnf' }
+  autorequire(:class) { 'mysql::server' }
 
   newparam(:name, :namevar => true) do
     desc "The name of the user. This uses the 'username@hostname' or username@hostname."

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -34,7 +34,7 @@ define mysql::db (
     charset  => $charset,
     collate  => $collate,
     provider => 'mysql',
-    require  => [ Class['mysql::server'], Class['mysql::client'] ],
+    require  => [ Class['mysql::client'] ],
   }
   ensure_resource('mysql_database', $dbname, $db_resource)
 
@@ -42,7 +42,6 @@ define mysql::db (
     ensure        => $ensure,
     password_hash => mysql_password($password),
     provider      => 'mysql',
-    require       => Class['mysql::server'],
   }
   ensure_resource('mysql_user', "${user}@${host}", $user_resource)
 
@@ -52,7 +51,10 @@ define mysql::db (
       provider   => 'mysql',
       user       => "${user}@${host}",
       table      => $table,
-      require    => [Mysql_database[$dbname], Mysql_user["${user}@${host}"], Class['mysql::server'] ],
+      require    => [
+        Mysql_database[$dbname],
+        Mysql_user["${user}@${host}"],
+      ],
     }
 
     $refresh = ! $enforce_sql


### PR DESCRIPTION
this is a rebase and fix up of https://github.com/puppetlabs/puppetlabs-mysql/pull/586
this pr closes MODULES-1685.