### PR TITLE
(MODULES-3623) Centralise MySQL calls, so they can all be modified fr…

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -3,3 +3,22 @@ Gemfile:
   optional:
     ':development, :unit_tests':
       - gem: rspec-puppet-facts
+.travis.yml:
+  includes:
+  - rvm: 2.3.1
+    env: PUPPET_GEM_VERSION="~> 4.0" STDLIB_LOG_DEPRECATIONS="false"
+    bundler_args: --without system_tests
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4.0" STDLIB_LOG_DEPRECATIONS="false"
+    bundler_args: --without system_tests
+  - rvm: 2.1.5
+    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+    bundler_args: --without system_tests
+  - rvm: 2.1.5
+    env: PUPPET_GEM_VERSION="~> 3.0"
+    bundler_args: --without system_tests
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0"
+    bundler_args: --without system_tests
+spec/spec_helper.rb:
+  allow_deprecations: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ matrix:
     sudo: required
   - rvm: 2.3.1
     bundler_args: --without system_tests
-    env: PUPPET_GEM_VERSION="~> 4.0"
+    env: PUPPET_GEM_VERSION="~> 4.0" STDLIB_LOG_DEPRECATIONS="false"
   - rvm: 2.1.9
     bundler_args: --without system_tests
-    env: PUPPET_GEM_VERSION="~> 4.0"
+    env: PUPPET_GEM_VERSION="~> 4.0" STDLIB_LOG_DEPRECATIONS="false"
   - rvm: 2.1.5
     bundler_args: --without system_tests
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"

--- a/README.md
+++ b/README.md
@@ -1048,3 +1048,4 @@ This module is based on work by David Schmitt. The following contributors have c
 * Chris Weyl
 * Daniël van Eeden
 * Jan-Otto Kröpke
+* Timothy Sven Nelson

--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ users => {
     max_updates_per_hour     => '0',
     max_user_connections     => '0',
     password_hash            => '*F3A2A51A9B0F2BE2468926B4132313728C250DBF',
+    tls_options              => ['NONE'],
   },
 }
 ```
@@ -870,6 +871,14 @@ mysql_user{ 'myuser'@'localhost':
 }
 ```
 
+TLS options can be specified for a user.
+```
+mysql_user{ 'myuser'@'localhost':
+  ensure                   => 'present',
+  tls_options              => ['SSL'],
+}
+```
+
 ##### `name`
 
 The name of the user, as 'username@hostname' or username@hostname.
@@ -893,6 +902,10 @@ Maximum queries per hour for the user. Must be an integer value. A value of '0' 
 ##### `max_updates_per_hour`
 
 Maximum updates per hour for the user. Must be an integer value. A value of '0' specifies no (or global) limit.
+
+##### `tls_options`
+
+SSL-related options for a MySQL account, using one or more tls_option values. 'NONE' specifies that the account has no TLS options enforced, and the available options are 'SSL', 'X509', 'CIPHER *cipher*', 'ISSUER *issuer*', 'SUBJECT *subject*'; as stated in the MySQL documentation.
 
 
 #### mysql_grant

--- a/README.md
+++ b/README.md
@@ -897,7 +897,7 @@ Maximum updates per hour for the user. Must be an integer value. A value of '0' 
 ```
 mysql_grant { 'root@localhost/*.*':
   ensure     => 'present',
-  options    => ['GRANT'],
+  options    => ['REQUIRE SSL', 'GRANT'],
   privileges => ['ALL'],
   table      => '*.*',
   user       => 'root@localhost',
@@ -939,7 +939,8 @@ User to whom privileges are granted.
 
 ##### `options`
 
-MySQL options to grant. Optional.
+Array of MySQL options to grant. Optional.
+Supported options are 'REQUIRE SSL', 'REQUIRE X509', 'GRANT'.
 
 #### mysql_plugin
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ mysql::db { 'mydb':
   password => 'mypass',
   host     => 'localhost',
   grant    => ['SELECT', 'UPDATE'],
-  sql      => '/path/to/sqlfile',
+  sql      => '/path/to/sqlfile.gz',
+  import_cat_cmd => 'zcat',
   import_timeout => 900,
 }
 ```
@@ -820,6 +821,10 @@ Specifies whether to create the database. Valid values are 'present', 'absent'. 
 
 Timeout, in seconds, for loading the sqlfiles. Defaults to '300'.
 
+##### `import_cat_cmd`
+
+Command to read the sqlfile for importing the database. Useful for compressed sqlfiles. For example, you can use 'zcat' for .gz files. Defaults to 'cat'.
+
 ### Types
 
 #### mysql_database
@@ -1030,4 +1035,4 @@ This module is based on work by David Schmitt. The following contributors have c
 * Michael Arnold
 * Chris Weyl
 * Daniël van Eeden
-
+* Jan-Otto Kröpke

