### PR TITLE
Re-Add the ability to set a empty string as option parameter

### DIFF
--- a/spec/classes/mycnf_template_spec.rb
+++ b/spec/classes/mycnf_template_spec.rb
@@ -29,6 +29,11 @@ describe 'mysql::server' do
           end
         end
 
+        describe 'skip-name-resolve set to an empty string' do
+          let(:params) {{ :override_options => { 'mysqld' => { 'skip-name-resolve' => '' }}}}
+          it { is_expected.to contain_file('mysql-config-file').with_content(/^skip-name-resolve$/) }
+        end
+
         describe 'ssl set to true' do
           let(:params) {{ :override_options => { 'mysqld' => { 'ssl' => true }}}}
           it { is_expected.to contain_file('mysql-config-file').with_content(/ssl/) }

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -6,7 +6,7 @@
 <%     v.sort.map do |ki, vi| -%>
 <%       if ki == 'ssl-disable' or (ki =~ /^ssl/ and v['ssl-disable'] == true) -%>
 <%         next %>
-<%       elsif vi == true or v == '' -%>
+<%       elsif vi == true or vi == '' -%>
 <%=        ki %>
 <%       elsif vi.is_a?(Array) -%>
 <%         vi.each do |vii| -%>


### PR DESCRIPTION
Prior to 136b1aa646efde57b91fd994bfcf55b38ba7c294 it was possible to
have an empty string as value of a my.cnf parameter, resulting in a line
with just the parameter name.

That commit re-enable that behavior that was removed by accident.