### PR TITLE
MODULES-3601 Change install order.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -75,8 +75,8 @@ class mysql::server (
   }
 
   Anchor['mysql::server::start'] ->
-  Class['mysql::server::config'] ->
   Class['mysql::server::install'] ->
+  Class['mysql::server::config'] ->
   Class['mysql::server::installdb'] ->
   Class['mysql::server::service'] ->
   Class['mysql::server::root_password'] ->


### PR DESCRIPTION
Fresh installation of Percona 56 fails due to the order of server installation / configuration. The module first tries to create the data directory and `chown` to the `mysql` system user, but this user does not exist until the package is fully installed. 

https://tickets.puppetlabs.com/browse/MODULES-3601