### PR TITLE
remove option from config if override_options set false or 'off'

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -44,6 +44,15 @@ class mysql::server::config {
     }
   }
 
+  # Issue a warning if other options are used for disabling SSL: according to
+  # the template they will be ordered before other 'ssl-*' options and in turns
+  # leads MySQL to ignore the deactivation request.
+  if (!$options['mysqld']['ssl'] or $options['mysqld']['skip-ssl'] or $options['mysqld']['disable-ssl']) {
+    notify {'warn-ineffective-disable-options':
+      message => 'Use "ssl-disable" => true to disable SSL! Other options are not respected!'
+    }
+  }
+
   if $options['mysqld']['ssl-disable'] {
     notify {'ssl-disable':
       message =>'Disabling SSL is evil! You should never ever do this except if you are forced to use a mysql version compiled without SSL support'

--- a/spec/classes/mycnf_template_spec.rb
+++ b/spec/classes/mycnf_template_spec.rb
@@ -42,19 +42,25 @@ describe 'mysql::server' do
 
         describe 'ssl set to false' do
           let(:params) {{ :override_options => { 'mysqld' => { 'ssl' => false }}}}
-          it { is_expected.to contain_file('mysql-config-file').with_content(/ssl = false/) }
+          it { is_expected.to contain_notify('warn-ineffective-disable-options') }
         end
 
         # ssl-disable (and ssl) are special cased within mysql.
         describe 'possibility of disabling ssl completely' do
           let(:params) {{ :override_options => { 'mysqld' => { 'ssl' => true, 'ssl-disable' => true }}}}
-          it { is_expected.to contain_file('mysql-config-file').without_content(/ssl = true/) }
+          it { is_expected.to contain_file('mysql-config-file').without_content(/^ssl.*/) }
         end
 
         describe 'a non ssl option set to true' do
           let(:params) {{ :override_options => { 'mysqld' => { 'test' => true }}}}
           it { is_expected.to contain_file('mysql-config-file').with_content(/^test$/) }
           it { is_expected.to contain_file('mysql-config-file').without_content(/test = true/) }
+        end
+
+        describe 'a non ssl option set to false' do
+          let(:params) {{ :override_options => { 'mysqld' => { 'test' => false }}}}
+          it { is_expected.to contain_file('mysql-config-file').without_content(/^test$/) }
+          it { is_expected.to contain_file('mysql-config-file').without_content(/test = false/) }
         end
 
         context 'with includedir' do

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -6,8 +6,10 @@
 <%     v.sort.map do |ki, vi| -%>
 <%       if ki == 'ssl-disable' or (ki =~ /^ssl/ and v['ssl-disable'] == true) -%>
 <%         next %>
-<%       elsif vi == true or vi == '' -%>
+<%       elsif [:true, true, ''].include?(vi) -%>
 <%=        ki %>
+<%       elsif [:false, false].include?(vi) -%>
+<%         next -%>
 <%       elsif vi.is_a?(Array) -%>
 <%         vi.each do |vii| -%>
 <%=          ki %> = <%= vii %>


### PR DESCRIPTION
In it's current state the my.cnf-template is not capable of removing a specific boolean option, i.e. 'skip-name-resolve'. Activation of such an option works properly and generates a single line with only the option name listed. If I do pass 'false' instead, the following line would be generated:
    skip-name-resolve = false
which MySQL (5.5) is happily using to activate the option:
```sql
show VARIABLES where Variable_Name = 'skip_name_resolve';
+-------------------+---------+
| Variable_name     | Value   |
|-------------------+---------|
| skip_name_resolve | ON      |
+-------------------+---------+
```
I'd like to solve this by adding a new condition to my.cnf-template to just ignore/skip any option whose content is false or 'off'.
Is this acceptable?