### PR TITLE
support for root password hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,14 @@ This is required if `create_root_user` or `create_root_my_cnf` are true. If `roo
 
 Password changes are supported; however, the old password must be set in `/root/.my.cnf`. Effectively, Puppet uses the old password, configured in `/root/my.cnf`, to set the new password in MySQL, and then updates `/root/.my.cnf` with the new password. 
 
+##### `root_hash`
+
+The MySQL root password hash obtained using `select password('password')`. Puppet attempts to set the root password but will not update `/root/.my.cnf` with it. 
+
+This option will ignore `create_root_my_cnf` and is not compatible with `root_password`
+
+Password changes are NOT supported.
+
 ##### `old_root_password`
 
 This parameter no longer does anything. It exists only for backwards compatibility. See the `root_password` parameter above for details on changing the root password.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@ class mysql::params {
   $purge_conf_dir         = false
   $restart                = false
   $root_password          = 'UNSET'
+  $root_hash              = 'UNSET'
   $install_secret_file    = '/.mysql_secret'
   $server_package_ensure  = 'present'
   $server_package_manage  = true
@@ -434,5 +435,16 @@ class mysql::params {
   ## Additional graceful failures
   if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '4' and $::operatingsystem != 'Amazon' {
     fail("Unsupported platform: puppetlabs-${module_name} only supports RedHat 5.0 and beyond")
+  }
+  
+  ## Fail if both root_password and root_hash are specified
+  if $root_password != 'UNSET' and $root_hash != 'UNSET' {
+    fail('Cannot set both root_password and root_hash')
+  }
+  
+  ## Do not save a .my.cnf if a root hash is requested
+  if $create_root_my_cnf and $root_hash != 'UNSET' {
+    $create_root_my_cnf = false,
+    warn('create_root_my_cnf cannot be true if a root_hash is provided')
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -444,7 +444,7 @@ class mysql::params {
   
   ## Do not save a .my.cnf if a root hash is requested
   if $create_root_my_cnf and $root_hash != 'UNSET' {
-    $create_root_my_cnf = false,
+    $create_root_my_cnf = false
     warn('create_root_my_cnf cannot be true if a root_hash is provided')
   }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -15,6 +15,7 @@ class mysql::server (
   $root_group              = $mysql::params::root_group,
   $mysql_group             = $mysql::params::mysql_group,
   $root_password           = $mysql::params::root_password,
+  $root_hash               = $mysql::params::root_hash,
   $service_enabled         = $mysql::params::server_service_enabled,
   $service_manage          = $mysql::params::server_service_manage,
   $service_name            = $mysql::params::server_service_name,

--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -25,7 +25,7 @@ class mysql::server::root_password {
       password_hash => mysql_password($mysql::server::root_password),
       require       => Exec['remove install pass']
     }
-  } elsif $mysql::server::create_root_root == true and $mysql::server::root_hash != 'UNSET' {
+  } elsif $mysql::server::create_root_user == true and $mysql::server::root_hash != 'UNSET' {
       mysql_user { 'root@localhost':
       ensure        => present,
       password_hash => $mysql::server::root_hash,

--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -25,6 +25,12 @@ class mysql::server::root_password {
       password_hash => mysql_password($mysql::server::root_password),
       require       => Exec['remove install pass']
     }
+  } elsif $mysql::server::create_root_root == true and $mysql::server::root_hash != 'UNSET' {
+      mysql_user { 'root@localhost':
+      ensure        => present,
+      password_hash => $mysql::server::root_hash,
+      require       => Exec['remove install pass']
+    }
   }
 
   if $mysql::server::create_root_my_cnf == true and $mysql::server::root_password != 'UNSET' {


### PR DESCRIPTION
adding support for a root_hash as an alternative to root_password.

root_hash and root_password are mutually exclusive and root_hash will also disable my.cnf creation