### PR TITLE
Added a mysql::user for creating a user and assing privileges. The users can also be exported and collected on a remote DB server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,37 @@ mysql::db { 'mydb':
 }
 ~~~
 
+### Creating a user
+
+To use `mysql::user` to create a user and assign some privileges:
+
+~~
+mysql::user { 'myuser':
+  password => 'mypass',
+  host     => 'localhost',
+  grant    => ['SELECT', 'UPDATE'],
+}
+~~
+
+Or to use a different resource name with exported resources:
+
+~~
+ @@mysql::user { "myuser_${fqdn}":
+  user     => 'myuser',
+  password => 'mypass',
+  dbname   => 'mydb',
+  host     => ${fqdn},
+  grant    => ['SELECT', 'UPDATE'],
+  tag      => $domain,
+}
+~~
+
+Then you can collect it on the remote DB server:
+
+~~
+Mysql::User <<| tag == $domain |>>
+
+
 ### Custom Configuration
 
 To add custom MySQL configuration, drop additional files into

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -33,7 +33,6 @@ define mysql::db (
     ensure   => $ensure,
     charset  => $charset,
     collate  => $collate,
-    provider => 'mysql',
     require  => [ Class['mysql::client'] ],
   }
   ensure_resource('mysql_database', $dbname, $db_resource)
