### PR TITLE
Fix show_diff already set on .my.cnf

### DIFF
--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -12,21 +12,12 @@ class mysql::server::root_password {
   }
 
   if $mysql::server::create_root_my_cnf == true and $mysql::server::root_password != 'UNSET' {
-    # Puppet 2.7 doesnt support show_diff
-    if versioncmp($::puppetversion, '3.0') <= 0 {
-      file { "${::root_home}/.my.cnf":
-        content   => template('mysql/my.cnf.pass.erb'),
-        owner     => 'root',
-        mode      => '0600',
-        show_diff => false,
-      }
-    } else {
-      file { "${::root_home}/.my.cnf":
-        content => template('mysql/my.cnf.pass.erb'),
-        owner   => 'root',
-        mode    => '0600',
-      }
+    file { "${::root_home}/.my.cnf":
+      content => template('mysql/my.cnf.pass.erb'),
+      owner   => 'root',
+      mode    => '0600',
     }
+
     # show_diff was added with puppet 3.0
     if versioncmp($::puppetversion, '3.0') <= 0 {
       File["${::root_home}/.my.cnf"] { show_diff => false }


### PR DESCRIPTION
show_diff is set twice on .my.cnf causing compilation error:

Parameter 'show_diff' is already set on File[/.my.cnf]

This patch removes one of them