### PR TITLE
Remove log_error from mysql_datadir as it causes compilation and ruby errors

### DIFF
--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -31,7 +31,6 @@ class mysql::server::installdb {
       datadir             => $datadir,
       basedir             => $basedir,
       user                => $mysqluser,
-      log_error           => $log_error,
       defaults_extra_file => $_config_file,
     }
 


### PR DESCRIPTION
This is a re-submit of #844 
Upon further investigation, the existence of $log_error in the mysql_datadir define causes puppet and ruby compilation errors on the puppet master server:
```
2016-06-13 11:09:10,882 ERROR [qtp1541603101-46] [puppet-server] Puppet no parameter named 'log_error' at /etc/puppetlabs/code/environments/production/modules/mysql/manifests/server/installdb.pp:29 on Mysql_datadir[/var/lib/mysql] at /etc/puppetlabs/code/environments/production/modules/mysql/manifests/server/installdb.pp:29 on node test
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/resource.rb:500:in `validate_parameter'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/parser/resource.rb:341:in `validate'
org/jruby/RubyHash.java:1341:in `each'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/parser/resource.rb:341:in `validate'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/parser/resource.rb:112:in `finish'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/parser/compiler.rb:685:in `finish'
org/jruby/RubyArray.java:1613:in `each'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/parser/compiler.rb:673:in `finish'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/parser/compiler.rb:198:in `compile'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/profiler/around_profiler.rb:58:in `profile'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/profiler.rb:51:in `profile'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/parser/compiler.rb:198:in `compile'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/context.rb:65:in `override'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:240:in `override'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/parser/compiler.rb:167:in `compile'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/parser/compiler.rb:35:in `compile'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/catalog/compiler.rb:266:in `compile'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/profiler/around_profiler.rb:58:in `profile'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/profiler.rb:51:in `profile'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/catalog/compiler.rb:264:in `compile'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:223:in `benchmark'
/opt/puppetlabs/server/apps/puppetserver/puppet-server-release.jar!/META-INF/jruby.home/lib/ruby/1.9/benchmark.rb:295:in `realtime'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:222:in `benchmark'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/catalog/compiler.rb:262:in `compile'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/catalog/compiler.rb:53:in `find'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/indirector/indirection.rb:194:in `find'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/network/http/api/indirected_routes.rb:132:in `do_find'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/network/http/api/indirected_routes.rb:48:in `call'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/context.rb:65:in `override'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:240:in `override'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/network/http/api/indirected_routes.rb:47:in `call'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/network/http/route.rb:82:in `process'
org/jruby/RubyArray.java:1613:in `each'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/network/http/route.rb:81:in `process'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/network/http/route.rb:87:in `process'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/network/http/route.rb:87:in `process'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/network/http/handler.rb:60:in `process'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/profiler/around_profiler.rb:58:in `profile'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/profiler.rb:51:in `profile'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/network/http/handler.rb:58:in `process'
file:/opt/puppetlabs/server/apps/puppetserver/puppet-server-release.jar!/puppet-server-lib/puppet/server/master.rb:42:in `handleRequest'
Puppet$$Server$$Master_865497743.gen:13:in `handleRequest'
request_handler_core.clj:280:in `invoke'
jruby_request.clj:67:in `invoke'
jruby_request.clj:49:in `invoke'
request_handler_service.clj:38:in `handle_request'
request_handler.clj:3:in `invoke'
request_handler.clj:3:in `invoke'
core.clj:2493:in `invoke'
ringutils.clj:115:in `invoke'
ringutils.clj:71:in `invoke'
ringutils.clj:77:in `invoke'
ringutils.clj:127:in `invoke'
master_core.clj:426:in `invoke'
ring.clj:21:in `invoke'
ring.clj:12:in `invoke'
comidi.clj:249:in `invoke'
jetty9_core.clj:424:in `invoke'
normalized_uri_helpers.clj:80:in `invoke'
```

I'm calling the class in a wrapper like this:
```
# A wrapper around puppetlabs/mysql that installs and configures Percona MySQL Server
class wrapper::mysql (
  $version = '5.6',
  $table_open_cache       = '4096',
  $table_definition_cache = '500',
  $max_allowed_packet     = '32M',
  $join_buffer_size       = '8M',
  $read_rnd_buffer_size   = '16M',
  $tmp_table_size         = '96M',
  $max_heap_table_size    = '96M',
  $query_cache_type       = '1',
  $query_cache_size       = '64M',
  $query_cache_limit      = '2M',
) {

  apt::key { '430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A':
    ensure => present,
    notify => Exec['wrapper::mysql::apt-get update'],
  }

  if defined('apt::sources_list') {
    # Camp2Camp/apt module
    apt::sources_list { 'percona':
      ensure  => present,
      source  => false,
      content => template ("${module_name}/mysql/sources.list.erb"),
      notify  => Exec['wrapper::mysql::apt-get update'],
      require => Apt::Key['430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A'],
    }
  }

  if defined('apt::source') {
    # Puppetlabs/apt module
    apt::source { 'percona':
      ensure      => present,
      include     => { 'src' => true },
      location    => 'http://repo.percona.com/apt',
      release     => $::lsbdistcodename,
      repos       => 'main',
      notify      => Exec['wrapper::mysql::apt-get update'],
      require     => Apt::Key['430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A'],
    }
  }

  exec { 'wrapper::mysql::apt-get update':
    command     => 'apt-get update',
    path        => '/usr/bin',
    refreshonly => true,
  }

  class { '::mysql::server':
    root_password    => fqdn_rand_string(20),
    package_name     => "percona-server-server-${version}",
    service_name     => 'mysql',
    require          => Apt::Source['percona'],
  }
  file { '/etc/mysql/conf.d/optimizations.cnf':
    ensure  => present,
    owner   => 'root',
    group   => 'root',
    mode    => '0644',
    content => template('wrapper/mysql/optimizations.cnf.erb'),
    notify  => Service['mysql'],
  }
}
```
Puppet client is Ubuntu 14.04 (Trusty) adding the Percona PPA repo (in the wrapper).
Server is Puppet 4 v2.4.0
Is there something else I could try?

I'd file this as an issue, but issues just redirect to pull requests and appear to be disabled, so I had to file this as a PR. 

As I said above, removing line 34 from server/installdb.pp fixes this compilation issue, but I can't trace where the problem actually is here. Has something to do with commit d472d5b