### PR TITLE
Fix global parameter usage in backup script

### DIFF
--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -68,7 +68,7 @@ cleanup
 <% end -%>
 <% if @backupdatabases.empty? -%>
 <% if @file_per_database -%>
-mysql --defaults-file=$TMPFILE -s -r -N -e 'SHOW DATABASES' | while read dbname
+mysql --defaults-extra-file=$TMPFILE -s -r -N -e 'SHOW DATABASES' | while read dbname
 do
   mysqldump --defaults-extra-file=$TMPFILE --opt --flush-logs --single-transaction \
     ${ADDITIONAL_OPTIONS} \


### PR DESCRIPTION
If mysqldump uses --defaults-extra-file mysql should use the same. Otherwise settings like different socket paths etc. will not work. Preferably this should be detected via test cases, as backups are quite important...