### PR TITLE
Fixed an issue with Amazon linux major release 4 installation

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -432,7 +432,7 @@ class mysql::params {
   }
 
   ## Additional graceful failures
-  if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '4' {
+  if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '4' and $::operatingsystem != 'Amazon' {
     fail("Unsupported platform: puppetlabs-${module_name} only supports RedHat 5.0 and beyond")
   }
 }


### PR DESCRIPTION
There was an issue with the latest amazon linux release that would make the installation fail because of the fact verification on params.pp:
```
[root@AmazonLinux ~]# facter operatingsystem
Amazon
[root@AmazonLinux ~]# facter operatingsystemmajrelease
4
[root@AmazonLinux ~]# facter osfamily
RedHat
```

Because of this line of code:
`  if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '4'  {`

The module would exit with an error stating that the installation is not supported on RedHat older than major release 5 which in the case of the latest amazon linux is not true.