### PR TITLE
(FM-5050) Configure the base of includedir

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -17,6 +17,16 @@ class mysql::server::config {
       recurse => $mysql::server::purge_conf_dir,
       purge   => $mysql::server::purge_conf_dir,
     }
+
+    # on some systems this is /etc/my.cnf.d, while Debian has /etc/mysql/conf.d and FreeBSD something in /usr/local. For the latter systems,
+    # managing this basedir is also required, to have it available before the package is installed.
+    $includeparentdir = mysql_dirname($includedir)
+    if $includeparentdir != '/' and $includeparentdir != '/etc' {
+      file { $includeparentdir:
+        ensure => directory,
+        mode   => '0755',
+      }
+    }
   }
 
   $logbin = pick($options['mysqld']['log-bin'], $options['mysqld']['log_bin'], false)


### PR DESCRIPTION
Without this change installing mysql fails with the following errors on Debian and
Ubuntu:

Error: Cannot create /etc/mysql/conf.d; parent directory /etc/mysql does not exist
Error: /Stage[main]/Mysql::Server::Config/File[/etc/mysql/conf.d]/ensure: change from absent to directory failed: Cannot create /etc/mysql/conf.d; parent directory /etc/mysql does not exist
Error: Could not set 'file' on ensure: No such file or directory @ dir_s_rmdir - /etc/mysql/my.cnf20160413-2395-1uo3ffj.lock at 39:/etc/puppetlabs/code/modules/mysql/manifests/server/config.pp
Error: Could not set 'file' on ensure: No such file or directory @ dir_s_rmdir - /etc/mysql/my.cnf20160413-2395-1uo3ffj.lock at 39:/etc/puppetlabs/code/modules/mysql/manifests/server/config.pp
Wrapped exception:
No such file or directory @ dir_s_rmdir - /etc/mysql/my.cnf20160413-2395-1uo3ffj.lock
Error: /Stage[main]/Mysql::Server::Config/File[mysql-config-file]/ensure: change from absent to file failed: Could not set 'file' on ensure: No such file or directory @ dir_s_rmdir - /etc/mysql/my.cnf20160413-2395-1uo3ffj.lock at 39:/etc/puppetlabs/code/modules/mysql/manifests/server/config.pp