### PR TITLE
[MODULES-3441] Discover mysql version using facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ host=localhost
 password=secret
 ```
 
+This module uses the `mysqld_version` fact to discover the server version being used.  By default, this is set to the output of `mysqld -V`.  If you're working with a remote MySQL server, you may need to set a custom fact for `mysqld_version` to ensure correct behaviour.
+
 When working with a remote server, do *not* use the `mysql::server` class in your Puppet manifests.
 
 ### Specify passwords

--- a/lib/facter/mysqld_version.rb
+++ b/lib/facter/mysqld_version.rb
@@ -1,0 +1,5 @@
+Facter.add("mysqld_version") do
+  setcode do
+    Facter::Util::Resolution.exec('mysqld -V')
+  end
+end

--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -33,7 +33,7 @@ class Puppet::Provider::Mysql < Puppet::Provider
   def self.mysqld_version_string
     # we cache the result ...
     return @mysqld_version_string unless @mysqld_version_string.nil?
-    @mysqld_version_string = mysqld(['-V'].compact)
+    @mysqld_version_string = Facter.value(:mysqld_version)
     return @mysqld_version_string
   end
 

--- a/spec/unit/facter/mysqld_version_spec.rb
+++ b/spec/unit/facter/mysqld_version_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe Facter::Util::Fact do
+  before {
+    Facter.clear
+  }
+
+  describe "mysqld_version" do
+    context 'with value' do
+      before :each do
+        Facter::Util::Resolution.stubs(:exec).with('mysqld -V').returns('mysqld  Ver 5.5.49-37.9 for Linux on x86_64 (Percona Server (GPL), Release 37.9, Revision efa0073)')
+      end
+      it {
+        expect(Facter.fact(:mysqld_version).value).to eq('mysqld  Ver 5.5.49-37.9 for Linux on x86_64 (Percona Server (GPL), Release 37.9, Revision efa0073)')
+      }
+    end
+
+  end
+
+end

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -200,10 +200,15 @@ usvn_user@localhost
   end
 
   describe 'self.mysqld_version' do
-    it 'queries mysql if unset' do
+    it 'uses the mysqld_version fact if unset' do
        provider.class.instance_variable_set(:@mysqld_version_string, nil)
-       provider.class.expects(:mysqld).with(['-V'])
-       expect(provider.mysqld_version).to be_nil
+       Facter.stubs(:value).with(:mysqld_version).returns('5.6.24')
+       expect(provider.mysqld_version).to eq '5.6.24'
+    end
+    it 'returns nil if the mysqld_version fact is absent' do
+       provider.class.instance_variable_set(:@mysqld_version_string, nil)
+       Facter.stubs(:value).with(:mysqld_version).returns(nil)
+       expect(provider.mysqld_version).to eq nil
     end
     it 'returns 5.7.6 for "mysqld  Ver 5.7.6 for Linux on x86_64 (MySQL Community Server (GPL))"' do
        provider.class.instance_variable_set(:@mysqld_version_string, 'mysqld  Ver 5.7.6 for Linux on x86_64 (MySQL Community Server (GPL))')


### PR DESCRIPTION
Per https://tickets.puppetlabs.com/browse/MODULES-3441, the mysql module has behaviour which varies by server version. The version is discovered by running `mysqld -V`. On hosts without a MySQL server package install, this fails, which means that contrary to the README, it's not actually possible to use this module to manage a remote db.

This PR moves the version string discovery into a new fact, `mysqld_version` which is used by the provider.  This makes it possible to configure the db version with a custom fact when a remote db (eg AWS RDS) is being managed.