### PR TITLE
ensure if service restart to wait till mysql is up

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -47,4 +47,18 @@ class mysql::server::service {
     File['mysql-config-file'] -> Service['mysqld']
   }
 
+  if $mysql::server::override_options and $mysql::server::override_options['mysqld'] and $mysql::server::override_options['mysqld']['socket'] {
+    $mysqlsocket = $mysql::server::override_options['mysqld']['socket']
+  } else {
+    $mysqlsocket = $options['mysqld']['socket']
+  }
+
+  exec { 'wait_for_mysql_socket_to_open':
+    command   => "test -S ${mysqlsocket}",
+    unless    => "test -S ${mysqlsocket}",
+    tries     => '3',
+    try_sleep => '10',
+    require   => Service['mysqld'],
+    path      => '/bin:/usr/bin',
+  }
 }


### PR DESCRIPTION
The old mysql init scripts waited till mysql was up and running till they finished. With ubuntu 14.04 and upstart (re)starting mysql will no longer wait for mysql to finish starting up. So in some cases, puppet will try to run mysql queries against the mysql server which is still starting up.

This patch prevents that by waiting till the configured mysql socket is available if the mysql service gets updated.