--- a/README.md
+++ b/README.md
@@ -902,7 +902,7 @@ Maximum updates per hour for the user. Must be an integer value. A value of '0' 
 ```
 mysql_grant { 'root@localhost/*.*':
   ensure     => 'present',
-  options    => ['REQUIRE SSL', 'GRANT'],
+  options    => ['GRANT'],
   privileges => ['ALL'],
   table      => '*.*',
   user       => 'root@localhost',
@@ -944,8 +944,7 @@ User to whom privileges are granted.
 
 ##### `options`
 
-Array of MySQL options to grant. Optional.
-Supported options are 'REQUIRE SSL', 'REQUIRE X509', 'GRANT'.
+MySQL options to grant. Optional.
 
 #### mysql_plugin
 

--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -104,10 +104,8 @@ class Puppet::Provider::Mysql < Puppet::Provider
   # Take in potential options and build up a query string with them.
   def self.cmd_options(options)
     option_string = ''
-    options.sort.reverse_each do |opt|
-      if op = opt.match(/^REQUIRE\s(SSL|X509)$/)
-        option_string << " #{op[0]}"
-      elsif opt == 'GRANT'
+    options.each do |opt|
+      if opt == 'GRANT'
         option_string << ' WITH GRANT OPTION'
       end
     end

--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -104,8 +104,10 @@ class Puppet::Provider::Mysql < Puppet::Provider
   # Take in potential options and build up a query string with them.
   def self.cmd_options(options)
     option_string = ''
-    options.each do |opt|
-      if opt == 'GRANT'
+    options.sort.reverse_each do |opt|
+      if op = opt.match(/^REQUIRE\s(SSL|X509)$/)
+        option_string << " #{op[0]}"
+      elsif opt == 'GRANT'
         option_string << ' WITH GRANT OPTION'
       end
     end

--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -56,9 +56,9 @@ class Puppet::Provider::Mysql < Puppet::Provider
 
   def self.mysql(textOfSQL, type)
     if type.eql? 'system'
-      mysql([defaults_file, '--host=', system_database, '-e', textOfSQL].compact)
-#    else
-#      mysql([defaults_file, '-NBe', textOfSQL].compact)
+      mysql([defaults_file, '--host=', system_database, '-e', textOfSQL].flatten.compact)
+    else
+      mysql([defaults_file, '-NBe', textOfSQL].flatten.compact)
     end
   end
 

--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -54,8 +54,16 @@ class Puppet::Provider::Mysql < Puppet::Provider
     self.class.defaults_file
   end
 
+  def self.mysql(textOfSQL, type)
+    if type.eql? 'system'
+      mysql([defaults_file, '--host=', system_database, '-e', textOfSQL].compact)
+#    else
+#      mysql([defaults_file, '-NBe', textOfSQL].compact)
+    end
+  end
+
   def self.users
-    mysql([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"].compact).split("\n")
+    self.mysql("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user").split("\n")
   end
 
   # Optional parameter to run a statement on the MySQL system database.

--- a/lib/puppet/provider/mysql_database/mysql.rb
+++ b/lib/puppet/provider/mysql_database/mysql.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::
   def self.instances
     self.mysql('show databases').split("\n").collect do |name|
       attributes = {}
-      self.mysql("show variables like '%_database'").split("\n").each do |line|
+      self.mysql(["show variables like '%_database'", name]).split("\n").each do |line|
         k,v = line.split(/\s/)
         attributes[k] = v
       end

--- a/lib/puppet/provider/mysql_database/mysql.rb
+++ b/lib/puppet/provider/mysql_database/mysql.rb
@@ -5,9 +5,9 @@ Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::
   commands :mysql => 'mysql'
 
   def self.instances
-    mysql([defaults_file, '-NBe', 'show databases'].compact).split("\n").collect do |name|
+    self.mysql('show databases').split("\n").collect do |name|
       attributes = {}
-      mysql([defaults_file, '-NBe', "show variables like '%_database'", name].compact).split("\n").each do |line|
+      self.mysql("show variables like '%_database'").split("\n").each do |line|
         k,v = line.split(/\s/)
         attributes[k] = v
       end
@@ -31,7 +31,7 @@ Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::
   end
 
   def create
-    mysql([defaults_file, '-NBe', "create database if not exists `#{@resource[:name]}` character set `#{@resource[:charset]}` collate `#{@resource[:collate]}`"].compact)
+    self.mysql("create database if not exists `#{@resource[:name]}` character set `#{@resource[:charset]}` collate `#{@resource[:collate]}`")
 
     @property_hash[:ensure]  = :present
     @property_hash[:charset] = @resource[:charset]
@@ -41,7 +41,7 @@ Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::
   end
 
   def destroy
-    mysql([defaults_file, '-NBe', "drop database if exists `#{@resource[:name]}`"].compact)
+    self.mysql("drop database if exists `#{@resource[:name]}`")
 
     @property_hash.clear
     exists? ? (return false) : (return true)
@@ -54,13 +54,13 @@ Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::
   mk_resource_methods
 
   def charset=(value)
-    mysql([defaults_file, '-NBe', "alter database `#{resource[:name]}` CHARACTER SET #{value}"].compact)
+    self.mysql("alter database `#{resource[:name]}` CHARACTER SET #{value}")
     @property_hash[:charset] = value
     charset == value ? (return true) : (return false)
   end
 
   def collate=(value)
