### PR TITLE
Add support for REQUIRE SSL|X509 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,7 +897,7 @@ Maximum updates per hour for the user. Must be an integer value. A value of '0' 
 ```
 mysql_grant { 'root@localhost/*.*':
   ensure     => 'present',
-  options    => ['GRANT'],
+  options    => ['REQUIRE SSL', 'GRANT'],
   privileges => ['ALL'],
   table      => '*.*',
   user       => 'root@localhost',
@@ -939,7 +939,8 @@ User to whom privileges are granted.
 
 ##### `options`
 
-MySQL options to grant. Optional.
+Array of MySQL options to grant. Optional.
+Supported options are 'REQUIRE SSL', 'REQUIRE X509', 'GRANT'.
 
 #### mysql_plugin
 

--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -104,8 +104,10 @@ class Puppet::Provider::Mysql < Puppet::Provider
   # Take in potential options and build up a query string with them.
   def self.cmd_options(options)
     option_string = ''
-    options.each do |opt|
-      if opt == 'GRANT'
+    options.sort.reverse_each do |opt|
+      if op = opt.match(/^REQUIRE\s(SSL|X509)$/)
+        option_string << " #{op[0]}"
+      elsif opt == 'GRANT'
         option_string << ' WITH GRANT OPTION'
       end
     end

--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -46,11 +46,11 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
             end
           end
           # Same here, but to remove OPTION leaving just GRANT.
-          if rest.match(/WITH\sGRANT\sOPTION/)           
-		options = ['GRANT']
-          else
-                options = ['NONE']
-          end
+          options = []
+          req_opt = rest.match(/REQUIRE\s(SSL|X509)/)
+          options << req_opt[0] if req_opt
+          options << 'GRANT' if rest.match(/WITH\sGRANT\sOPTION/)
+          options << 'NONE' if options.empty?
           # fix double backslash that MySQL prints, so resources match
           table.gsub!("\\\\", "\\")
           # We need to return an array of instances so capture these


### PR DESCRIPTION
Basic support for REQUIRE SSL or REQUIRE X509 only through the options param on the mysql_grant type. This seems like an option we should support.

It would be nice to support any option in the options array, but I'm not sure about the code to check if the options are set in the instances method. Seems like you need to look for something explicitly in the rest, the way it is set up currently.