### PR TITLE
Support mysql_install_db script on Gentoo

### DIFF
--- a/lib/puppet/provider/mysql_datadir/mysql.rb
+++ b/lib/puppet/provider/mysql_datadir/mysql.rb
@@ -5,8 +5,8 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, :parent => Puppet::Provider::M
 
   initvars
 
-  # Make sure we find mysqld on CentOS
-  ENV['PATH']=ENV['PATH'] + ':/usr/libexec'
+  # Make sure we find mysqld on CentOS and mysql_install_db on Gentoo
+  ENV['PATH']=ENV['PATH'] + ':/usr/libexec:/usr/share/mysql/scripts'
 
   commands :mysqld => 'mysqld'
   commands :mysql_install_db => 'mysql_install_db'


### PR DESCRIPTION
On Gentoo, mysql_install_db script is installed into /usr/share/mysql/scripts
and therefore is not found by mysql_datadir type.
This commit adds scripts path to ENV['PATH'] so it can be found.