### PR TITLE
Config before install

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -53,8 +53,8 @@ class mysql::server (
 
   Class['mysql::server::root_password'] -> Mysql::Db <| |>
 
-  include '::mysql::server::install'
   include '::mysql::server::config'
+  include '::mysql::server::install'
   include '::mysql::server::installdb'
   include '::mysql::server::service'
   include '::mysql::server::root_password'
@@ -75,8 +75,8 @@ class mysql::server (
   }
 
   Anchor['mysql::server::start'] ->
-  Class['mysql::server::install'] ->
   Class['mysql::server::config'] ->
+  Class['mysql::server::install'] ->
   Class['mysql::server::installdb'] ->
   Class['mysql::server::service'] ->
   Class['mysql::server::root_password'] ->


### PR DESCRIPTION
When there is a new install, the package installation will run `mysqld
--initialize` or `mysql_install_db` which leaves `mysqld` in a running
state. If you have `$mysql::server::restart` set to false, `mysqld` will
not restart and you will be left in a state of running a default config
instead of your intended configuration.