### PR TITLE
MODULES-3904: Abiliity to use SQL_LOG_BIN for MySQL types

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ users => {
     max_updates_per_hour     => '0',
     max_user_connections     => '0',
     password_hash            => '*F3A2A51A9B0F2BE2468926B4132313728C250DBF',
+    session_sql_log_bin      => '1',
   },
 }
 ```
@@ -484,11 +485,12 @@ Optional hash of grants, which are passed to [mysql_grant](#mysql_grant).
 ```
 grants => {
   'someuser@localhost/somedb.*' => {
-    ensure     => 'present',
-    options    => ['GRANT'],
-    privileges => ['SELECT', 'INSERT', 'UPDATE', 'DELETE'],
-    table      => 'somedb.*',
-    user       => 'someuser@localhost',
+    ensure              => 'present',
+    options             => ['GRANT'],
+    privileges          => ['SELECT', 'INSERT', 'UPDATE', 'DELETE'],
+    table               => 'somedb.*',
+    user                => 'someuser@localhost',
+    session_sql_log_bin => '1',
   },
 }
 ```
@@ -498,10 +500,11 @@ grants => {
 Optional hash of databases to create, which are passed to [mysql_database](#mysql_database).
 
 ```
-databases   => {
-  'somedb'  => {
-    ensure  => 'present',
-    charset => 'utf8',
+databases => {
+  'somedb' => {
+    ensure              => 'present',
+    charset             => 'utf8',
+    session_sql_log_bin => '1',
   },
 }
 ```
@@ -847,6 +850,10 @@ The CHARACTER SET setting for the database. Defaults to ':utf8'.
 
 The COLLATE setting for the database. Defaults to ':utf8_general_ci'. 
 
+##### `session_sql_log_bin`
+
+Sets session level value for `SQL_LOG_BIN`. A value of '0' means changes will not replicate. Defaults to '1' which means it will replicate.
+
 #### mysql_user
 
 Creates and manages user grants within MySQL.
@@ -858,6 +865,7 @@ mysql_user { 'root@127.0.0.1':
   max_queries_per_hour     => '0',
   max_updates_per_hour     => '0',
   max_user_connections     => '0',
+  session_sql_log_bin      => '1',
 }
 ```
 
@@ -894,6 +902,9 @@ Maximum queries per hour for the user. Must be an integer value. A value of '0' 
 
 Maximum updates per hour for the user. Must be an integer value. A value of '0' specifies no (or global) limit.
 
+##### `session_sql_log_bin`
+
+Sets session level value for `SQL_LOG_BIN`. A value of '0' means changes will not replicate. Defaults to '1' which means it will replicate.
 
 #### mysql_grant
 
@@ -901,11 +912,12 @@ Maximum updates per hour for the user. Must be an integer value. A value of '0' 
 
 ```
 mysql_grant { 'root@localhost/*.*':
-  ensure     => 'present',
-  options    => ['REQUIRE SSL', 'GRANT'],
-  privileges => ['ALL'],
-  table      => '*.*',
-  user       => 'root@localhost',
+  ensure              => 'present',
+  options             => ['REQUIRE SSL','GRANT'],
+  privileges          => ['ALL'],
+  table               => '*.*',
+  user                => 'root@localhost',
+  session_sql_log_bin => '1',
 }
 ```
 
@@ -946,6 +958,10 @@ User to whom privileges are granted.
 
 Array of MySQL options to grant. Optional.
 Supported options are 'REQUIRE SSL', 'REQUIRE X509', 'GRANT'.
+
+##### `session_sql_log_bin`
+
+Sets session level value for `SQL_LOG_BIN`. A value of '0' means changes will not replicate. Defaults to '1' which means it will replicate.
 
 #### mysql_plugin
 

--- a/lib/puppet/provider/mysql_database/mysql.rb
+++ b/lib/puppet/provider/mysql_database/mysql.rb
@@ -31,7 +31,7 @@ Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::
   end
 
   def create
-    mysql([defaults_file, '-NBe', "create database if not exists `#{@resource[:name]}` character set `#{@resource[:charset]}` collate `#{@resource[:collate]}`"].compact)
+    mysql([defaults_file, sql_log_bin, '-NBe', "create database if not exists `#{@resource[:name]}` character set `#{@resource[:charset]}` collate `#{@resource[:collate]}`"].compact)
 
     @property_hash[:ensure]  = :present
     @property_hash[:charset] = @resource[:charset]
@@ -41,7 +41,7 @@ Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::
   end
 
   def destroy
-    mysql([defaults_file, '-NBe', "drop database if exists `#{@resource[:name]}`"].compact)
+    mysql([defaults_file, sql_log_bin, '-NBe', "drop database if exists `#{@resource[:name]}`"].compact)
 
     @property_hash.clear
     exists? ? (return false) : (return true)
@@ -54,15 +54,21 @@ Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::
   mk_resource_methods
 
   def charset=(value)
-    mysql([defaults_file, '-NBe', "alter database `#{resource[:name]}` CHARACTER SET #{value}"].compact)
+    mysql([defaults_file, sql_log_bin, '-NBe', "alter database `#{resource[:name]}` CHARACTER SET #{value}"].compact)
     @property_hash[:charset] = value
     charset == value ? (return true) : (return false)
   end
 
   def collate=(value)
-    mysql([defaults_file, '-NBe', "alter database `#{resource[:name]}` COLLATE #{value}"].compact)
+    mysql([defaults_file, sql_log_bin, '-NBe', "alter database `#{resource[:name]}` COLLATE #{value}"].compact)
     @property_hash[:collate] = value
     collate == value ? (return true) : (return false)
+  end
+
+  def sql_log_bin
+    session_sql_log_bin = @resource.value(:session_sql_log_bin) || 1
+
+    "--init-command='SET SESSION SQL_LOG_BIN = #{session_sql_log_bin}'"
   end
 
 end

--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -85,7 +85,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
     query << " ON #{table_string}"
     query << " TO #{user_string}"
     query << self.class.cmd_options(options) unless options.nil?
-    mysql([defaults_file, system_database, '-e', query].compact)
+    mysql([defaults_file, system_database, sql_log_bin, '-e', query].compact)
   end
 
   def create
@@ -111,10 +111,10 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
     # exist to be executed successfully
     if revoke_privileges.include? 'ALL'
       query = "REVOKE GRANT OPTION ON #{table_string} FROM #{user_string}"
-      mysql([defaults_file, system_database, '-e', query].compact)
+      mysql([defaults_file, system_database, sql_log_bin, '-e', query].compact)
     end
     query = "REVOKE #{priv_string} ON #{table_string} FROM #{user_string}"
-    mysql([defaults_file, system_database, '-e', query].compact)
+    mysql([defaults_file, system_database, sql_log_bin, '-e', query].compact)
   end
 
   def destroy
@@ -171,6 +171,12 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
     @property_hash[:options] = options
 
     self.options
+  end
+
+  def sql_log_bin
+    session_sql_log_bin = @resource.value(:session_sql_log_bin) || 1
+
+    "--init-command='SET SESSION SQL_LOG_BIN = #{session_sql_log_bin}'"
   end
 
 end

--- a/lib/puppet/type/mysql_database.rb
+++ b/lib/puppet/type/mysql_database.rb
@@ -22,4 +22,10 @@ Puppet::Type.newtype(:mysql_database) do
     newvalue(/^\S+$/)
   end
 
+  newparam(:session_sql_log_bin) do
+    desc "Assign SET SESSION SQL_LOG_BIN = x for USER statements."
+    newvalues(0, 1)
+    defaultto 1
+  end
+
 end

--- a/lib/puppet/type/mysql_grant.rb
+++ b/lib/puppet/type/mysql_grant.rb
@@ -100,4 +100,10 @@ Puppet::Type.newtype(:mysql_grant) do
     desc 'Options to grant.'
   end
 
+  newparam(:session_sql_log_bin) do
+    desc "Assign SET SESSION SQL_LOG_BIN = x for USER statements."
+    newvalues(0, 1)
+    defaultto 1
+  end
+
 end

--- a/lib/puppet/type/mysql_user.rb
+++ b/lib/puppet/type/mysql_user.rb
@@ -75,4 +75,10 @@ Puppet::Type.newtype(:mysql_user) do
     newvalue(/\d+/)
   end
 
+  newparam(:session_sql_log_bin) do
+    desc "Assign SET SESSION SQL_LOG_BIN = x for USER statements."
+    newvalues(0, 1)
+    defaultto 1
+  end
+
 end

--- a/spec/acceptance/types/mysql_user_spec.rb
+++ b/spec/acceptance/types/mysql_user_spec.rb
@@ -73,6 +73,29 @@ describe 'mysql_user' do
       end
     end
   end
+
+  context 'using ashp-session@localhost' do
+    describe 'adding user' do
+      it 'should work without errors' do
+        pp = <<-EOS
+          mysql_user { 'ashp-session@localhost':
+            password_hash       => '*F9A8E96790775D196D12F53BCC88B8048FF62ED5',
+            session_sql_log_bin => 0,
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+      end
+
+      it 'should find the user' do
+        shell("mysql -NBe \"select '1' from mysql.user where CONCAT(user, '@', host) = 'ashp-session@localhost'\"") do |r|
+          expect(r.stdout).to match(/^1$/)
+          expect(r.stderr).to be_empty
+        end
+      end
+    end
+  end
+
   context 'using resource should throw no errors' do
     describe 'find users' do
       it {

--- a/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Puppet::Type.type(:mysql_database).provider(:mysql) do
 
   let(:defaults_file) { '--defaults-extra-file=/root/.my.cnf' }
+  let(:sql_log_bin) { "--init-command='SET SESSION SQL_LOG_BIN = 1'" }
 
   let(:raw_databases) do
     <<-SQL_OUTPUT
@@ -56,7 +57,7 @@ test
 
   describe 'create' do
     it 'makes a database' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "create database if not exists `#{resource[:name]}` character set `#{resource[:charset]}` collate `#{resource[:collate]}`"])
+      provider.expects(:mysql).with([defaults_file, sql_log_bin, '-NBe', "create database if not exists `#{resource[:name]}` character set `#{resource[:charset]}` collate `#{resource[:collate]}`"])
       provider.expects(:exists?).returns(true)
       expect(provider.create).to be_truthy
     end
@@ -64,7 +65,7 @@ test
 
   describe 'destroy' do
     it 'removes a database if present' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "drop database if exists `#{resource[:name]}`"])
