### PR TITLE
(MODULES-1256) Fix parameters on OpenSUSE 12

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -96,7 +96,7 @@ class mysql::params {
     'Suse': {
       case $::operatingsystem {
         'OpenSuSE': {
-          if versioncmp( $::operatingsystemmajrelease, '13' ) >= 0 {
+          if versioncmp( $::operatingsystemmajrelease, '12' ) >= 0 {
             $client_package_name = 'mariadb-client'
             $server_package_name = 'mariadb'
             # First service start fails if this is set. Runs fine without


### PR DESCRIPTION
This ticket points out that the opensuse 12 configuration bails on a very simple manifest, so 12 should actually have the defaults that are currently set only for 13 and higher.