### PR TITLE
revoking GRANT privilege fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,6 +941,8 @@ mysql_grant { 'root@localhost/mysql.user':
 }
 ```
 
+To revoke GRANT privilege specify ['NONE'].
+
 ##### `ensure`
 
 Whether the resource is present. Valid values are 'present', 'absent'. Defaults to 'present'.

--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -46,7 +46,11 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
             end
           end
           # Same here, but to remove OPTION leaving just GRANT.
-          options = ['GRANT'] if rest.match(/WITH\sGRANT\sOPTION/)
+          if rest.match(/WITH\sGRANT\sOPTION/)           
+		options = ['GRANT']
+          else
+                options = ["NONE"]
+          end
           # fix double backslash that MySQL prints, so resources match
           table.gsub!("\\\\", "\\")
           # We need to return an array of instances so capture these

--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -49,7 +49,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
           if rest.match(/WITH\sGRANT\sOPTION/)           
 		options = ['GRANT']
           else
-                options = ["NONE"]
+                options = ['NONE']
           end
           # fix double backslash that MySQL prints, so resources match
           table.gsub!("\\\\", "\\")


### PR DESCRIPTION
hello,

while trying to implement some basic stuff on mysql/identity management (account lifecycle present,disabled,absent) I came across on a not nice behavior. If user is ever granted a granting option, those cannot be revoked in a fine manner. the "feature" itself is not documented because it's more like side effect.

testcase:
1. mysql_grant( ... options=>['GRANT'])
2. grant is present
3. mysql_grant( ... options=>[])
3a. mysql_grant( ...)
4. grant is present
5. mysql_grant( ... options=>"")
6. grant is revoked
7. mysql_grant( ... options=>"")
8. grant is revoked again
... its revoked everytime


This patch proposes a more proper handling options attribute on grant resource. Initialize option everytime even if it's not present, NONE keyword is not honored in providers cmd_options, so it does not matter and it's backward compatible.

the test and results before and after applying this patch is attached

[grandfix1-testlog.txt](https://github.com/puppetlabs/puppetlabs-mysql/files/440834/grandfix1-testlog.txt)

