### PR TITLE
[MODULES-#3557] Add Ubuntu 16.04 package names for language bindings

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -187,11 +187,15 @@ class mysql::params {
       # mysql::bindings
       $java_package_name   = 'libmysql-java'
       $perl_package_name   = 'libdbd-mysql-perl'
-      $php_package_name    = 'php5-mysql'
+      $php_package_name    = $::lsbdistcodename ? {
+        'xenial'           => 'php-mysql',
+        default            => 'php5-mysql',
+      }
       $python_package_name = 'python-mysqldb'
       $ruby_package_name   = $::lsbdistcodename ? {
         'trusty'           => 'ruby-mysql',
         'jessie'           => 'ruby-mysql',
+        'xenial'           => 'ruby-mysql',
         default            => 'libmysql-ruby',
       }
       $client_dev_package_name = 'libmysqlclient-dev'


### PR DESCRIPTION
As in [this ticket](https://tickets.puppetlabs.com/browse/MODULES-3557), Ubuntu 16.04
package names for language bindings are not present in manifests/params.pp, incurring errors
when using the module.

This pull request adds an additional case ('xenial') for the
ruby_package_name parameter in the 'Debian' case, so as to avoid falling
through to the default case. A conditional block for the
php_package_name parameter in the 'Debian' case has also been added, so
as to allow for correct package name usage on 16.04, whilst maintaining
backwards-compatibility with the default case.