### PR TITLE
(#3028) Fix mysql_grant with MySQL ANSI_QUOTES mode

### DIFF
--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
       # Once we have the list of grants generate entries for each.
       grants.each_line do |grant|
         # Match the munges we do in the type.
-        munged_grant = grant.delete("'").delete("`")
+        munged_grant = grant.delete("'").delete("`").delete('"')
         # Matching: GRANT (SELECT, UPDATE) PRIVILEGES ON (*.*) TO ('root')@('127.0.0.1') (WITH GRANT OPTION)
         if match = munged_grant.match(/^GRANT\s(.+)\sON\s(.+)\sTO\s(.*)@(.*?)(\s.*)?$/)
           privileges, table, user, host, rest = match.captures


### PR DESCRIPTION
Change mysql_grant provider to ignore/delete double-quotes -- as it does with single quotes and backticks -- in the returned list of existing grants. With ANSI_QUOTES enabled in MySQL's sql_mode, grant identifiers (e.g. database name) are quoted with double-quotes rather than backticks, for example "foo".* vs. `foo`.*. This breaks mysql_grant's evaluation of existing grants and causes it to apply grants with every run.