-    mysql([defaults_file, '-NBe', "alter database `#{resource[:name]}` COLLATE #{value}"].compact)
+    self.mysql("alter database `#{resource[:name]}` COLLATE #{value}")
     @property_hash[:collate] = value
     collate == value ? (return true) : (return false)
   end

--- a/lib/puppet/provider/mysql_datadir/mysql.rb
+++ b/lib/puppet/provider/mysql_datadir/mysql.rb
@@ -41,16 +41,16 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, :parent => Puppet::Provider::M
     end
 
     if mysqld_version.nil?
-      debug("Installing MySQL data directory with mysql_install_db #{defaults_extra_file} --basedir=#{basedir} --datadir=#{datadir} --user=#{user}")
+      debug("Installing MySQL data directory with mysql_install_db #{opts.compact.join(" ")}")
       mysql_install_db(opts.compact)
     else
       if (mysqld_type == "mysql" or mysqld_type == "percona") and Puppet::Util::Package.versioncmp(mysqld_version, '5.7.6') >= 0
-        debug("Initializing MySQL data directory >= 5.7.6 with 'mysqld #{defaults_extra_file} #{initialize} --basedir=#{basedir} --datadir=#{datadir} --user=#{user}'")
         opts<<"--log-error=#{log_error}"
         opts<<"#{initialize}"
+        debug("Initializing MySQL data directory >= 5.7.6 with mysqld: #{opts.compact.join(" ")}")
         mysqld(opts.compact)
       else
-        debug("Installing MySQL data directory with mysql_install_db #{defaults_extra_file} --basedir=#{basedir} --datadir=#{datadir} --user=#{user}")
+        debug("Installing MySQL data directory with mysql_install_db #{opts.compact.join(" ")}")
         mysql_install_db(opts.compact)
       end
     end

--- a/lib/puppet/provider/mysql_datadir/mysql.rb
+++ b/lib/puppet/provider/mysql_datadir/mysql.rb
@@ -47,6 +47,7 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, :parent => Puppet::Provider::M
       if (mysqld_type == "mysql" or mysqld_type == "percona") and Puppet::Util::Package.versioncmp(mysqld_version, '5.7.6') >= 0
         debug("Initializing MySQL data directory >= 5.7.6 with 'mysqld #{defaults_extra_file} #{initialize} --basedir=#{basedir} --datadir=#{datadir} --user=#{user}'")
         opts<<"--log-error=#{log_error}"
+        opts<<"#{initialize}"
         mysqld(opts.compact)
       else
         debug("Installing MySQL data directory with mysql_install_db #{defaults_extra_file} --basedir=#{basedir} --datadir=#{datadir} --user=#{user}")
@@ -64,7 +65,7 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, :parent => Puppet::Provider::M
 
   def exists?
     datadir = @resource[:datadir]
-    (File.directory?("#{datadir}/mysql")) && (Dir.entries("#{datadir}/mysql") - %w{ . .. }).any? 
+    (File.directory?("#{datadir}/mysql")) && (Dir.entries("#{datadir}/mysql") - %w{ . .. }).any?
   end
 
   ##
@@ -75,4 +76,3 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, :parent => Puppet::Provider::M
   mk_resource_methods
 
 end
-

--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -46,11 +46,11 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
             end
           end
           # Same here, but to remove OPTION leaving just GRANT.
-          options = []
-          req_opt = rest.match(/REQUIRE\s(SSL|X509)/)
-          options << req_opt[0] if req_opt
-          options << 'GRANT' if rest.match(/WITH\sGRANT\sOPTION/)
-          options << 'NONE' if options.empty?
+          if rest.match(/WITH\sGRANT\sOPTION/)           
+		options = ['GRANT']
+          else
+                options = ['NONE']
+          end
           # fix double backslash that MySQL prints, so resources match
           table.gsub!("\\\\", "\\")
           # We need to return an array of instances so capture these

--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
       user_string = self.cmd_user(user)
       query = "SHOW GRANTS FOR #{user_string};"
       begin
-        grants = mysql([defaults_file, "-NBe", query].compact)
+        grants = self.mysql(query)
       rescue Puppet::ExecutionFailure => e
         # Silently ignore users with no grants. Can happen e.g. if user is
         # defined with fqdn and server is run with skip-name-resolve. Example:
@@ -85,7 +85,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
     query << " ON #{table_string}"
     query << " TO #{user_string}"
     query << self.class.cmd_options(options) unless options.nil?
-    mysql([defaults_file, system_database, '-e', query].compact)
+    self.mysql(query, 'system')
   end
 
   def create
@@ -111,10 +111,10 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
     # exist to be executed successfully
     if revoke_privileges.include? 'ALL'
       query = "REVOKE GRANT OPTION ON #{table_string} FROM #{user_string}"
-      mysql([defaults_file, system_database, '-e', query].compact)
+      self.mysql(query, 'system')
     end
     query = "REVOKE #{priv_string} ON #{table_string} FROM #{user_string}"
-    mysql([defaults_file, system_database, '-e', query].compact)
+    self.mysql(query, 'system')
   end
 
   def destroy
@@ -134,7 +134,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
 
   def flush
     @property_hash.clear
-    mysql([defaults_file, '-NBe', 'FLUSH PRIVILEGES'].compact)
+    self.mysql('FLUSH PRIVILEGES')
   end
 
   mk_resource_methods

