### PR TITLE
Fixing error when disabling service management and the service does not exist

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -26,11 +26,13 @@ class mysql::server::service {
     }
   }
 
-  service { 'mysqld':
-    ensure   => $service_ensure,
-    name     => $mysql::server::service_name,
-    enable   => $mysql::server::real_service_enabled,
-    provider => $mysql::server::service_provider,
+  if $mysql::server::real_service_manage {
+    service { 'mysqld':
+      ensure   => $service_ensure,
+      name     => $mysql::server::service_name,
+      enable   => $mysql::server::real_service_enabled,
+      provider => $mysql::server::service_provider,
+    }
   }
 
   # only establish ordering between service and package if


### PR DESCRIPTION
If you set service_manage => false, because your instance of mysql is not managed by any service management OR in my case I'm only using this puppet module to manage mysql users, puppet generates an error.

Error: /Stage[main]/Mysql::Server::Service/Service[mysqld]: Could not evaluate: Could not find init script or upstart conf file for 'mysql'
