### PR TITLE
 MODULES-3729 - puppetlabs/MySQL module -- Percona/MySQL 5.7 initialize bug

### DIFF
--- a/lib/puppet/provider/mysql_datadir/mysql.rb
+++ b/lib/puppet/provider/mysql_datadir/mysql.rb
@@ -57,7 +57,7 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, :parent => Puppet::Provider::M
 
   def exists?
     datadir = @resource[:datadir]
-    (File.directory?("#{datadir}/mysql")) && (Dir.entries("#{datadir}/mysql") - %w{ . .. }).any? 
+    (File.directory?("#{datadir}")) && (Dir.entries("#{datadir}") - %w{ . .. }).any?
   end
 
   ##


### PR DESCRIPTION
There is a bug in the Puppetlabs/MySQL module that affects MySQL/Percona 5.7. Please see below:

```ruby
  def exists?
    datadir = @resource[:datadir]
    (File.directory?("#{datadir}/mysql")) && (Dir.entries("#{datadir}/mysql") - %w{ . .. }).any?
  end
```

This code appends 'mysql' to the specified datadir, for example, if we set a datadir to /var/lib/mysql, it will look for /var/lib/mysql/mysql, which never exists and initialize is always called. When called, it fails because the data directory exists.


See bug report here: https://tickets.puppetlabs.com/browse/MODULES-3729