### PR TITLE
Added properties 'ssl_type' and 'ssl_cipher' to mysql_user to enable …

### DIFF
--- a/lib/puppet/type/mysql_user.rb
+++ b/lib/puppet/type/mysql_user.rb
@@ -7,6 +7,12 @@ Puppet::Type.newtype(:mysql_user) do
   autorequire(:file) { '/root/.my.cnf' }
   autorequire(:class) { 'mysql::server' }
 
+  validate do
+    if !self[:ssl_cipher].empty? and self[:ssl_type] != 'SPECIFIED'
+      fail ArgumentError, "Specifying a SSL cipher requires SSL-type 'SPECIFIED'"
+    end
+  end
+
   newparam(:name, :namevar => true) do
     desc "The name of the user. This uses the 'username@hostname' or username@hostname."
     validate do |value|
@@ -71,6 +77,24 @@ Puppet::Type.newtype(:mysql_user) do
   newproperty(:max_updates_per_hour) do
     desc "Max updates per hour for the user. 0 means no (or global) limit."
     newvalue(/\d+/)
+  end
+
+  newproperty(:ssl_type) do
+    desc "SSL-type the user has to use to connect. Can be any of '', 'ANY', 'SPECIFIED', 'X509'."
+    newvalues('', 'ANY', 'SPECIFIED', 'X509')
+    defaultto ''
+    munge do |value|
+      String(value).upcase
+    end
+  end
+
+  newproperty(:ssl_cipher) do
+    desc "SSL-cipher the user has to use to connect. Requires ssl-type='SPECIFIED'."
+    newvalue(/\w*/)
+    defaultto ''
+    munge do |value|
+      String(value)
+    end
   end
 
 end


### PR DESCRIPTION
…SSL encrypted authentication.

Added two properties 'ssl_type' and 'ssl_cipher' to mysql_user to allow specifying the required SSL method for the user to log in.
'ssl_type' can take the values '', 'ANY', 'SPECIFIED', or 'X509', which results in no requirement for SSL (''), any SSL-based authentication ('ANY'), SSL-based authentication using a specific cipher ('SPECIFIED'), or authentication using a signed client certificate ('X509').
'ssl_cipher' allows to provide the cipher and requires ssl_type == 'SPECIFIED'.
This is in compliance with the MySQL GRANT syntax, cf. e.g. https://dev.mysql.com/doc/refman/5.6/en/grant.html

The additional properties and corresponding SQL-statements for X509-options are not yet implemented.

Examples:
```puppet
mysql_user { 'someuser@%':
  ensure        => 'present',
  password_hash => '*F3A2A51A9B0F2BE2468926B4132313728C250DBF',
  ssl_type      => 'ANY'
}
```
generates
```
  GRANT USAGE ON *.* TO 'someuser'@'%' REQUIRE SSL;
```
for an existing user or inserts the REQUIRE-clause in the GRANT command of the create-method for a new user.
```puppet
mysql_user { 'someuser@%':
  ensure        => 'present',
  password_hash => '*F3A2A51A9B0F2BE2468926B4132313728C250DBF',
  ssl_type      => 'SPECIFIED',
  ssl_cipher    => 'EDH-RSA-DES-CBC3-SHA'
}
```
generates
```
  GRANT USAGE ON *.* TO 'someuser'@'%' REQUIRE SSL;
  GRANT USAGE ON *.* TO 'someuser'@'%' REQUIRE CIPHER 'EDH-RSA-DES-CBC3-SHA';
```
for an existing user or inserts the REQUIRE-clause connected by AND in the GRANT command of the create-method for a new user.