### PR TITLE
Silence STDERR in Facter

### DIFF
--- a/lib/facter/mysqld_version.rb
+++ b/lib/facter/mysqld_version.rb
@@ -1,5 +1,5 @@
 Facter.add("mysqld_version") do
   setcode do
-    Facter::Util::Resolution.exec('mysqld -V')
+    Facter::Util::Resolution.exec('mysqld -V 2>/dev/null')
   end
 end

--- a/spec/unit/facter/mysqld_version_spec.rb
+++ b/spec/unit/facter/mysqld_version_spec.rb
@@ -8,7 +8,7 @@ describe Facter::Util::Fact do
   describe "mysqld_version" do
     context 'with value' do
       before :each do
-        Facter::Util::Resolution.stubs(:exec).with('mysqld -V').returns('mysqld  Ver 5.5.49-37.9 for Linux on x86_64 (Percona Server (GPL), Release 37.9, Revision efa0073)')
+        Facter::Util::Resolution.stubs(:exec).with('mysqld -V 2>/dev/null').returns('mysqld  Ver 5.5.49-37.9 for Linux on x86_64 (Percona Server (GPL), Release 37.9, Revision efa0073)')
       end
       it {
         expect(Facter.fact(:mysqld_version).value).to eq('mysqld  Ver 5.5.49-37.9 for Linux on x86_64 (Percona Server (GPL), Release 37.9, Revision efa0073)')


### PR DESCRIPTION
Currenly performing a `puppet apply`, the following output is shown

```
Info: Loading facts
160903 16:55:09 [Note] /usr/sbin/mysqld (mysqld 10.0.26-MariaDB-0+deb8u1) starting as process 6358 ...
Notice: Compiled catalog for foo.example.com in environment production in 1.52 seconds
```

This is due to Facter performing `mysqld -V` to determine the version as fact.

The output of this command alone is this:
```
$ sudo mysqld -V
mysqld  Ver 10.0.26-MariaDB-0+deb8u1 for debian-linux-gnu on x86_64 ((Debian))
160903 17:02:08 [Note] mysqld (mysqld 10.0.26-MariaDB-0+deb8u1) starting as process 7260 ...
```
Where the line with 'starting as process' is STDERR.

This diff redirects STDERR to /dev/null, since it probably contain any critical information (during a version check). 

After applying this diff, the expected outcome is the same again
```
$ sudo mysqld -V 2>/dev/null
mysqld  Ver 10.0.26-MariaDB-0+deb8u1 for debian-linux-gnu on x86_64 ((Debian))
```

As well as within Puppet.

```
Info: Loading facts
Notice: Compiled catalog for foo.example.com in environment production in 1.52 seconds
Info: Applying configuration version '1472915111'
```