### PR TITLE
Ensure idempotency between Puppet runs

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -37,9 +37,10 @@ class mysql::server::config {
 
   if $mysql::server::manage_config_file  {
     file { 'mysql-config-file':
-      path    => $mysql::server::config_file,
-      content => template('mysql/my.cnf.erb'),
-      mode    => '0644',
+      path                    => $mysql::server::config_file,
+      content                 => template('mysql/my.cnf.erb'),
+      mode                    => '0644',
+      selinux_ignore_defaults => true,
     }
   }
 

--- a/spec/classes/mycnf_template_spec.rb
+++ b/spec/classes/mycnf_template_spec.rb
@@ -11,7 +11,8 @@ describe 'mysql::server' do
             let(:params) {{ :override_options => { 'mysqld' => { 'socket' => '/var/lib/mysql/mysql.sock' } } }}
             it do
               is_expected.to contain_file('mysql-config-file').with({
-                :mode => '0644',
+                :mode                    => '0644',
+                :selinux_ignore_defaults => true,
               }).with_content(/socket = \/var\/lib\/mysql\/mysql.sock/)
             end
           end


### PR DESCRIPTION
Running RHEL 7.1, puppetlabs-mysql is not idempotent.
After a second run, puppet tries to change the SElinux context:
/File[mysql-config-file]/seltype: seltype changed 'etc_t' to
'mysqld_etc_t'

Since packaging already manages SElinux labels, we should not let
Puppet doing it (default behavior).
This patch aims to set selinux_ignore_defaults to True for the
mysql-config-file File resource.

Thanks to that patch, Puppet will be indempotent between all runs on
RHEL platforms.