@@ -41,14 +40,12 @@ define mysql::db (
   $user_resource = {
     ensure        => $ensure,
     password_hash => mysql_password($password),
-    provider      => 'mysql',
   }
   ensure_resource('mysql_user', "${user}@${host}", $user_resource)
 
   if $ensure == 'present' {
     mysql_grant { "${user}@${host}/${table}":
       privileges => $grant,
-      provider   => 'mysql',
       user       => "${user}@${host}",
       table      => $table,
       require    => [

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,0 +1,44 @@
+# See README.md for details.
+define mysql::user (
+  $user,
+  $password,
+  $dbname         = $name,
+  $charset        = 'utf8',
+  $collate        = 'utf8_general_ci',
+  $host           = 'localhost',
+  $grant          = 'ALL',
+  $grant_options  = undef,
+  $ensure         = 'present',
+) {
+  #input validation
+  validate_re($ensure, '^(present|absent)$',
+  "${ensure} is not supported for ensure. Allowed values are 'present' and 'absent'.")
+  $table = "${dbname}.*"
+
+  include '::mysql::client'
+
+  anchor{"mysql::user_${name}::begin": }->
+  Class['::mysql::client']->
+  anchor{"mysql::user_${name}::end": }
+
+  $user_resource = {
+    ensure        => $ensure,
+    password_hash => mysql_password($password),
+#    provider      => 'mysql',
+  }
+  ensure_resource('mysql_user', "${user}@${host}", $user_resource)
+
+  if $ensure == 'present' {
+    mysql_grant { "${user}@${host}/${table}":
+      privileges => $grant,
+      options    => $grant_options,
+#      provider   => 'mysql',
+      user       => "${user}@${host}",
+      table      => $table,
+      require    => [
+        Mysql_user["${user}@${host}"],
+      ],
+    }
+
+  }
+}

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,8 +1,8 @@
 # See README.md for details.
 define mysql::user (
-  $user           = $name,
   $password,
   $dbname,
+  $user           = $name,
   $charset        = 'utf8',
   $collate        = 'utf8_general_ci',
   $host           = 'localhost',

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,8 +1,8 @@
 # See README.md for details.
 define mysql::user (
-  $user,
+  $user           = $name,
   $password,
-  $dbname         = $name,
+  $dbname,
   $charset        = 'utf8',
   $collate        = 'utf8_general_ci',
   $host           = 'localhost',

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -24,7 +24,6 @@ define mysql::user (
   $user_resource = {
     ensure        => $ensure,
     password_hash => mysql_password($password),
-#    provider      => 'mysql',
   }
   ensure_resource('mysql_user', "${user}@${host}", $user_resource)
 
@@ -32,7 +31,6 @@ define mysql::user (
     mysql_grant { "${user}@${host}/${table}":
       privileges => $grant,
       options    => $grant_options,
-#      provider   => 'mysql',
       user       => "${user}@${host}",
       table      => $table,
       require    => [

--- a/spec/acceptance/mysql_user_spec.rb
+++ b/spec/acceptance/mysql_user_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper_acceptance'
+
+describe 'mysql::user define' do
+  describe 'creating a user' do
+    let(:pp) do
+      <<-EOS
+        class { 'mysql::server': root_password => 'password' }
+        mysql::db { 'spec1':
+          user     => 'root1',
+          password => 'password',
+        }
+        mysql::user { 'user1':
+          password       => 'password',
+          dbname         => 'spec1',
+        }
+      EOS
+    end
+    it_behaves_like "a idempotent resource"
+
+    describe command("mysql -e 'select host, user, password from mysql.user;'") do
+      its(:exit_status) { is_expected.to eq 0 }
+      its(:stdout) { is_expected.to match /^spec1$/ }
+    end
+  end
+
+  describe 'creating a user with user parameter' do
+    let(:check_command) { " | grep realuser" }
+    let(:pp) do
+      <<-EOS
+        class { 'mysql::server': override_options => { 'root_password' => 'password' } }
+        mysql::db { 'spec1':
+          user     => 'root1',
+          password => 'password',
+        }
+        mysql::user { 'user1':
+          user     => 'realuser',
+          password => 'password',
+          dbname   => 'spec1',
+        }
+      EOS
+    end
+    it_behaves_like "a idempotent resource"
+
+    describe command("mysql -e 'select host, user, password from mysql.user;'") do
+      its(:exit_status) { is_expected.to eq 0 }
+      its(:stdout) { is_expected.to match /^realuser$/ }
+    end
+  end
+end

--- a/spec/defines/mysql_user_spec.rb
+++ b/spec/defines/mysql_user_spec.rb
@@ -30,7 +30,7 @@ describe 'mysql::user', :type => :define do
 
       it 'should use user parameter as user name instead of name' do
         params.merge!({'user' => 'realuser'})
-        is_expected.to contain_mysql_user('realuser')
+        is_expected.to contain_mysql_user('realuser@localhost').with_ensure('absent')
       end
     end
   end

--- a/spec/defines/mysql_user_spec.rb
+++ b/spec/defines/mysql_user_spec.rb
@@ -12,7 +12,8 @@ describe 'mysql::user', :type => :define do
       let(:title) { 'testuser' }
 
       let(:params) {
-        { 'password' => 'testpass',
+        { 'dbname'   => 'test_db',
+          'password' => 'testpass',
         }
       }
 

--- a/spec/defines/mysql_user_spec.rb
+++ b/spec/defines/mysql_user_spec.rb
@@ -29,8 +29,8 @@ describe 'mysql::user', :type => :define do
       end
 
       it 'should use user parameter as user name instead of name' do
-        params.merge!({'user' => 'realuser'})
-        is_expected.to contain_mysql_user('realuser@localhost').with_ensure('absent')
+        params.merge!({'user' => 'realuser', 'host' => 'localhost'})
+        is_expected.to contain_mysql_user('realuser@localhost').with_ensure('present')
       end
     end
   end

--- a/spec/defines/mysql_user_spec.rb
+++ b/spec/defines/mysql_user_spec.rb
@@ -12,7 +12,7 @@ describe 'mysql::user', :type => :define do
       let(:title) { 'testuser' }
 
       let(:params) {
-          'password' => 'testpass',
+        { 'password' => 'testpass',
         }
       }
 

--- a/spec/defines/mysql_user_spec.rb
+++ b/spec/defines/mysql_user_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'mysql::user', :type => :define do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) {
+        facts.merge({
+          :root_home => '/root',
+        })
+      }
+
+      let(:title) { 'testuser' }
+
+      let(:params) {
+          'password' => 'testpass',
+        }
+      }
+
+      it 'should report an error when ensure is not present or absent' do
+        params.merge!({'ensure' => 'invalid_val'})
+        expect { catalogue }.to raise_error(Puppet::Error,
+                                          /invalid_val is not supported for ensure\. Allowed values are 'present' and 'absent'\./)
+      end
+
+      it 'should not create database user' do
+        params.merge!({'ensure' => 'absent', 'host' => 'localhost'})
+        is_expected.to contain_mysql_user('testuser@localhost').with_ensure('absent')
+      end
+
+      it 'should use user parameter as user name instead of name' do
+        params.merge!({'user' => 'realuser'})
+        is_expected.to contain_mysql_user('realuser')
+      end
+    end
+  end
+end

--- a/spec/defines/mysql_user_spec.rb
+++ b/spec/defines/mysql_user_spec.rb
@@ -12,7 +12,8 @@ describe 'mysql::user', :type => :define do
       let(:title) { 'testuser' }
 
       let(:params) {
-        { 'password' => 'testpass',
+        { 'user'     => 'testuser',
+          'password' => 'testpass',
         }
       }
 

--- a/spec/defines/mysql_user_spec.rb
+++ b/spec/defines/mysql_user_spec.rb
@@ -12,8 +12,7 @@ describe 'mysql::user', :type => :define do
       let(:title) { 'testuser' }
 
       let(:params) {
-        { 'user'     => 'testuser',
-          'password' => 'testpass',
+        { 'password' => 'testpass',
         }
       }
 


### PR DESCRIPTION
I have created a new resource 'mysql::user', based on the code for mysql::db.

### Creating a user

To use `mysql::user` to create a user and assign some privileges:

~~~puppet
mysql::user { 'myuser':
  password => 'mypass',
  host     => 'localhost',
  grant    => ['SELECT', 'UPDATE'],
}
~~~

Or to use a different resource name with exported resources:

~~~puppet
 @@mysql::user { "myuser_${fqdn}":
  user     => 'myuser',
  password => 'mypass',
  dbname   => 'mydb',
  host     => ${fqdn},
  grant    => ['SELECT', 'UPDATE'],
  tag      => $domain,
}
~~~

Then you can collect it on the remote DB server:

~~~puppet
Mysql::User <<| tag == $domain |>>
~~~