--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -46,11 +46,11 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
             end
           end
           # Same here, but to remove OPTION leaving just GRANT.
-          if rest.match(/WITH\sGRANT\sOPTION/)           
-		options = ['GRANT']
-          else
-                options = ['NONE']
-          end
+          options = []
+          req_opt = rest.match(/REQUIRE\s(SSL|X509)/)
+          options << req_opt[0] if req_opt
+          options << 'GRANT' if rest.match(/WITH\sGRANT\sOPTION/)
+          options << 'NONE' if options.empty?
           # fix double backslash that MySQL prints, so resources match
           table.gsub!("\\\\", "\\")
           # We need to return an array of instances so capture these

--- a/lib/puppet/provider/mysql_plugin/mysql.rb
+++ b/lib/puppet/provider/mysql_plugin/mysql.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:mysql_plugin).provide(:mysql, :parent => Puppet::Provider::My
   commands :mysql => 'mysql'
 
   def self.instances
-    mysql([defaults_file, '-NBe', 'show plugins'].compact).split("\n").collect do |line|
+    self.mysql('show plugins').split("\n").collect do |line|
       name, status, type, library, license = line.split(/\t/)
       new(:name    => name,
           :ensure  => :present,
@@ -29,7 +29,7 @@ Puppet::Type.type(:mysql_plugin).provide(:mysql, :parent => Puppet::Provider::My
     # Use plugin_name.so as soname if it's not specified. This won't work on windows as
     # there it should be plugin_name.dll
     @resource[:soname].nil? ? (soname=@resource[:name] + '.so') : (soname=@resource[:soname])
-    mysql([defaults_file, '-NBe', "install plugin #{@resource[:name]} soname '#{soname}'"].compact)
+    self.mysql("install plugin #{@resource[:name]} soname '#{soname}'")
 
     @property_hash[:ensure]  = :present
     @property_hash[:soname] = @resource[:soname]
@@ -38,7 +38,7 @@ Puppet::Type.type(:mysql_plugin).provide(:mysql, :parent => Puppet::Provider::My
   end
 
   def destroy
-    mysql([defaults_file, '-NBe', "uninstall plugin #{@resource[:name]}"].compact)
+    self.mysql("uninstall plugin #{@resource[:name]}")
 
     @property_hash.clear
     exists? ? (return false) : (return true)

--- a/lib/puppet/type/mysql_user.rb
+++ b/lib/puppet/type/mysql_user.rb
@@ -75,4 +75,31 @@ Puppet::Type.newtype(:mysql_user) do
     newvalue(/\d+/)
   end
 
+  newproperty(:tls_options, :array_matching => :all) do
+    desc "Options to that set the TLS-related REQUIRE attributes for the user."
+    validate do |value|
+      value = [value] if not value.is_a?(Array)
+      if value.include? 'NONE' or value.include? 'SSL' or value.include? 'X509'
+        if value.length > 1
+          raise(ArgumentError, "REQUIRE tls options NONE, SSL and X509 cannot be used with other options, you may only use one of them.")
+        end
+      else
+        value.each do |opt|
+          if not o = opt.match(/^(CIPHER|ISSUER|SUBJECT)/i)
+            raise(ArgumentError, "Invalid tls option #{o}")
+          end
+        end
+      end
+    end
+    def insync?(is)
+      # The current value may be nil and we don't
+      # want to call sort on it so make sure we have arrays
+      if is.is_a?(Array) and @should.is_a?(Array)
+        is.sort == @should.sort
+      else
+        is == @should
+      end
+    end
+  end
+
 end

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -11,6 +11,7 @@ define mysql::db (
   $enforce_sql    = false,
   $ensure         = 'present',
   $import_timeout = 300,
+  $import_cat_cmd = 'cat',
 ) {
   #input validation
   validate_re($ensure, '^(present|absent)$',
@@ -57,7 +58,7 @@ define mysql::db (
 
     if $sql {
       exec{ "${dbname}-import":
-        command     => "cat ${sql_inputs} | mysql ${dbname}",
+        command     => "${import_cat_cmd} ${sql_inputs} | mysql ${dbname}",
         logoutput   => true,
         environment => "HOME=${::root_home}",
         refreshonly => $refresh,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -187,11 +187,15 @@ class mysql::params {
       # mysql::bindings
       $java_package_name   = 'libmysql-java'
       $perl_package_name   = 'libdbd-mysql-perl'
-      $php_package_name    = 'php5-mysql'
+      $php_package_name    = $::lsbdistcodename ? {
+        'xenial'           => 'php-mysql',
+        default            => 'php5-mysql',
+      }
       $python_package_name = 'python-mysqldb'
       $ruby_package_name   = $::lsbdistcodename ? {
         'trusty'           => 'ruby-mysql',
         'jessie'           => 'ruby-mysql',
+        'xenial'           => 'ruby-mysql',
         default            => 'libmysql-ruby',
       }
       $client_dev_package_name = 'libmysqlclient-dev'

--- a/spec/acceptance/types/mysql_grant_spec.rb
+++ b/spec/acceptance/types/mysql_grant_spec.rb
@@ -17,7 +17,7 @@ describe 'mysql_grant' do
   describe 'missing privileges for user' do
     it 'should fail' do
       pp = <<-EOS
-        mysql_user { 'test1@tester':
+        mysql_user { 'test1@tester': 
           ensure => present,
         }
         mysql_grant { 'test1@tester/test.*':
@@ -129,35 +129,7 @@ describe 'mysql_grant' do
     end
   end
 
-  describe 'adding REQUIRE SSL option' do
-    it 'should work without errors' do
-      pp = <<-EOS
-        mysql_user { 'test3@tester':
-          ensure => present,
-        }
-        mysql_grant { 'test3@tester/test.*':
-          ensure     => 'present',
-          table      => 'test.*',
-          user       => 'test3@tester',
-          options    => ['REQUIRE SSL'],
-          privileges => ['SELECT', 'UPDATE'],
-          require    => Mysql_user['test3@tester'],
-        }
-      EOS
-
-      apply_manifest(pp, :catch_failures => true)
-    end
-
-    it 'should find the user' do
-      shell("mysql -NBe \"SHOW GRANTS FOR test3@tester\"") do |r|
-        expect(r.stdout).to match(/GRANT USAGE ON *.* TO 'test3'@'tester' REQUIRE SSL$/)
-        expect(r.stdout).to match(/GRANT SELECT, UPDATE ON `test`.* TO 'test3'@'tester'$/)
-        expect(r.stderr).to be_empty
-      end
-    end
-  end
-
-  describe 'adding GRANT option' do
+  describe 'adding option' do
     it 'should work without errors' do
       pp = <<-EOS
         mysql_user { 'test3@tester':
@@ -178,62 +150,6 @@ describe 'mysql_grant' do
 
     it 'should find the user' do
       shell("mysql -NBe \"SHOW GRANTS FOR test3@tester\"") do |r|
-        expect(r.stdout).to match(/GRANT SELECT, UPDATE ON `test`.* TO 'test3'@'tester' WITH GRANT OPTION$/)
-        expect(r.stderr).to be_empty
-      end
-    end
-  end
-
-  describe 'adding REQUIRE X509 and GRANT option' do
-    it 'should work without errors' do
-      pp = <<-EOS
-        mysql_user { 'test3@tester':
-          ensure => present,
-        }
-        mysql_grant { 'test3@tester/test.*':
-          ensure     => 'present',
-          table      => 'test.*',
-          user       => 'test3@tester',
-          options    => ['REQUIRE X509', 'GRANT'],
-          privileges => ['SELECT', 'UPDATE'],
-          require    => Mysql_user['test3@tester'],
-        }
-      EOS
-
-      apply_manifest(pp, :catch_failures => true)
-    end
-
-    it 'should find the user' do
-      shell("mysql -NBe \"SHOW GRANTS FOR test3@tester\"") do |r|
-        expect(r.stdout).to match(/GRANT USAGE ON *.* TO 'test3'@'tester' REQUIRE X509$/)
-        expect(r.stdout).to match(/GRANT SELECT, UPDATE ON `test`.* TO 'test3'@'tester' WITH GRANT OPTION$/)
-        expect(r.stderr).to be_empty
-      end
-    end
-  end
-
-  describe 'adding GRANT and REQUIRE X509 option' do
-    it 'should work without errors' do
-      pp = <<-EOS
-        mysql_user { 'test3@tester':
-          ensure => present,
-        }
-        mysql_grant { 'test3@tester/test.*':
-          ensure     => 'present',
-          table      => 'test.*',
-          user       => 'test3@tester',
-          options    => ['GRANT', 'REQUIRE X509'],
-          privileges => ['SELECT', 'UPDATE'],
-          require    => Mysql_user['test3@tester'],
-        }
-      EOS
-
-      apply_manifest(pp, :catch_failures => true)
-    end
-
-    it 'should find the user' do
-      shell("mysql -NBe \"SHOW GRANTS FOR test3@tester\"") do |r|
-        expect(r.stdout).to match(/GRANT USAGE ON *.* TO 'test3'@'tester' REQUIRE X509$/)
         expect(r.stdout).to match(/GRANT SELECT, UPDATE ON `test`.* TO 'test3'@'tester' WITH GRANT OPTION$/)
         expect(r.stderr).to be_empty
       end

--- a/spec/acceptance/types/mysql_user_spec.rb
+++ b/spec/acceptance/types/mysql_user_spec.rb
@@ -29,6 +29,12 @@ describe 'mysql_user' do
           expect(r.stderr).to be_empty
         end
       end
+      it 'has no SSL options' do
+        shell("mysql -NBe \"select SSL_TYPE from mysql.user where CONCAT(user, '@', host) = 'ashp@localhost'\"") do |r|
+          expect(r.stdout).to match(/^\s*$/)
+          expect(r.stderr).to be_empty
+        end
+      end
     end
   end
 
@@ -81,6 +87,60 @@ describe 'mysql_user' do
           expect(r.stdout).to_not match(/must be properly quoted, invalid character:/)
         end
       }
+    end
+  end
+  context 'using user-w-ssl@localhost with SSL' do
+    describe 'adding user' do
+      it 'should work without errors' do
+        pp = <<-EOS
+          mysql_user { 'user-w-ssl@localhost':
+            password_hash => '*F9A8E96790775D196D12F53BCC88B8048FF62ED5',
+            tls_options   => ['SSL'],
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+      end
+
+      it 'should find the user' do
+        shell("mysql -NBe \"select '1' from mysql.user where CONCAT(user, '@', host) = 'user-w-ssl@localhost'\"") do |r|
+          expect(r.stdout).to match(/^1$/)
+          expect(r.stderr).to be_empty
+        end
+      end
+      it 'should show correct ssl_type' do
+        shell("mysql -NBe \"select SSL_TYPE from mysql.user where CONCAT(user, '@', host) = 'user-w-ssl@localhost'\"") do |r|
+          expect(r.stdout).to match(/^ANY$/)
+          expect(r.stderr).to be_empty
+        end
+      end
+    end
+  end
+  context 'using user-w-x509@localhost with X509' do
+    describe 'adding user' do
+      it 'should work without errors' do
+        pp = <<-EOS
+          mysql_user { 'user-w-x509@localhost':
+            password_hash => '*F9A8E96790775D196D12F53BCC88B8048FF62ED5',
+            tls_options   => ['X509'],
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+      end
+
+      it 'should find the user' do
+        shell("mysql -NBe \"select '1' from mysql.user where CONCAT(user, '@', host) = 'user-w-x509@localhost'\"") do |r|
+          expect(r.stdout).to match(/^1$/)
+          expect(r.stderr).to be_empty
+        end
+      end
+      it 'should show correct ssl_type' do
+        shell("mysql -NBe \"select SSL_TYPE from mysql.user where CONCAT(user, '@', host) = 'user-w-x509@localhost'\"") do |r|
+          expect(r.stdout).to match(/^X509$/)
+          expect(r.stderr).to be_empty
+        end
+      end
     end
   end
 end

--- a/spec/defines/mysql_db_spec.rb
+++ b/spec/defines/mysql_db_spec.rb
@@ -40,7 +40,13 @@ describe 'mysql::db', :type => :define do
       it 'should import sql script on creation if enforcing' do
         params.merge!({'sql' => 'test_sql', 'enforce_sql' => true})
         is_expected.to contain_exec('test_db-import').with_refreshonly(false)
-        is_expected.to contain_exec('test_db-import').with_command("cat test_sql | mysql test_db")
+        is_expected.to contain_exec('test_db-import').with_command('cat test_sql | mysql test_db')
+      end
+
+      it 'should import sql script with custom command on creation if enforcing' do
+        params.merge!({'sql' => 'test_sql', 'enforce_sql' => true, 'import_cat_cmd' => 'zcat'})
+        is_expected.to contain_exec('test_db-import').with_refreshonly(false)
+        is_expected.to contain_exec('test_db-import').with_command('zcat test_sql | mysql test_db')
       end
 
       it 'should import sql scripts when more than one is specified' do

--- a/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
@@ -30,17 +30,17 @@ test
     Facter.stubs(:value).with(:root_home).returns('/root')
     Puppet::Util.stubs(:which).with('mysql').returns('/usr/bin/mysql')
     File.stubs(:file?).with('/root/.my.cnf').returns(true)
-    provider.class.stubs(:mysql).with([defaults_file, '-NBe', 'show databases']).returns('new_database')
-    provider.class.stubs(:mysql).with([defaults_file, '-NBe', "show variables like '%_database'", 'new_database']).returns("character_set_database latin1\ncollation_database latin1_swedish_ci\nskip_show_database OFF")
+    provider.class.stubs(:mysql).with('show databases').returns('new_database')
+    provider.class.stubs(:mysql).with(["show variables like '%_database'", 'new_database']).returns("character_set_database latin1\ncollation_database latin1_swedish_ci\nskip_show_database OFF")
   end
 
   let(:instance) { provider.class.instances.first }
 
   describe 'self.instances' do
     it 'returns an array of databases' do
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', 'show databases']).returns(raw_databases)
+      provider.class.stubs(:mysql).with('show databases').returns(raw_databases)
       raw_databases.each_line do |db|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "show variables like '%_database'", db.chomp]).returns("character_set_database latin1\ncollation_database  latin1_swedish_ci\nskip_show_database  OFF")
+        provider.class.stubs(:mysql).with(["show variables like '%_database'", db.chomp]).returns("character_set_database latin1\ncollation_database  latin1_swedish_ci\nskip_show_database  OFF")
       end
       databases = provider.class.instances.collect {|x| x.name }
       expect(parsed_databases).to match_array(databases)
@@ -56,7 +56,7 @@ test
 
   describe 'create' do
     it 'makes a database' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "create database if not exists `#{resource[:name]}` character set `#{resource[:charset]}` collate `#{resource[:collate]}`"])
+      provider.expects(:mysql).with("create database if not exists `#{resource[:name]}` character set `#{resource[:charset]}` collate `#{resource[:collate]}`")
       provider.expects(:exists?).returns(true)
       expect(provider.create).to be_truthy
     end
@@ -64,7 +64,7 @@ test
 
   describe 'destroy' do
     it 'removes a database if present' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "drop database if exists `#{resource[:name]}`"])
+      provider.expects(:mysql).with("drop database if exists `#{resource[:name]}`")
       provider.expects(:exists?).returns(false)
       expect(provider.destroy).to be_truthy
     end
@@ -95,7 +95,7 @@ test
 
   describe 'charset=' do
     it 'changes the charset' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "alter database `#{resource[:name]}` CHARACTER SET blah"]).returns('0')
+      provider.expects(:mysql).with("alter database `#{resource[:name]}` CHARACTER SET blah").returns('0')
 
       provider.charset=('blah')
     end
@@ -109,7 +109,7 @@ test
 
   describe 'collate=' do
     it 'changes the collate' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "alter database `#{resource[:name]}` COLLATE blah"]).returns('0')
+      provider.expects(:mysql).with("alter database `#{resource[:name]}` COLLATE blah").returns('0')
 
       provider.collate=('blah')
     end

--- a/spec/unit/puppet/provider/mysql_plugin/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_plugin/mysql_spec.rb
@@ -17,7 +17,7 @@ describe Puppet::Type.type(:mysql_plugin).provider(:mysql) do
     Facter.stubs(:value).with(:root_home).returns('/root')
     Puppet::Util.stubs(:which).with('mysql').returns('/usr/bin/mysql')
     File.stubs(:file?).with('/root/.my.cnf').returns(true)
-    provider.class.stubs(:mysql).with([defaults_file, '-NBe', 'show plugins']).returns('auth_socket	ACTIVE	AUTHENTICATION	auth_socket.so	GPL')
+    provider.class.stubs(:mysql).with('show plugins').returns('auth_socket	ACTIVE	AUTHENTICATION	auth_socket.so	GPL')
   end
 
   let(:instance) { provider.class.instances.first }
@@ -31,7 +31,7 @@ describe Puppet::Type.type(:mysql_plugin).provider(:mysql) do
 
   describe 'create' do
     it 'loads a plugin' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "install plugin #{resource[:name]} soname '#{resource[:soname]}'"])
+      provider.expects(:mysql).with("install plugin #{resource[:name]} soname '#{resource[:soname]}'")
       provider.expects(:exists?).returns(true)
       expect(provider.create).to be_truthy
     end
@@ -39,7 +39,7 @@ describe Puppet::Type.type(:mysql_plugin).provider(:mysql) do
 
   describe 'destroy' do
     it 'unloads a plugin if present' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "uninstall plugin #{resource[:name]}"])
