### PR TITLE
Check that /var/lib/mysql actually contains files.

### DIFF
--- a/lib/puppet/provider/mysql_datadir/mysql.rb
+++ b/lib/puppet/provider/mysql_datadir/mysql.rb
@@ -57,7 +57,7 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, :parent => Puppet::Provider::M
 
   def exists?
     datadir = @resource[:datadir]
-    File.directory?("#{datadir}/mysql")
+    (File.directory?("#{datadir}/mysql")) && (Dir.entries("#{datadir}/mysql") - %w{ . .. }).any? 
   end
 
   ##


### PR DESCRIPTION
MySQL-server-advanced installs install the 'mysql' directory in /var/lib/mysql by default,
therefore the check fails and does not run mysql_install_db.
Check is adjusted to check if any files exist in the directory.