### PR TITLE
Add support for Percona 5.7

### DIFF
--- a/lib/puppet/provider/mysql_user/mysql.rb
+++ b/lib/puppet/provider/mysql_user/mysql.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:mysql_user).provide(:mysql, :parent => Puppet::Provider::Mysq
         ## Default ...
         query = "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{name}'"
       else
-        if mysqld_type == "mysql" and Puppet::Util::Package.versioncmp(mysqld_version, '5.7.6') >= 0
+        if (mysqld_type == "mysql" or mysqld_type == "percona") and Puppet::Util::Package.versioncmp(mysqld_version, '5.7.6') >= 0
           query = "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, AUTHENTICATION_STRING, PLUGIN FROM mysql.user WHERE CONCAT(user, '@', host) = '#{name}'"
         else
           query = "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{name}'"
@@ -109,7 +109,7 @@ Puppet::Type.type(:mysql_user).provide(:mysql, :parent => Puppet::Provider::Mysq
       mysql([defaults_file, '-e', "SET PASSWORD FOR #{merged_name} = '#{string}'"].compact)
     else
       # Version >= 5.7.6 (many password related changes)
-      if mysqld_type == "mysql" and Puppet::Util::Package.versioncmp(mysqld_version, '5.7.6') >= 0
+      if (mysqld_type == "mysql" or mysqld_type == "percona") and Puppet::Util::Package.versioncmp(mysqld_version, '5.7.6') >= 0
         if string.match(/^\*/)
           mysql([defaults_file, '-e', "ALTER USER #{merged_name} IDENTIFIED WITH mysql_native_password AS '#{string}'"].compact)
         else

--- a/lib/puppet/type/mysql_datadir.rb
+++ b/lib/puppet/type/mysql_datadir.rb
@@ -27,4 +27,9 @@ Puppet::Type.newtype(:mysql_datadir) do
     desc "Insecure initialization (needed for 5.7.6++)."
   end
 
+  newparam(:log_error) do
+    desc "The path to the mysqld error log file (used with the --log-error option)"
+    newvalues(/^\//)
+  end
+
 end

--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -8,6 +8,7 @@ class mysql::server::installdb {
     $datadir = $mysql::server::options['mysqld']['datadir']
     $basedir = $mysql::server::options['mysqld']['basedir']
     $config_file = $mysql::server::config_file
+    $log_error = $mysql::server::options['mysqld']['log-error']
 
     if $mysql::server::manage_config_file and $config_file != $mysql::params::config_file {
       $_config_file=$config_file
@@ -20,6 +21,7 @@ class mysql::server::installdb {
       datadir             => $datadir,
       basedir             => $basedir,
       user                => $mysqluser,
+      log_error           => $log_error,
       defaults_extra_file => $_config_file,
     }
 


### PR DESCRIPTION
This PR adds support for Percona 5.7. Percona Server is a superset of community mysql and essentially acts like it.

This PR will resolve MODULES-3193.

I notice that there is a tagged 3.7.0 release but the CHANGELOG.md still states "Supported Release 3.6.2". What are the plans to release and/or support 3.7.0?
