### PR TITLE
MODULES-3697 Changed puppet fail behaviour for mysql create user and grant if user name is longer than 16 chars

### DIFF
--- a/lib/puppet/type/mysql_grant.rb
+++ b/lib/puppet/type/mysql_grant.rb
@@ -80,8 +80,10 @@ Puppet::Type.newtype(:mysql_grant) do
 
       mysql_version = Facter.value(:mysql_version)
       unless mysql_version.nil?
-        if Puppet::Util::Package.versioncmp(mysql_version, '10.0.0') < 0 and user_part.size > 16
+        if Puppet::Util::Package.versioncmp(mysql_version, '5.7.8') < 0 and user_part.size > 16
           raise(ArgumentError, 'MySQL usernames are limited to a maximum of 16 characters')
+        elsif Puppet::Util::Package.versioncmp(mysql_version, '10.0.0') < 0 and user_part.size > 32
+          raise(ArgumentError, 'MySQL usernames are limited to a maximum of 32 characters')
         elsif Puppet::Util::Package.versioncmp(mysql_version, '10.0.0') > 0 and user_part.size > 80
           raise(ArgumentError, 'MySQL usernames are limited to a maximum of 80 characters')
         end

--- a/lib/puppet/type/mysql_user.rb
+++ b/lib/puppet/type/mysql_user.rb
@@ -29,8 +29,10 @@ Puppet::Type.newtype(:mysql_user) do
 
       mysql_version = Facter.value(:mysql_version)
       unless mysql_version.nil?
-        if Puppet::Util::Package.versioncmp(mysql_version, '10.0.0') < 0 and user_part.size > 16
+        if Puppet::Util::Package.versioncmp(mysql_version, '5.7.8') < 0 and user_part.size > 16
           raise(ArgumentError, 'MySQL usernames are limited to a maximum of 16 characters')
+        elsif Puppet::Util::Package.versioncmp(mysql_version, '10.0.0') < 0 and user_part.size > 32
+          raise(ArgumentError, 'MySQL usernames are limited to a maximum of 32 characters')
         elsif Puppet::Util::Package.versioncmp(mysql_version, '10.0.0') > 0 and user_part.size > 80
           raise(ArgumentError, 'MySQL usernames are limited to a maximum of 80 characters')
         end


### PR DESCRIPTION
User name length has changed "MySQL user names can be up to 32 characters long (16 characters before MySQL 5.7.8)"
see http://dev.mysql.com/doc/refman/5.7/en/user-names.html

Tested on CentOS release 6.8 (Final) with mysql version 5.7.14