### PR TITLE
Add possibility to override Mysql implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     * [Customizing Server Options](#customizing-server-options)
     * [Creating a Database](#creating-a-database)
     * [Custom Configuration](#custom-configuration)
+    * [Overriding Mysql Implementation](#overriding-mysql-implementation)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
 6. [Limitations - OS compatibility, etc.](#limitations)
 7. [Development - Guide for contributing to the module](#development)
@@ -25,7 +26,7 @@ The MySQL module manages both the installation and configuration of MySQL, as we
 ### Beginning with MySQL
 
 If you want a server installed with the default options you can run
-`include '::mysql::server'`. 
+`include '::mysql::server'`.
 
 If you need to customize options, such as the root
 password or `/etc/my.cnf` settings, then you must also pass in an override hash:
@@ -63,7 +64,7 @@ For items that you would traditionally represent as
 thing = X
 ~~~
 
-you can make an entry like `thing => true`, `thing => value`, or `thing => "` in the hash. Alternatively, you can pass an array, as `thing => ['value', 'value2']`, or list each `thing => value` separately on separate lines. 
+you can make an entry like `thing => true`, `thing => value`, or `thing => "` in the hash. Alternatively, you can pass an array, as `thing => ['value', 'value2']`, or list each `thing => value` separately on separate lines.
 
 MySQL doesn't care if 'thing' is alone or set to a value; it happily accepts both. To keep an option out of the my.cnf file --- e.g., when using `override_options` to revert to a default value --- you can pass `thing => undef`.
 
@@ -152,6 +153,18 @@ server address and credentials. For example:
 When working with a remote server, do *not* use the
 `mysql::server` class in your Puppet manifests.
 
+### Overriding Mysql Implementation
+
+Depending on the distribution a certain assumption is being made to which flavour of Mysql is to be used by default (Oracle Mysql, MariaDB, ... ).
+
+This can be overriden by specifing the provider_override option to the mysql::params class.
+
+~~~
+  class { 'mysql::params':
+    provider_override => 'mysql',
+  }
+~~~
+
 ## Reference
 
 ### Classes
@@ -209,7 +222,7 @@ The MySQL root password. Puppet attempts to set the root password and update `/r
 
 This is required if `create_root_user` or `create_root_my_cnf` are 'true'. If `root_password` is 'UNSET', then `create_root_user` and `create_root_my_cnf` are assumed to be false --- that is, the MySQL root user and `/root/.my.cnf` are not created.
 
-Password changes are supported; however, the old password must be set in `/root/.my.cnf`. Effectively, Puppet uses the old password, configured in `/root/my.cnf`, to set the new password in MySQL, and then updates `/root/.my.cnf` with the new password. 
+Password changes are supported; however, the old password must be set in `/root/.my.cnf`. Effectively, Puppet uses the old password, configured in `/root/my.cnf`, to set the new password in MySQL, and then updates `/root/.my.cnf` with the new password.
 
 ##### `old_root_password`
 
@@ -293,7 +306,7 @@ The provider to use to manage the service. For Ubuntu, defaults to 'upstart'; ot
 
 ##### `users`
 
-Optional hash of users to create, which are passed to [mysql_user](#mysql_user). 
+Optional hash of users to create, which are passed to [mysql_user](#mysql_user).
 
 ~~~
 users => {
@@ -310,7 +323,7 @@ users => {
 
 ##### `grants`
 
-Optional hash of grants, which are passed to [mysql_grant](#mysql_grant). 
+Optional hash of grants, which are passed to [mysql_grant](#mysql_grant).
 
 ~~~
 grants => {
@@ -434,7 +447,7 @@ The password to create for MySQL monitoring.
 
 ##### `mysql_monitor_hostname`
 
-The hostname from which the monitoring user requests are allowed access. 
+The hostname from which the monitoring user requests are allowed access.
 
 #### mysql::server::mysqltuner
 
@@ -489,11 +502,11 @@ Pass `install_options` array to managed package resources. You must pass the [ap
 ##### `client_dev_package_ensure`
 
 Whether the package should be present, absent, or a specific version. Valid values are 'present', 'absent', or 'x.y.z'. Only applies if `client_dev => true`.
- 
+
 ##### `client_dev_package_name`
 
 The name of the client_dev package to install. Only applies if `client_dev => true`.
- 
+
 ##### `client_dev_package_provider`
 
 The provider to use to install the client_dev package. Only applies if `client_dev => true`.
@@ -537,7 +550,7 @@ The provider to use to install the Perl package. Only applies if `perl_enable =>
 ##### `php_package_ensure`
 
 Whether the package should be present, absent, or a specific version. Valid values are 'present', 'absent', or 'x.y.z'. Only applies if `php_enable => true`.
- 
+
 ##### `php_package_name`
 
 The name of the PHP package to install. Only applies if `php_enable => true`.
@@ -607,7 +620,7 @@ mysql_database { 'mysql':
 ##### `user`
 
 The user for the database you're creating.
- 
+
 ##### `password`
 
 The password for $user for the database you're creating.
@@ -615,7 +628,7 @@ The password for $user for the database you're creating.
 ##### `dbname`
 
 The name of the database to create. Defaults to $name.
- 
+
 ##### `charset`
 
 The character set for the database. Defaults to 'utf8'.
@@ -623,7 +636,7 @@ The character set for the database. Defaults to 'utf8'.
 ##### `collate`
 
 The collation for the database. Defaults to 'utf8_general_ci'.
- 
+
 ##### `host`
 
 The host to use as part of user@host for grants. Defaults to 'localhost'.
@@ -639,10 +652,10 @@ The path to the sqlfile you want to execute. This can be single file specified a
 ##### `enforce_sql`
 
 Specify whether executing the sqlfiles should happen on every run. If set to 'false', sqlfiles only run once. Valid values are 'true', 'false'. Defaults to 'false'.
- 
+
 ##### `ensure`
 
-Specify whether to create the database. Valid values are 'present', 'absent'. Defaults to 'present'. 
+Specify whether to create the database. Valid values are 'present', 'absent'. Defaults to 'present'.
 
 ##### `import_timeout`
 
@@ -668,7 +681,7 @@ The CHARACTER SET setting for the database. Defaults to ':utf8'.
 
 ##### `collate`
 
-The COLLATE setting for the database. Defaults to ':utf8_general_ci'. 
+The COLLATE setting for the database. Defaults to ':utf8_general_ci'.
 
 #### mysql_user
 
@@ -751,7 +764,7 @@ Whether the resource is present. Valid values are 'present', 'absent'. Defaults 
 
 ##### `name`
 
-Name to describe the grant. Must in a 'user/table' format. 
+Name to describe the grant. Must in a 'user/table' format.
 
 ##### `privileges`
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,7 @@
 # Private class: See README.md.
-class mysql::params {
+class mysql::params (
+  $provider_override = undef,
+) {
 
   $manage_config_file     = true
   $purge_conf_dir         = false
@@ -34,24 +36,28 @@ class mysql::params {
 
   case $::osfamily {
     'RedHat': {
-      case $::operatingsystem {
-        'Fedora': {
-          if versioncmp($::operatingsystemrelease, '19') >= 0 or $::operatingsystemrelease == 'Rawhide' {
-            $provider = 'mariadb'
-          } else {
+      if $provider_override == undef {
+        case $::operatingsystem {
+          'Fedora': {
+            if versioncmp($::operatingsystemrelease, '19') >= 0 or $::operatingsystemrelease == 'Rawhide' {
+              $provider = 'mariadb'
+            } else {
+              $provider = 'mysql'
+            }
+          }
+          /^(RedHat|CentOS|Scientific|OracleLinux)$/: {
+            if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
+              $provider = 'mariadb'
+            } else {
+              $provider = 'mysql'
+            }
+          }
+          default: {
             $provider = 'mysql'
           }
         }
-        /^(RedHat|CentOS|Scientific|OracleLinux)$/: {
-          if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
-            $provider = 'mariadb'
-          } else {
-            $provider = 'mysql'
-          }
-        }
-        default: {
-          $provider = 'mysql'
-        }
+      } else {
+        $provider = $provider_override
       }
 
       if $provider == 'mariadb' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,12 @@ class mysql::params (
   $daemon_dev_package_ensure   = 'present'
   $daemon_dev_package_provider = undef
 
+  # Validate provider_override value
+  if $provider_override != undef {
+    if ! $provider_override =~ /^(mariadb|mysql)$/ {
+      fail('Invalid provider_override value passed. Only \'mariadb\' or \'mysql\' allowed.')
+    }
+  }
 
   case $::osfamily {
     'RedHat': {


### PR DESCRIPTION
In some cases a different flavour of Mysql is required.

Example:  default on RHEL 7 is MariaDB, but Oracle Mysql is required due to support contracts.

Signed-off-by: Christophe Vanlancker christophe.vanlancker@inuits.eu
