### PR TITLE
Move all dependencies to not have them in case of service unmanaged

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -33,34 +33,34 @@ class mysql::server::service {
       enable   => $mysql::server::real_service_enabled,
       provider => $mysql::server::service_provider,
     }
-  }
 
-  # only establish ordering between service and package if
-  # we're managing the package.
-  if $mysql::server::package_manage {
-    Service['mysqld'] {
-      require  => Package['mysql-server'],
+    # only establish ordering between service and package if
+    # we're managing the package.
+    if $mysql::server::package_manage {
+      Service['mysqld'] {
+        require  => Package['mysql-server'],
+      }
     }
-  }
 
-  # only establish ordering between config file and service if
-  # we're managing the config file.
-  if $mysql::server::manage_config_file {
-    File['mysql-config-file'] -> Service['mysqld']
-  }
+    # only establish ordering between config file and service if
+    # we're managing the config file.
+    if $mysql::server::manage_config_file {
+      File['mysql-config-file'] -> Service['mysqld']
+    }
 
-  if $mysql::server::override_options and $mysql::server::override_options['mysqld'] and $mysql::server::override_options['mysqld']['socket'] {
-    $mysqlsocket = $mysql::server::override_options['mysqld']['socket']
-  } else {
-    $mysqlsocket = $options['mysqld']['socket']
-  }
+    if $mysql::server::override_options and $mysql::server::override_options['mysqld'] and $mysql::server::override_options['mysqld']['socket'] {
+      $mysqlsocket = $mysql::server::override_options['mysqld']['socket']
+    } else {
+      $mysqlsocket = $options['mysqld']['socket']
+    }
 
-  exec { 'wait_for_mysql_socket_to_open':
-    command   => "test -S ${mysqlsocket}",
-    unless    => "test -S ${mysqlsocket}",
-    tries     => '3',
-    try_sleep => '10',
-    require   => Service['mysqld'],
-    path      => '/bin:/usr/bin',
+    exec { 'wait_for_mysql_socket_to_open':
+      command   => "test -S ${mysqlsocket}",
+      unless    => "test -S ${mysqlsocket}",
+      tries     => '3',
+      try_sleep => '10',
+      require   => Service['mysqld'],
+      path      => '/bin:/usr/bin',
+    }
   }
 }


### PR DESCRIPTION
When service in not managed, this kind af errors appears:
Error 400 on SERVER: Could not find resource 'Service[mysqld]' for relationship from 'File[mysql-config-file]'