### PR TITLE
default group for logfiles on Debian/Ubuntu should be adm

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -169,7 +169,7 @@ class mysql::params {
       $log_error               = '/var/log/mysql/error.log'
       $pidfile                 = '/var/run/mysqld/mysqld.pid'
       $root_group              = 'root'
-      $mysql_group             = 'mysql'
+      $mysql_group             = 'adm'
       $server_service_name     = 'mysql'
       $socket                  = '/var/run/mysqld/mysqld.sock'
       $ssl_ca                  = '/etc/mysql/cacert.pem'


### PR DESCRIPTION
On Debian, it's a good practise to use 'adm' for the group in logfiles: 

> adm: Group adm is used for system monitoring tasks. Members of this group can read many log files in /var/log

Most of the packages available are using it for the initial creation of the error.log and add an logrotate job which creates a new logfile with this group while rotating. Causing puppet to change the group after every logrotate.

