### PR TITLE
(maint) Add missing nanliu/staging module

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -49,6 +49,7 @@ RSpec.configure do |c|
       else
         on host, puppet('module','install','puppetlabs-stdlib','--version','3.2.0')
         on host, puppet('module','install','stahnma/epel')
+        on host, puppet('module','install','nanliu/staging')
       end
     end
   end


### PR DESCRIPTION
The module is not really used, but its absence creates nasty warning
messages.