### PR TITLE
Fix error in server/installdb: Error: Could not retrieve catalog from…

### DIFF
--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -31,7 +31,6 @@ class mysql::server::installdb {
       datadir             => $datadir,
       basedir             => $basedir,
       user                => $mysqluser,
-      log_error           => $log_error,
       defaults_extra_file => $_config_file,
     }
 


### PR DESCRIPTION
… remote server: Error 400 on SERVER: no parameter named 'log_error' at installdb.pp:29 on Mysql_datadir[/var/lib/mysql] at installdb.pp:29