### PR TITLE
Remove mysql regex when checking type

### DIFF
--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -22,7 +22,6 @@ class Puppet::Provider::Mysql < Puppet::Provider
   def self.mysqld_type
     # find the mysql "dialect" like mariadb / mysql etc.
     mysqld_version_string.scan(/mariadb/i) { return "mariadb" }
-    mysqld_version_string.scan(/\s\(mysql/i) { return "mysql" }
     mysqld_version_string.scan(/\s\(percona/i) { return "percona" }
     return "mysql"
   end


### PR DESCRIPTION
Since the default MySQL return type is 'mysql', only check for MariaDB and Percona specially.