### PR TITLE
Use mariadb by default for Debian Jessie

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -159,8 +159,20 @@ class mysql::params {
     }
 
     'Debian': {
-      $client_package_name     = 'mysql-client'
-      $server_package_name     = 'mysql-server'
+      # jessie onwards
+      if versioncmp($::operatingsystemrelease, '8') >= 0 {
+        $client_package_name     = 'mariadb-client'
+        $server_package_name     = 'mariadb-server'
+
+        $client_dev_package_name = 'libmariadb-client-lgpl-dev'
+        $daemon_dev_package_name = 'libmariadb-dev'
+      } else {
+        $client_package_name     = 'mysql-client'
+        $server_package_name     = 'mysql-server'
+
+        $client_dev_package_name = 'libmysqlclient-dev'
+        $daemon_dev_package_name = 'libmysqld-dev'
+      }
 
       $basedir                 = '/usr'
       $config_file             = '/etc/mysql/my.cnf'
@@ -186,8 +198,6 @@ class mysql::params {
         'jessie'           => 'ruby-mysql',
         default            => 'libmysql-ruby',
       }
-      $client_dev_package_name = 'libmysqlclient-dev'
-      $daemon_dev_package_name = 'libmysqld-dev'
     }
 
     'Archlinux': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -159,8 +159,7 @@ class mysql::params {
     }
 
     'Debian': {
-      # jessie onwards
-      if versioncmp($::operatingsystemrelease, '8') >= 0 {
+      if  $::lsbdistid == 'Debian' and $::lsbdistcodename == 'jessie' {
         $client_package_name     = 'mariadb-client'
         $server_package_name     = 'mariadb-server'
 


### PR DESCRIPTION
Just updates params.pp to use mariadb specific packages. All other configurations (files, paths, groups) stay the same.