### PR TITLE
Resource fails when fqdn is not set.

### DIFF
--- a/manifests/server/account_security.pp
+++ b/manifests/server/account_security.pp
@@ -16,7 +16,7 @@ class mysql::server::account_security {
       require => Anchor['mysql::server::end'],
     }
   }
-  if ($::fqdn != 'localhost') {
+  if ($::fqdn and $::fqdn != 'localhost') {
     mysql_user {
       [ "root@${::fqdn}",
         "@${::fqdn}"]:


### PR DESCRIPTION
if server don't have domain name facter don't initialize fqdn and mysql_user resource fails with "...Invalid database user..." error.