### PR TITLE
Ported to Windows.

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -22,8 +22,12 @@ class mysql::client (
 
   # Anchor pattern workaround to avoid resources of mysql::client::install to
   # "float off" outside mysql::client
+  # JOE
+  # Did this to avoid:
+  # Error: Could not apply complete catalog: Found 1 dependency cycle:
+  # (Anchor[mysql::client::end] => Class[Mysql::Client] => Anchor[mysql::db_quartz::end] => Mysql::Db[quartz] => Mysql::Db[repository] => Anchor[mysql::db_repository::begin] => Class[Mysql::Client] => Anchor[mysql::client::end])
   anchor { 'mysql::client::start': } ->
-    Class['mysql::client::install'] ->
+  #  Class['mysql::client::install'] ->
   anchor { 'mysql::client::end': }
 
 }

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -2,13 +2,14 @@
 class mysql::client::install {
 
   if $mysql::client::package_manage {
-
-    package { 'mysql_client':
-      ensure          => $mysql::client::package_ensure,
-      install_options => $mysql::client::install_options,
-      name            => $mysql::client::package_name,
-    }
-
+		if $::osfamily == 'Windows' {  
+			include mysql::server::install
+		} else {
+			package { 'mysql_client':
+				ensure =>          $mysql::client::package_ensure,
+        install_options => $mysql::client::install_options,
+				name   =>          $mysql::client::package_name,
+			}  
+		}
   }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -311,6 +311,36 @@ class mysql::params {
       $daemon_dev_package_name     = undef
     }
 
+    # Based on Debian. Needs Cygwin.
+    'Windows': {
+      warning('Experimental support for Windows.')
+      
+      $client_package_name = 'mysql-client'
+      $server_package_name = 'mysql'
+
+      $basedir             = '/usr'
+      $config_file         = '/etc/mysql/my.cnf'
+      $datadir             = 'C:/tools/mysql/current/data'
+      $log_error           = 'C:/tools/mysql/current'
+      $pidfile             = '/var/run/mysqld/mysqld.pid'
+      $root_group          = 'root'
+      $server_service_name = 'MySQL'
+      $socket              = '/var/run/mysqld/mysqld.sock'
+      $ssl_ca              = '/etc/mysql/cacert.pem'
+      $ssl_cert            = '/etc/mysql/server-cert.pem'
+      $ssl_key             = '/etc/mysql/server-key.pem'
+      $tmpdir              = '/tmp'
+      # mysql::bindings
+      $java_package_name   = 'libmysql-java'
+      $perl_package_name   = 'libdbd-mysql-perl'
+      $php_package_name    = 'php5-mysql'
+      $python_package_name = 'python-mysqldb'
+      $ruby_package_name   = $::lsbdistcodename ? {
+        'trusty'           => 'ruby-mysql',
+        default            => 'libmysql-ruby',
+      }
+    }
+
     default: {
       case $::operatingsystem {
         'Amazon': {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -11,11 +11,19 @@ class mysql::server::config {
   }
 
   if $includedir and $includedir != '' {
-    file { $includedir:
-      ensure  => directory,
-      mode    => '0755',
-      recurse => $mysql::server::purge_conf_dir,
-      purge   => $mysql::server::purge_conf_dir,
+    unless $::osfamily == 'Windows' {
+      
+      file { '/etc/mysql':
+        ensure => directory,
+        mode   => '0755',
+      }
+      
+      file { $includedir:
+        ensure  => directory,
+        mode    => '0755',
+        recurse => $mysql::server::purge_conf_dir,
+        purge   => $mysql::server::purge_conf_dir,
+      }
     }
   }
 

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -2,12 +2,20 @@
 class mysql::server::install {
 
   if $mysql::server::package_manage {
-
-    package { 'mysql-server':
-      ensure          => $mysql::server::package_ensure,
-      install_options => $mysql::server::install_options,
-      name            => $mysql::server::package_name,
-    }
-  }
-
+		if $::osfamily == 'Windows' { 
+			# You might have to install Chocolatey manually before this works.
+			package { 'mysql-server':
+				ensure => $mysql::server::package_ensure,
+				install_options => $mysql::server::install_options,
+				name   => $mysql::server::package_name,
+				provider => 'chocolatey',
+			} 
+		} else {
+			package { 'mysql-server':
+				ensure => $mysql::server::package_ensure,
+				install_options => $mysql::server::install_options,
+				name   => $mysql::server::package_name,
+			}
+		}
+	}
 }

--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -14,12 +14,14 @@ class mysql::server::installdb {
 
     }
 
-    exec { 'mysql_install_db':
-      command   => "mysql_install_db ${install_db_args}",
-      creates   => "${datadir}/mysql",
-      logoutput => on_failure,
-      path      => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
-      require   => Package['mysql-server'],
+    unless $::osfamily == 'Windows' {
+	    exec { 'mysql_install_db':
+	      command   => "mysql_install_db ${install_db_args}",
+	      creates   => "${datadir}/mysql",
+	      logoutput => on_failure,
+	      path      => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
+	      require   => Package['mysql-server'],
+	    }
     }
 
     if $mysql::server::restart {

--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -1,6 +1,13 @@
 #
 class mysql::server::root_password {
 
+  # JOE
+	if $::osfamily == 'Windows' {
+	  $exec_provider = 'cygwin'
+	} else { 
+	  $exec_provider = 'posix'
+	}
+  
   $options = $mysql::server::options
   $secret_file = $mysql::server::install_secret_file
 
@@ -15,7 +22,8 @@ class mysql::server::root_password {
   exec { 'remove install pass':
     command => $rm_pass_cmd,
     onlyif  => "test -f ${secret_file}",
-    path    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin'
+    path    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
+  	provider => $exec_provider,
   }
 
   # manage root password if it is set

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -18,12 +18,15 @@ class mysql::server::service {
     $mysqluser = $options['mysqld']['user']
   }
 
-  if $options['mysqld']['log-error'] {
-    file { $options['mysqld']['log-error']:
-      ensure => present,
-      owner  => $mysqluser,
-      group  => $::mysql::server::mysql_group,
-    }
+  # JOE
+  unless $::osfamily == 'Windows' {
+	  if $options['mysqld']['log-error'] {
+	    file { $options['mysqld']['log-error']:
+	      ensure => present,
+	      owner  => $mysqluser,
+	      group  => $::mysql::server::mysql_group,
+	    }
+	  }  
   }
 
   service { 'mysqld':

--- a/metadata.json
+++ b/metadata.json
@@ -84,6 +84,8 @@
   "description": "Mysql module",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 5.0.0"},
-    {"name":"nanliu/staging","version_requirement":">= 1.0.1 < 2.0.0"}
+    {"name":"nanliu/staging","version_requirement":">= 1.0.1 < 2.0.0"},
+    {"name":"johnericson/cygwin_exec","version_requirement":">=0.1.0"},
+    {"name":"rismoney/chocolatey","version_requirement":">=0.4.0"}
   ]
 }


### PR DESCRIPTION
I would like to merge my changes in this module. I have ported the module so it now also works on Windows and used it successfully in a mixed Windows/Linux environment for several months. In order to minimize the changes required in order to make it run on Windows I've relied on Cygwin for providing the Unix commands needed for the many execs. Where packages is needed I've used Chocolatey which is a package management tool for Windows.

I'm relying on the changes in this module for making the Puppet-Pentaho (https://github.com/JohnEricson/puppet-pentaho) module working on both Linux and Windows.