### PR TITLE
(MODULES-2787) Fixes for future parser

### DIFF
--- a/manifests/backup/mysqlbackup.pp
+++ b/manifests/backup/mysqlbackup.pp
@@ -62,7 +62,7 @@ class mysql::backup::mysqlbackup (
     user    => 'root',
     hour    => $time[0],
     minute  => $time[1],
-    weekday => 0,
+    weekday => '0',
     require => Package['meb'],
   }
 
@@ -72,7 +72,7 @@ class mysql::backup::mysqlbackup (
     user    => 'root',
     hour    => $time[0],
     minute  => $time[1],
-    weekday => 1-6,
+    weekday => '1-6',
     require => Package['meb'],
   }
 

--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -32,7 +32,7 @@ class mysql::backup::xtrabackup (
     user    => 'root',
     hour    => $time[0],
     minute  => $time[1],
-    weekday => 0,
+    weekday => '0',
     require => Package['percona-xtrabackup'],
   }
 
@@ -42,7 +42,7 @@ class mysql::backup::xtrabackup (
     user    => 'root',
     hour    => $time[0],
     minute  => $time[1],
-    weekday => 1-6,
+    weekday => '1-6',
     require => Package['percona-xtrabackup'],
   }
 


### PR DESCRIPTION
The weekday attribute of cron resource will be parse to negetive integer
with future parser. This patch is aim to ensure that the value types of
cron resouce are valid with future parser.

JIRA issue: https://tickets.puppetlabs.com/browse/MODULES-2787