### PR TITLE
move out $options['mysqld']['log-error'] from service.pp into installdb.pp

### DIFF
--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -1,5 +1,6 @@
 #
 class mysql::server::installdb {
+  $options = $mysql::server::options
 
   if $mysql::server::package_manage {
 
@@ -15,6 +16,15 @@ class mysql::server::installdb {
     } else {
       $_config_file=undef
     }
+
+  if $options['mysqld']['log-error'] {
+    file { $options['mysqld']['log-error']:
+      ensure => present,
+      owner  => $mysqluser,
+      group  => $::mysql::server::mysql_group,
+      before => Mysql_datadir[ $datadir ],
+    }
+  }
 
     mysql_datadir { $datadir:
       ensure              => 'present',

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -18,14 +18,6 @@ class mysql::server::service {
     $mysqluser = $options['mysqld']['user']
   }
 
-  if $options['mysqld']['log-error'] {
-    file { $options['mysqld']['log-error']:
-      ensure => present,
-      owner  => $mysqluser,
-      group  => $::mysql::server::mysql_group,
-    }
-  }
-
   if $mysql::server::real_service_manage {
     service { 'mysqld':
       ensure   => $service_ensure,


### PR DESCRIPTION
Installation of Percona-Server-57 from yum repository has a side effect - touching of /var/log/mysqld.log. The file is empty and owned by root user, and that prevents mysql datadir initialization. 

puppet-agent[2003]: Execution of '/usr/sbin/mysqld --initialize-insecure --basedir=/usr --datadir=/var/lib/mysql --user=mysql --log-error=/var/lib/mysql/mysqld.log' returned 1
.
Given issue reproduced on CentOS 6.7, possibly on CentOS7.