### PR TITLE
Ticket Forge Modules / MODULES-2675 - Unique server_id

### DIFF
--- a/lib/facter/mysql_server_id.rb
+++ b/lib/facter/mysql_server_id.rb
@@ -1,5 +1,5 @@
 def get_mysql_id
-  Facter.value(:macaddress).split(':').inject(0) { |total,value| (total << 4) + value.hex }
+  Facter.value(:macaddress).split(':').inject(0) { |total,value| (total << 6) + value.hex }
 end
 
 Facter.add("mysql_server_id") do

--- a/spec/unit/facter/mysql_server_id_spec.rb
+++ b/spec/unit/facter/mysql_server_id_spec.rb
@@ -11,7 +11,7 @@ describe Facter::Util::Fact do
         Facter.fact(:macaddress).stubs(:value).returns('3c:97:0e:69:fb:e1')
       end
       it do
-        Facter.fact(:mysql_server_id).value.to_s.should == '72898961'
+        Facter.fact(:mysql_server_id).value.to_s.should == '66961985441'
       end
     end
 


### PR DESCRIPTION
Ticket Forge Modules / MODULES-2675
Fixed Unique server_id facter fact. Allowing a unique id to be generated by reading in all 6 splits of the mac address, where as it was only reading in 4 of the 6 splits.