### PR TITLE
MODULES-3711 - Add limit to mysql server ID generated value

### DIFF
--- a/lib/facter/mysql_server_id.rb
+++ b/lib/facter/mysql_server_id.rb
@@ -1,5 +1,5 @@
 def get_mysql_id
-  Facter.value(:macaddress).split(':').inject(0) { |total,value| (total << 6) + value.hex }
+  Facter.value(:macaddress).split(':')[2..-1].inject(0) { |total,value| (total << 6) + value.hex }
 end
 
 Facter.add("mysql_server_id") do

--- a/spec/unit/facter/mysql_server_id_spec.rb
+++ b/spec/unit/facter/mysql_server_id_spec.rb
@@ -11,7 +11,7 @@ describe Facter::Util::Fact do
         Facter.fact(:macaddress).stubs(:value).returns('3c:97:0e:69:fb:e1')
       end
       it do
-        Facter.fact(:mysql_server_id).value.to_s.should == '66961985441'
+        Facter.fact(:mysql_server_id).value.to_s.should == '4116385'
       end
     end
 


### PR DESCRIPTION
MySQL server ID requires a value that is less than 2^32. With the current server-id generation it's possible to get a value that exceeds this limit. Reference the following documentation: 
– https://dev.mysql.com/doc/refman/5.7/en/replication-options.html#option_mysqld_server-id
I have provided an example of the fix below: 

```ruby
irb(main):002:0> x = ['ff','ff','ff','ff','ff','ff'][2..-1].inject(0)
{ |total, value| (total << 6) + value.hex }
=> 67907775
```
```ruby
irb(main):003:0> x < 2**32
=> true
```

See bug report here: https://tickets.puppetlabs.com/browse/MODULES-3711