+      provider.expects(:mysql).with("uninstall plugin #{resource[:name]}")
       provider.expects(:exists?).returns(false)
       expect(provider.destroy).to be_truthy
     end

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -88,7 +88,7 @@ usvn_user@localhost
     Puppet::Util.stubs(:which).with('mysqld').returns('/usr/sbin/mysqld')
     File.stubs(:file?).with('/root/.my.cnf').returns(true)
     provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns('joe@localhost')
-    provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = 'joe@localhost'"]).returns('10 10 10 10 *6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4')
+    provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = 'joe@localhost'"]).returns('10 10 10 10     *6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4')
   end
 
   let(:instance) { provider.class.instances.first }
@@ -98,7 +98,7 @@ usvn_user@localhost
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
       provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10 ')
+        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -108,7 +108,7 @@ usvn_user@localhost
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
       provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10 ')
+        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -118,7 +118,7 @@ usvn_user@localhost
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
       provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10 ')
+        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -128,7 +128,7 @@ usvn_user@localhost
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
       provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, AUTHENTICATION_STRING, PLUGIN FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10 ')
+        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, AUTHENTICATION_STRING, PLUGIN FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -138,7 +138,7 @@ usvn_user@localhost
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
       provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10 ')
+        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -148,7 +148,7 @@ usvn_user@localhost
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['percona-5.5'][:string])
       provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10 ')
