### PR TITLE
Use mysql_install_db only with uniq defaults-extra-file

### DIFF
--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -9,7 +9,7 @@ class mysql::server::installdb {
     $basedir = $mysql::server::options['mysqld']['basedir']
     $config_file = $mysql::server::config_file
 
-    if $mysql::server::manage_config_file {
+    if $mysql::server::manage_config_file and $config_file != $mysql::params::config_file {
       $_config_file=$config_file
     } else {
       $_config_file=undef


### PR DESCRIPTION
Executing mysql_install_db with the defaults-extra-file set to the
global option file can produce errors with duplicates. For example it
happens when 'ignore-db-dir' option passed to $override_options in
mysql::server class. Same as https://bugs.mysql.com/bug.php?id=69441