### PR TITLE
Generate .my.cnf for all sections

### DIFF
--- a/templates/my.cnf.pass.erb
+++ b/templates/my.cnf.pass.erb
@@ -1,9 +1,11 @@
 ### MANAGED BY PUPPET ###
 
-[client]
+<% %w(mysql client mysqldump mysqladmin mysqlcheck).each do |section| %>
+[<%= section -%>]
 user=root
 host=localhost
 <% unless scope.lookupvar('mysql::server::root_password') == 'UNSET' -%>
 password='<%= scope.lookupvar('mysql::server::root_password') %>'
 <% end -%>
-socket=<%= @options['client']['socket'] -%>
+socket=<%= @options['client']['socket'] %>
+<% end %>


### PR DESCRIPTION
MySQL ecosystem has a lot of tools that use .my.cnf such as mysqldump or
mysqladmin. Generating all sections allows operator to use them under
root account without passing -p<password>