+        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -180,6 +180,7 @@ usvn_user@localhost
     it 'makes a user' do
       provider.expects(:mysql).with([defaults_file, system_database, '-e', "CREATE USER 'joe'@'localhost' IDENTIFIED BY PASSWORD '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4'"])
       provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' WITH MAX_USER_CONNECTIONS 10 MAX_CONNECTIONS_PER_HOUR 10 MAX_QUERIES_PER_HOUR 10 MAX_UPDATES_PER_HOUR 10"])
+      provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE"])
       provider.expects(:exists?).returns(true)
       expect(provider.create).to be_truthy
     end
@@ -282,6 +283,44 @@ usvn_user@localhost
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
+    end
+  end
+
+  describe 'tls_options=' do
+    it 'adds SSL option grant in mysql 5.5' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
+      provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE"]).returns('0')
+
+      provider.expects(:tls_options).returns(['NONE'])
+      provider.tls_options=(['NONE'])
+    end
+    it 'adds SSL option grant in mysql 5.6' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
+      provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE"]).returns('0')
+
+      provider.expects(:tls_options).returns(['NONE'])
+      provider.tls_options=(['NONE'])
+    end
+    it 'adds SSL option grant in mysql < 5.7.6' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
+      provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE"]).returns('0')
+
+      provider.expects(:tls_options).returns(['NONE'])
+      provider.tls_options=(['NONE'])
+    end
+    it 'adds SSL option grant in mysql >= 5.7.6' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
+      provider.expects(:mysql).with([defaults_file, system_database, '-e', "ALTER USER 'joe'@'localhost' REQUIRE NONE"]).returns('0')
+
+      provider.expects(:tls_options).returns(['NONE'])
+      provider.tls_options=(['NONE'])
+    end
+    it 'adds SSL option grant in mariadb-10.0' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
+      provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE"]).returns('0')
+
+      provider.expects(:tls_options).returns(['NONE'])
+      provider.tls_options=(['NONE'])
     end
   end
 

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -87,8 +87,8 @@ usvn_user@localhost
     Puppet::Util.stubs(:which).with('mysql').returns('/usr/bin/mysql')
     Puppet::Util.stubs(:which).with('mysqld').returns('/usr/sbin/mysqld')
     File.stubs(:file?).with('/root/.my.cnf').returns(true)
