### PR TITLE
Support for puppet/staging 2.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 5.0.0"},
-    {"name":"puppet/staging","version_requirement":">= 1.0.1 < 2.0.0"}
+    {"name":"puppet/staging","version_requirement":">= 1.0.1 < 3.0.0"}
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
Staging 2.0.0 has dropped ruby 1.8.7 support only. All tests are run against the head of puppet/staging already.