### PR TITLE
 Find MySQL 5.5 installation on CentOS

### DIFF
--- a/lib/puppet/provider/mysql_datadir/mysql.rb
+++ b/lib/puppet/provider/mysql_datadir/mysql.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, :parent => Puppet::Provider::M
   initvars
 
   # Make sure we find mysqld on CentOS and mysql_install_db on Gentoo
-  ENV['PATH']=ENV['PATH'] + ':/usr/libexec:/usr/share/mysql/scripts'
+  ENV['PATH']=ENV['PATH'] + ':/usr/libexec:/usr/share/mysql/scripts:/opt/rh/mysql55/root/usr/bin:/opt/rh/mysql55/root/usr/libexec'
 
   commands :mysqld => 'mysqld'
   commands :mysql_install_db => 'mysql_install_db'


### PR DESCRIPTION
MySQL from CentOS SCL repository is installed in different location. You should also check for binaries in this location.
Without this change puppet returns error like: Could not find a suitable provider for mysql_datadir