### PR TITLE
Default mysqld_type should be "mysql"

### DIFF
--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -24,7 +24,7 @@ class Puppet::Provider::Mysql < Puppet::Provider
     mysqld_version_string.scan(/mariadb/i) { return "mariadb" }
     mysqld_version_string.scan(/\s\(mysql/i) { return "mysql" }
     mysqld_version_string.scan(/\s\(percona/i) { return "percona" }
-    nil
+    return "mysql"
   end
 
   def mysqld_type


### PR DESCRIPTION
Default mysqld_type return value should be "mysql" if another type is not detected. Returning nil breaks mysql 5.7.11 on Ubuntu (at least) due to the conditional used in mysql_user provider.