### PR TITLE
Revert "Use mariadb by default for Debian Jessie (#845)"

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -159,19 +159,8 @@ class mysql::params {
     }
 
     'Debian': {
-      if  $::lsbdistid == 'Debian' and $::lsbdistcodename == 'jessie' {
-        $client_package_name     = 'mariadb-client'
-        $server_package_name     = 'mariadb-server'
-
-        $client_dev_package_name = 'libmariadb-client-lgpl-dev'
-        $daemon_dev_package_name = 'libmariadb-dev'
-      } else {
-        $client_package_name     = 'mysql-client'
-        $server_package_name     = 'mysql-server'
-
-        $client_dev_package_name = 'libmysqlclient-dev'
-        $daemon_dev_package_name = 'libmysqld-dev'
-      }
+      $client_package_name     = 'mysql-client'
+      $server_package_name     = 'mysql-server'
 
       $basedir                 = '/usr'
       $config_file             = '/etc/mysql/my.cnf'
@@ -197,6 +186,8 @@ class mysql::params {
         'jessie'           => 'ruby-mysql',
         default            => 'libmysql-ruby',
       }
+      $client_dev_package_name = 'libmysqlclient-dev'
+      $daemon_dev_package_name = 'libmysqld-dev'
     }
 
     'Archlinux': {


### PR DESCRIPTION
This reverts commit af85cf7dfb1c3d0cab5b123cdf7ccfe40b7b90d3. It turned out to
be a very bad idea to change the defaults. To fix this in the long term, the
module needs to separate product/version selection from the OS-defaults. For now,
please supply those values through the main parameters to select mariadb.