+      provider.expects(:mysql).with([defaults_file, sql_log_bin, '-NBe', "drop database if exists `#{resource[:name]}`"])
       provider.expects(:exists?).returns(false)
       expect(provider.destroy).to be_truthy
     end
@@ -95,7 +96,7 @@ test
 
   describe 'charset=' do
     it 'changes the charset' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "alter database `#{resource[:name]}` CHARACTER SET blah"]).returns('0')
+      provider.expects(:mysql).with([defaults_file, sql_log_bin, '-NBe', "alter database `#{resource[:name]}` CHARACTER SET blah"]).returns('0')
 
       provider.charset=('blah')
     end
@@ -109,7 +110,7 @@ test
 
   describe 'collate=' do
     it 'changes the collate' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "alter database `#{resource[:name]}` COLLATE blah"]).returns('0')
+      provider.expects(:mysql).with([defaults_file, sql_log_bin, '-NBe', "alter database `#{resource[:name]}` COLLATE blah"]).returns('0')
 
       provider.collate=('blah')
     end

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -49,6 +49,7 @@ describe Puppet::Type.type(:mysql_user).provider(:mysql) do
     }
 
   let(:defaults_file) { '--defaults-extra-file=/root/.my.cnf' }
+  let(:sql_log_bin) { "--init-command='SET SESSION SQL_LOG_BIN = 1'" }
   let(:system_database) { '--database=mysql' }
   let(:newhash) { '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5' }
 
