### PR TITLE
Additional mysql_datadir exists check for MySQL Enterprise

### DIFF
--- a/lib/puppet/provider/mysql_datadir/mysql.rb
+++ b/lib/puppet/provider/mysql_datadir/mysql.rb
@@ -56,7 +56,7 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, :parent => Puppet::Provider::M
 
   def exists?
     datadir = @resource[:datadir]
-    File.directory?("#{datadir}/mysql")
+    File.directory?("#{datadir}/mysql/servers.frm")
   end
 
   ##

--- a/lib/puppet/provider/mysql_datadir/mysql.rb
+++ b/lib/puppet/provider/mysql_datadir/mysql.rb
@@ -56,7 +56,7 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, :parent => Puppet::Provider::M
 
   def exists?
     datadir = @resource[:datadir]
-    File.directory?("#{datadir}/mysql/servers.frm")
+    (File.directory?("#{datadir}/mysql")) && (Dir.entries("#{datadir}/mysql") - %w{ . .. }).any? 
   end
 
   ##


### PR DESCRIPTION
MySQL Enterprise rpm's, downloaded directly from Oracle, install an empty 'mysql' dir inside of the datadir (/var/lib/mysql).  Due to this, when the exists? method runs with "File.directory?("#{datadir}/mysql")", since the directory does exist for MySQL Enterprise (though, it is empty), the 'mysql_install_db' script never gets run to install the base mysql DB.

This change adjusts the check to confirm the dir exists and is not empty.