### PR TITLE
fixes problem with package name change from php5-mysql to php-mysql on 16.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -187,7 +187,10 @@ class mysql::params {
       # mysql::bindings
       $java_package_name   = 'libmysql-java'
       $perl_package_name   = 'libdbd-mysql-perl'
-      $php_package_name    = 'php5-mysql'
+      $php_package_name    = $::lsbdistcodename ? {
+        'xenial'           => 'php-mysql',
+        default            => 'php5-mysql',
+      }
       $python_package_name = 'python-mysqldb'
       $ruby_package_name   = $::lsbdistcodename ? {
         'trusty'           => 'ruby-mysql',


### PR DESCRIPTION
This fixes the following error which occurs during usage on ubuntu 16.04:

Debug: Executing '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install php5-mysql'
Error: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install php5-mysql' returned                                                                                                                       100: Reading package lists...
Building dependency tree...
Reading state information...
Package php5-mysql is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'php5-mysql' has no installation candidate
/usr/lib/ruby/vendor_ruby/puppet/util/execution.rb:219:in `execute'
/usr/lib/ruby/vendor_ruby/puppet/provider/command.rb:23:in `execute'
/usr/lib/ruby/vendor_ruby/puppet/provider.rb:237:in `block in has_command'
/usr/lib/ruby/vendor_ruby/puppet/provider.rb:463:in `block in create_class_and_instance_method'
/usr/lib/ruby/vendor_ruby/puppet/provider/package/apt.rb:73:in `install'
/usr/lib/ruby/vendor_ruby/puppet/type/package.rb:73:in `block (3 levels) in <module:Puppet>'
/usr/lib/ruby/vendor_ruby/puppet/property.rb:197:in `call_valuemethod'
/usr/lib/ruby/vendor_ruby/puppet/property.rb:498:in `set'
/usr/lib/ruby/vendor_ruby/puppet/property.rb:581:in `sync'
/usr/lib/ruby/vendor_ruby/puppet/transaction/resource_harness.rb:204:in `sync'
/usr/lib/ruby/vendor_ruby/puppet/transaction/resource_harness.rb:128:in `sync_if_needed'
/usr/lib/ruby/vendor_ruby/puppet/transaction/resource_harness.rb:81:in `perform_changes'
/usr/lib/ruby/vendor_ruby/puppet/transaction/resource_harness.rb:20:in `evaluate'
/usr/lib/ruby/vendor_ruby/puppet/transaction.rb:204:in `apply'
/usr/lib/ruby/vendor_ruby/puppet/transaction.rb:217:in `eval_resource'
/usr/lib/ruby/vendor_ruby/puppet/transaction.rb:147:in `call'
/usr/lib/ruby/vendor_ruby/puppet/transaction.rb:147:in `block (2 levels) in evaluate'
/usr/lib/ruby/vendor_ruby/puppet/util.rb:335:in `block in thinmark'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/usr/lib/ruby/vendor_ruby/puppet/util.rb:334:in `thinmark'
/usr/lib/ruby/vendor_ruby/puppet/transaction.rb:147:in `block in evaluate'
/usr/lib/ruby/vendor_ruby/puppet/graph/relationship_graph.rb:118:in `traverse'
/usr/lib/ruby/vendor_ruby/puppet/transaction.rb:138:in `evaluate'
/usr/lib/ruby/vendor_ruby/puppet/resource/catalog.rb:169:in `block in apply'
/usr/lib/ruby/vendor_ruby/puppet/util/log.rb:149:in `with_destination'
/usr/lib/ruby/vendor_ruby/puppet/transaction/report.rb:112:in `as_logging_destination'
/usr/lib/ruby/vendor_ruby/puppet/resource/catalog.rb:168:in `apply'
/usr/lib/ruby/vendor_ruby/puppet/configurer.rb:120:in `block in apply_catalog'
/usr/lib/ruby/vendor_ruby/puppet/util.rb:161:in `block in benchmark'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/usr/lib/ruby/vendor_ruby/puppet/util.rb:160:in `benchmark'
/usr/lib/ruby/vendor_ruby/puppet/configurer.rb:119:in `apply_catalog'
/usr/lib/ruby/vendor_ruby/puppet/configurer.rb:227:in `run_internal'
/usr/lib/ruby/vendor_ruby/puppet/configurer.rb:134:in `block in run'
/usr/lib/ruby/vendor_ruby/puppet/context.rb:64:in `override'
/usr/lib/ruby/vendor_ruby/puppet.rb:246:in `override'
/usr/lib/ruby/vendor_ruby/puppet/configurer.rb:133:in `run'
/usr/lib/ruby/vendor_ruby/puppet/agent.rb:47:in `block (4 levels) in run'
/usr/lib/ruby/vendor_ruby/puppet/agent/locker.rb:20:in `lock'
/usr/lib/ruby/vendor_ruby/puppet/agent.rb:47:in `block (3 levels) in run'
/usr/lib/ruby/vendor_ruby/puppet/agent.rb:117:in `with_client'
/usr/lib/ruby/vendor_ruby/puppet/agent.rb:44:in `block (2 levels) in run'
/usr/lib/ruby/vendor_ruby/puppet/agent.rb:82:in `run_in_fork'
/usr/lib/ruby/vendor_ruby/puppet/agent.rb:43:in `block in run'
/usr/lib/ruby/vendor_ruby/puppet/application.rb:179:in `controlled_run'
/usr/lib/ruby/vendor_ruby/puppet/agent.rb:41:in `run'
/usr/lib/ruby/vendor_ruby/puppet/application/agent.rb:361:in `onetime'
/usr/lib/ruby/vendor_ruby/puppet/application/agent.rb:327:in `run_command'
/usr/lib/ruby/vendor_ruby/puppet/application.rb:381:in `block (2 levels) in run'
/usr/lib/ruby/vendor_ruby/puppet/application.rb:507:in `plugin_hook'
/usr/lib/ruby/vendor_ruby/puppet/application.rb:381:in `block in run'
/usr/lib/ruby/vendor_ruby/puppet/util.rb:496:in `exit_on_fail'
/usr/lib/ruby/vendor_ruby/puppet/application.rb:381:in `run'
/usr/lib/ruby/vendor_ruby/puppet/util/command_line.rb:146:in `run'
/usr/lib/ruby/vendor_ruby/puppet/util/command_line.rb:92:in `execute'
/usr/bin/puppet:8:in `<main>'
Error: /Stage[main]/Mysql::Bindings::Php/Package[php-mysql]/ensure: change from purged to present failed: E                                                                                                                      xecution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install php5-mysql' returned 100: Re                                                                                                                      ading package lists...
Building dependency tree...
Reading state information...
Package php5-mysql is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'php5-mysql' has no installation candidate