-    provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns('joe@localhost')
-    provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = 'joe@localhost'"]).returns('10 10 10 10     *6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4')
+    provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user").returns('joe@localhost')
+    provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = 'joe@localhost'").returns('10 10 10 10     *6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4')
   end
 
   let(:instance) { provider.class.instances.first }
@@ -96,9 +96,9 @@ usvn_user@localhost
   describe 'self.instances' do
     it 'returns an array of users MySQL 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user").returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'").returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -106,9 +106,9 @@ usvn_user@localhost
     end
     it 'returns an array of users MySQL 5.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user").returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'").returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -116,9 +116,9 @@ usvn_user@localhost
     end
     it 'returns an array of users MySQL >= 5.7.0 < 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user").returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'").returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -126,9 +126,9 @@ usvn_user@localhost
     end
     it 'returns an array of users MySQL >= 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user").returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, AUTHENTICATION_STRING, PLUGIN FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, AUTHENTICATION_STRING, PLUGIN FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'").returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -136,9 +136,9 @@ usvn_user@localhost
     end
     it 'returns an array of users mariadb 10.0' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user").returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'").returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -146,9 +146,9 @@ usvn_user@localhost
     end
     it 'returns an array of users percona 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['percona-5.5'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user").returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'").returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -178,9 +178,9 @@ usvn_user@localhost
 
   describe 'create' do
     it 'makes a user' do
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "CREATE USER 'joe'@'localhost' IDENTIFIED BY PASSWORD '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4'"])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' WITH MAX_USER_CONNECTIONS 10 MAX_CONNECTIONS_PER_HOUR 10 MAX_QUERIES_PER_HOUR 10 MAX_UPDATES_PER_HOUR 10"])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE"])
+      provider.expects(:mysql).with("CREATE USER 'joe'@'localhost' IDENTIFIED BY PASSWORD '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4'", 'system')
+      provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' WITH MAX_USER_CONNECTIONS 10 MAX_CONNECTIONS_PER_HOUR 10 MAX_QUERIES_PER_HOUR 10 MAX_UPDATES_PER_HOUR 10", 'system')
+      provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system')
       provider.expects(:exists?).returns(true)
       expect(provider.create).to be_truthy
     end
