### PR TITLE
MODULES-3907 Add MySQL/Percona 5.7 initialize on fresh deploy

### DIFF
--- a/lib/puppet/provider/mysql_datadir/mysql.rb
+++ b/lib/puppet/provider/mysql_datadir/mysql.rb
@@ -47,6 +47,7 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, :parent => Puppet::Provider::M
       if (mysqld_type == "mysql" or mysqld_type == "percona") and Puppet::Util::Package.versioncmp(mysqld_version, '5.7.6') >= 0
         debug("Initializing MySQL data directory >= 5.7.6 with 'mysqld #{defaults_extra_file} #{initialize} --basedir=#{basedir} --datadir=#{datadir} --user=#{user}'")
         opts<<"--log-error=#{log_error}"
+        opts<<"#{initialize}"
         mysqld(opts.compact)
       else
         debug("Installing MySQL data directory with mysql_install_db #{defaults_extra_file} --basedir=#{basedir} --datadir=#{datadir} --user=#{user}")
@@ -64,7 +65,7 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, :parent => Puppet::Provider::M
 
   def exists?
     datadir = @resource[:datadir]
-    (File.directory?("#{datadir}/mysql")) && (Dir.entries("#{datadir}/mysql") - %w{ . .. }).any? 
+    (File.directory?("#{datadir}/mysql")) && (Dir.entries("#{datadir}/mysql") - %w{ . .. }).any?
   end
 
   ##
@@ -75,4 +76,3 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, :parent => Puppet::Provider::M
   mk_resource_methods
 
 end
-


### PR DESCRIPTION
Please review the following ticket. 

https://tickets.puppetlabs.com/browse/MODULES-3907


Puppetlabs/mysql does not run --insecure-initilize if the datadir does not contain the mysql directory. The module fails on a fresh MySQL / Percona 5.7 deploy.  

I have reviewed the logic, and don't see anything that would actually run the initialize command. 

After adding the initialize command to the 5.7 block, the deploy is successful, and only runs if the $data_dir/mysql does not exist. 

```
==> integration-7: Notice: /Stage[main]/Mysql::Server::Installdb/File[/var/log/mysql/mysqld.err]/ensure: created
==> integration-7: Debug: /Stage[main]/Mysql::Server::Installdb/File[/var/log/mysql/mysqld.err]: The container Class[Mysql::Server::Installdb] will propagate my refresh event
==> integration-7: Debug: Executing: '/sbin/mysqld -V'
==> integration-7: Debug: Mysql_datadir[/var/lib/mysql](provider=mysql): Initializing MySQL data directory >= 5.7.6 with 'mysqld --defaults-extra-file=/etc/my.cnf --initialize-insecure --basedir=/usr --datadir=/var/lib/mysql --user=mysql'
==> integration-7: Debug: Executing: '/sbin/mysqld --defaults-extra-file=/etc/my.cnf --basedir=/usr --datadir=/var/lib/mysql --user=mysql --log-error=/var/log/mysql/mysqld.err --initialize-insecure'

```
