### PR TITLE
Ensure that error log is writable by owner

### DIFF
--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -22,6 +22,7 @@ class mysql::server::installdb {
       ensure => present,
       owner  => $mysqluser,
       group  => $::mysql::server::mysql_group,
+      mode   => 'u+rw',
       before => Mysql_datadir[ $datadir ],
     }
   }


### PR DESCRIPTION
In the case that the Puppet manifest has

```puppet
File {
  mode => '0444',
}
```
this will be inherited and render the log file unwritable, unless we specify mode.