### PR TITLE
add new backup dump parameter maxallowedpacket

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,10 @@ Sets the server backup implementation. Valid values are:
 * `mysqlbackup`: Implements backups with MySQL Enterprise Backup from Oracle. Backup type: Physical. To use this type of backup, you'll need the `meb` package, which is available in RPM and TAR formats from Oracle. For Ubuntu, you can use [meb-deb](https://github.com/dveeden/meb-deb) to create a package from an official tarball.
 * `xtrabackup`: Implements backups with XtraBackup from Percona. Backup type: Physical.
 
+##### `maxallowedpacket`
+
+Define the maximum SQL statement size for the backup dump script. The default value is 1MB as this is the default Mysql Server value.
+
 #### mysql::server::monitor
 
 ##### `mysql_monitor_username`

--- a/manifests/backup/mysqlbackup.pp
+++ b/manifests/backup/mysqlbackup.pp
@@ -2,6 +2,7 @@
 class mysql::backup::mysqlbackup (
   $backupuser         = '',
   $backuppassword     = '',
+  $maxallowedpacket   = '1M',
   $backupdir          = '',
   $backupdirmode      = '0700',
   $backupdirowner     = 'root',

--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -3,6 +3,7 @@ class mysql::backup::mysqldump (
   $backupuser         = '',
   $backuppassword     = '',
   $backupdir          = '',
+  $maxallowedpacket   = '1M',
   $backupdirmode      = '0700',
   $backupdirowner     = 'root',
   $backupdirgroup     = $mysql::params::root_group,

--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -3,6 +3,7 @@ class mysql::backup::xtrabackup (
   $backupuser         = '',
   $backuppassword     = '',
   $backupdir          = '',
+  $maxallowedpacket   = '1M',
   $backupmethod       = 'mysqldump',
   $backupdirmode      = '0700',
   $backupdirowner     = 'root',

--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -20,6 +20,7 @@ class mysql::server::backup (
   $postscript         = false,
   $execpath           = '/usr/bin:/usr/sbin:/bin:/sbin',
   $provider           = 'mysqldump',
+  $maxallowedpacket   = '1M',
 ) {
 
   if $prescript and $provider =~ /(mysqldump|mysqlbackup)/ {
@@ -47,6 +48,7 @@ class mysql::server::backup (
       'prescript'          => $prescript,
       'postscript'         => $postscript,
       'execpath'           => $execpath,
+      'maxallowedpacket'   => $maxallowedpacket,
     }
   })
 

--- a/spec/classes/mysql_server_backup_spec.rb
+++ b/spec/classes/mysql_server_backup_spec.rb
@@ -12,10 +12,12 @@ describe 'mysql::server::backup' do
       let(:default_params) {
         { 'backupuser'         => 'testuser',
           'backuppassword'     => 'testpass',
+          'maxallowedpacket'   => '1M',
           'backupdir'          => '/tmp',
           'backuprotate'       => '25',
           'delete_before_dump' => true,
           'execpath'           => '/usr/bin:/usr/sbin:/bin:/sbin:/opt/zimbra/bin',
+          'maxallowedpacket'   => '1M',
         }
       }
 

--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -16,12 +16,13 @@
 
 USER=<%= @backupuser %>
 PASS='<%= @backuppassword %>'
+MAX_ALLOWED_PACKET=<%= @maxallowedpacket %>
 DIR=<%= @backupdir %>
 ROTATE=<%= [ Integer(@backuprotate) - 1, 0 ].max %>
 
 # Create temporary mysql cnf file.
 TMPFILE=`mktemp /tmp/backup.XXXXXX` || exit 1
-echo -e "[client]\npassword=$PASS\nuser=$USER" > $TMPFILE
+echo -e "[client]\npassword=$PASS\nuser=$USER\nmax_allowed_packet=$MAX_ALLOWED_PACKET" > $TMPFILE
 
 # Ensure backup directory exist.
 mkdir -p $DIR


### PR DESCRIPTION
Add maxallowedpacket parameter for the puppetlab mysql module backup dump script. Feature request:  https://tickets.puppetlabs.com/browse/PUP-6404 The default value is 1MB as it is default for Mysql.