### PR TITLE
Added bzip2 package support on mysqldump backup

### DIFF
--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -21,9 +21,7 @@ class mysql::backup::mysqldump (
   $execpath           = '/usr/bin:/usr/sbin:/bin:/sbin',
 ) inherits mysql::params {
 
-  package { 'bzip2':
-    ensure    => $ensure,
-  }
+  ensure_packages(['bzip2'])
 
   mysql_user { "${backupuser}@localhost":
     ensure        => $ensure,

--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -21,6 +21,10 @@ class mysql::backup::mysqldump (
   $execpath           = '/usr/bin:/usr/sbin:/bin:/sbin',
 ) inherits mysql::params {
 
+  package { 'bzip2':
+    ensure    => $ensure,
+  }
+
   mysql_user { "${backupuser}@localhost":
     ensure        => $ensure,
     password_hash => mysql_password($backuppassword),
@@ -47,7 +51,7 @@ class mysql::backup::mysqldump (
     user    => 'root',
     hour    => $time[0],
     minute  => $time[1],
-    require => File['mysqlbackup.sh'],
+    require => [File['mysqlbackup.sh'], Package['bzip2']],
   }
 
   file { 'mysqlbackup.sh':


### PR DESCRIPTION
The script used by this mysqldump class, mysqlbackup.sh, requires bzcat
which is part of the bzip2 package.

This patch will make sure that bzip2 is installed before setting up the
cron tab job using mysqlbackup.sh