@@ -188,7 +188,7 @@ usvn_user@localhost
 
   describe 'destroy' do
     it 'removes a user if present' do
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "DROP USER 'joe'@'localhost'"])
+      provider.expects(:mysql).with("DROP USER 'joe'@'localhost'", 'system')
       provider.expects(:exists?).returns(false)
       expect(provider.destroy).to be_truthy
     end
@@ -244,42 +244,42 @@ usvn_user@localhost
   describe 'password_hash=' do
     it 'changes the hash mysql 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
     end
     it 'changes the hash mysql 5.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
     end
     it 'changes the hash mysql < 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
     end
     it 'changes the hash MySQL >= 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "ALTER USER 'joe'@'localhost' IDENTIFIED WITH mysql_native_password AS '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("ALTER USER 'joe'@'localhost' IDENTIFIED WITH mysql_native_password AS '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
     end
     it 'changes the hash mariadb-10.0' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
     end
     it 'changes the hash percona-5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['percona-5.5'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
@@ -335,7 +335,7 @@ usvn_user@localhost
 
     describe "#{property}=" do
       it "changes #{property}" do
-        provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' WITH #{property.upcase} 42"]).returns('0')
+        provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' WITH #{property.upcase} 42", 'system').returns('0')
         provider.expects(property.to_sym).returns('42')
         provider.send("#{property}=".to_sym, '42')
       end


### PR DESCRIPTION
…om one place

The current codebase handles each mysql call via calls to the command-line
mysql client.  There are basically only two sets of options passed, but the
options are repeated separately in various places throughout the code.  The
new self.mysql function now issues the call to the mysql client with one of
the two sets of options (selected via an optional function parameter).

Now the options to all mysql calls can be modified from one place.  This will
be useful when we are converting the module to allow for databases on multiple
remote servers, since we will be able to add the -h switch to all calls at
once.