@@ -178,8 +179,8 @@ usvn_user@localhost
 
   describe 'create' do
     it 'makes a user' do
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "CREATE USER 'joe'@'localhost' IDENTIFIED BY PASSWORD '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4'"])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' WITH MAX_USER_CONNECTIONS 10 MAX_CONNECTIONS_PER_HOUR 10 MAX_QUERIES_PER_HOUR 10 MAX_UPDATES_PER_HOUR 10"])
+      provider.expects(:mysql).with([defaults_file, system_database, sql_log_bin, '-e', "CREATE USER 'joe'@'localhost' IDENTIFIED BY PASSWORD '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4'"])
+      provider.expects(:mysql).with([defaults_file, system_database, sql_log_bin, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' WITH MAX_USER_CONNECTIONS 10 MAX_CONNECTIONS_PER_HOUR 10 MAX_QUERIES_PER_HOUR 10 MAX_UPDATES_PER_HOUR 10"])
       provider.expects(:exists?).returns(true)
       expect(provider.create).to be_truthy
     end
@@ -187,7 +188,7 @@ usvn_user@localhost
 
   describe 'destroy' do
     it 'removes a user if present' do
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "DROP USER 'joe'@'localhost'"])
+      provider.expects(:mysql).with([defaults_file, system_database, sql_log_bin, '-e', "DROP USER 'joe'@'localhost'"])
       provider.expects(:exists?).returns(false)
       expect(provider.destroy).to be_truthy
     end
@@ -243,42 +244,42 @@ usvn_user@localhost
   describe 'password_hash=' do
     it 'changes the hash mysql 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with([defaults_file, system_database, sql_log_bin, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
     end
     it 'changes the hash mysql 5.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with([defaults_file, system_database, sql_log_bin, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
     end
     it 'changes the hash mysql < 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with([defaults_file, system_database, sql_log_bin, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
     end
     it 'changes the hash MySQL >= 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "ALTER USER 'joe'@'localhost' IDENTIFIED WITH mysql_native_password AS '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with([defaults_file, system_database, sql_log_bin, '-e', "ALTER USER 'joe'@'localhost' IDENTIFIED WITH mysql_native_password AS '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
     end
     it 'changes the hash mariadb-10.0' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with([defaults_file, system_database, sql_log_bin, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
     end
     it 'changes the hash percona-5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['percona-5.5'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with([defaults_file, system_database, sql_log_bin, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
@@ -296,7 +297,7 @@ usvn_user@localhost
 
     describe "#{property}=" do
       it "changes #{property}" do
-        provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' WITH #{property.upcase} 42"]).returns('0')
+        provider.expects(:mysql).with([defaults_file, system_database, sql_log_bin, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' WITH #{property.upcase} 42"]).returns('0')
         provider.expects(property.to_sym).returns('42')
         provider.send("#{property}=".to_sym, '42')
       end


### PR DESCRIPTION
There are times where you may want a `mysql_user{}` or mysql_grant{}`to
exist only on one host. The addition of session_sql_log_bin can be set
to enable or disable binary logging for the change. This also works for
`mysql_database{}` but I believe this would be used less often.
