### PR TITLE
Added parameter import_cat_cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ mysql::db { 'mydb':
   password => 'mypass',
   host     => 'localhost',
   grant    => ['SELECT', 'UPDATE'],
-  sql      => '/path/to/sqlfile',
+  sql      => '/path/to/sqlfile.gz',
+  import_cat_cmd => 'zcat',
   import_timeout => 900,
 }
 ```
@@ -820,6 +821,10 @@ Specifies whether to create the database. Valid values are 'present', 'absent'. 
 
 Timeout, in seconds, for loading the sqlfiles. Defaults to '300'.
 
+##### `import_cat_cmd`
+
+Command to read the sqlfile for importing the database. Useful for compressed sqlfiles. For example, you can use 'zcat' for .gz files. Defaults to 'cat'.
+
 ### Types
 
 #### mysql_database
@@ -1029,4 +1034,4 @@ This module is based on work by David Schmitt. The following contributors have c
 * Michael Arnold
 * Chris Weyl
 * Daniël van Eeden
-
+* Jan-Otto Kröpke

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -11,6 +11,7 @@ define mysql::db (
   $enforce_sql    = false,
   $ensure         = 'present',
   $import_timeout = 300,
+  $import_cat_cmd = 'cat',
 ) {
   #input validation
   validate_re($ensure, '^(present|absent)$',
@@ -57,7 +58,7 @@ define mysql::db (
 
     if $sql {
       exec{ "${dbname}-import":
-        command     => "cat ${sql_inputs} | mysql ${dbname}",
+        command     => "${import_cat_cmd} ${sql_inputs} | mysql ${dbname}",
         logoutput   => true,
         environment => "HOME=${::root_home}",
         refreshonly => $refresh,

--- a/spec/defines/mysql_db_spec.rb
+++ b/spec/defines/mysql_db_spec.rb
@@ -40,7 +40,13 @@ describe 'mysql::db', :type => :define do
       it 'should import sql script on creation if enforcing' do
         params.merge!({'sql' => 'test_sql', 'enforce_sql' => true})
         is_expected.to contain_exec('test_db-import').with_refreshonly(false)
-        is_expected.to contain_exec('test_db-import').with_command("cat test_sql | mysql test_db")
+        is_expected.to contain_exec('test_db-import').with_command('cat test_sql | mysql test_db')
+      end
+
+      it 'should import sql script with custom command on creation if enforcing' do
+        params.merge!({'sql' => 'test_sql', 'enforce_sql' => true, 'import_cat_cmd' => 'zcat'})
+        is_expected.to contain_exec('test_db-import').with_refreshonly(false)
+        is_expected.to contain_exec('test_db-import').with_command('zcat test_sql | mysql test_db')
       end
 
       it 'should import sql scripts when more than one is specified' do


### PR DESCRIPTION
Added parameter import_cat_cmd to specify the command to read sql files. Usefull for compressed sqlfiles

See: https://tickets.puppetlabs.com/browse/MODULES-3879