### PR TITLE
Fix when not managing config file

### DIFF
--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -11,7 +11,8 @@ class mysql::server::installdb {
 
     if $mysql::server::manage_config_file {
       $install_db_args = "--basedir=${basedir} --defaults-extra-file=${config_file} --datadir=${datadir} --user=${mysqluser}"
-
+    } else {
+      $install_db_args = "--basedir=${basedir} --datadir=${datadir} --user=${mysqluser}"
     }
 
     exec { 'mysql_install_db':

--- a/spec/classes/mysql_server_spec.rb
+++ b/spec/classes/mysql_server_spec.rb
@@ -19,6 +19,11 @@ describe 'mysql::server' do
           it { is_expected.to contain_class('mysql::server::account_security') }
         end
 
+        context 'when not managing config file' do
+          let(:params) {{ :manage_config_file => false }}
+          it { is_expected.to compile.with_all_deps }
+        end
+
         context 'mysql::server::install' do
           it 'contains the package by default' do
             is_expected.to contain_package('mysql-server').with({


### PR DESCRIPTION
This code have been remove here https://github.com/puppetlabs/puppetlabs-mysql/commit/4bab65edcb98f82f87a4414840fe90ab81b6cea3#diff-0938042fe2382aeb10032aa7f8444995 but it is required otherwise we get an `Evaluation Error: Unknown variable: 'install_db_args'.` when using `manage_config_file = false`