### PR TITLE
Fixes edge-case with dropping pre-existing users with grants

### DIFF
--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -114,7 +114,11 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
   end
 
   def destroy
-    revoke(@property_hash[:user], @property_hash[:table])
+    # if the user was dropped, it'll have been removed from the user hash
+    # as the grants are alraedy removed by the DROP statement
+    if self.class.users.include? @property_hash[:user]
+      revoke(@property_hash[:user], @property_hash[:table])
+    end
     @property_hash.clear
 
     exists? ? (return false) : (return true)


### PR DESCRIPTION
If a user exists in the database upon first Puppet run (for example, in the case of loading a database snapshot) and the run sets that user's :ensure attribute to 'absent', the mysql_grant provider will throw an error when the dependency chain causes it to try to destroy the grants associated with that user because the DROP statement from the mysql_user provider already removed the grants. To fix, we must check if the user exists before revoking the grants.