### PR TITLE
Use mysql_install_db only with uniq defaults-extra-file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :development, :unit_tests do
   gem 'puppet_facts',            :require => false
   gem 'json',                    :require => false
   gem 'metadata-json-lint',      :require => false
+  gem 'rake', '~> 10.5',         :require => false
 end
 
 group :system_tests do

--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -9,9 +9,10 @@ class mysql::server::installdb {
     $basedir = $mysql::server::options['mysqld']['basedir']
     $config_file = $mysql::server::config_file
 
-    if $mysql::server::manage_config_file {
+    if $mysql::server::manage_config_file and $config_file != $mysql::params::config_file {
       $install_db_args = "--basedir=${basedir} --defaults-extra-file=${config_file} --datadir=${datadir} --user=${mysqluser}"
-
+    } else {
+      $install_db_args = "--basedir=${basedir} --datadir=${datadir} --user=${mysqluser}"
     }
 
     exec { 'mysql_install_db':


### PR DESCRIPTION
Executing mysql_install_db with the defaults-extra-file set to the
global option file can produce errors with duplicates. For example it
happens when 'ignore-db-dir' option passed to $override_options in
mysql::server class. Same as https://bugs.mysql.com/bug.php?id=69441