### PR TITLE
Fixing logdir dependency issue

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -39,8 +39,6 @@ class mysql::server::config {
       file { $logbindir:
         ensure => directory,
         mode   => '0755',
-        owner  => $options['mysqld']['user'],
-        group  => $options['mysqld']['user'],
       }
     }
   }


### PR DESCRIPTION
mysql user doesn't exist until mysql-server package is installed

I didn't notice this problem until trying to install a server from scratch.