### PR TITLE
remove erroneous anchors to mysql::client from mysql::db

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -25,10 +25,6 @@ define mysql::db (
 
   include '::mysql::client'
 
-  anchor{"mysql::db_${name}::begin": }->
-  Class['::mysql::client']->
-  anchor{"mysql::db_${name}::end": }
-
   $db_resource = {
     ensure   => $ensure,
     charset  => $charset,


### PR DESCRIPTION
The anchors create a dependency cycle if `mysql::client` must be installed before `mysql::server` and `mysql::db` resources are configured.

We are forced to use official mysql packages from http://repo.mysql.com. There the mysqladmin script is in the mysql client package. Therefore, that `mysql::server::root_password` can use mysqladmin, we added:

`Class[Mysql::Client] -> Class[Mysql::Server]`

this works as long as we don't configure any `mysql::db` resources. As soon as a `mysql::db` resource is defined the following dependency cycle exists:

`
Anchor[mysql::client::end] => Class[Mysql::Client] => Class[Mysql::Server] => Anchor[mysql::server::start] => Class[Mysql::Server::Config] => File[mysql-config-file] => Service[mysqld] => Class[Mysql::Server::Service] => Class[Mysql::Server::Root_password] => Exec[remove install pass] => Class[Mysql::Server::Root_password] => Mysql::Db[dummy] => Anchor[mysql::db_dummy::begin] => Class[Mysql::Client] => Anchor[mysql::client::end]
`

As I can see no reason for the anchors, I removed them. If there is a reason please let me know so that I can figure out another solution.