### PR TITLE
Fixing server id 32 bit overrun error

### DIFF
--- a/lib/facter/mysql_server_id.rb
+++ b/lib/facter/mysql_server_id.rb
@@ -1,5 +1,5 @@
 def get_mysql_id
-  Facter.value(:macaddress).split(':').inject(0) { |total,value| (total << 6) + value.hex }
+  Facter.value(:macaddress).split(':').inject(0) { |total,value| (total << 4) + value.hex }
 end
 
 Facter.add("mysql_server_id") do

--- a/spec/unit/facter/mysql_server_id_spec.rb
+++ b/spec/unit/facter/mysql_server_id_spec.rb
@@ -11,7 +11,7 @@ describe Facter::Util::Fact do
         Facter.fact(:macaddress).stubs(:value).returns('3c:97:0e:69:fb:e1')
       end
       it do
-        Facter.fact(:mysql_server_id).value.to_s.should == '66961985441'
+        Facter.fact(:mysql_server_id).value.to_s.should == '72898961'
       end
     end
 


### PR DESCRIPTION
As per comments on this commit https://github.com/puppetlabs/puppetlabs-mysql/commit/96c9d6d9a749e0e68f6006c80c86fcfab72d9763 we need to roll this back.

If the original committer still has issues then we should find a better solution
