### PR TITLE
Revert "Add support for REQUIRE SSL|X509 option"

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,7 +902,7 @@ Maximum updates per hour for the user. Must be an integer value. A value of '0' 
 ```
 mysql_grant { 'root@localhost/*.*':
   ensure     => 'present',
-  options    => ['REQUIRE SSL', 'GRANT'],
+  options    => ['GRANT'],
   privileges => ['ALL'],
   table      => '*.*',
   user       => 'root@localhost',
@@ -944,8 +944,7 @@ User to whom privileges are granted.
 
 ##### `options`
 
-Array of MySQL options to grant. Optional.
-Supported options are 'REQUIRE SSL', 'REQUIRE X509', 'GRANT'.
+MySQL options to grant. Optional.
 
 #### mysql_plugin
 

--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -104,10 +104,8 @@ class Puppet::Provider::Mysql < Puppet::Provider
   # Take in potential options and build up a query string with them.
   def self.cmd_options(options)
     option_string = ''
-    options.sort.reverse_each do |opt|
-      if op = opt.match(/^REQUIRE\s(SSL|X509)$/)
-        option_string << " #{op[0]}"
-      elsif opt == 'GRANT'
+    options.each do |opt|
+      if opt == 'GRANT'
         option_string << ' WITH GRANT OPTION'
       end
     end

--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -46,11 +46,11 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
             end
           end
           # Same here, but to remove OPTION leaving just GRANT.
-          options = []
-          req_opt = rest.match(/REQUIRE\s(SSL|X509)/)
-          options << req_opt[0] if req_opt
-          options << 'GRANT' if rest.match(/WITH\sGRANT\sOPTION/)
-          options << 'NONE' if options.empty?
+          if rest.match(/WITH\sGRANT\sOPTION/)           
+		options = ['GRANT']
+          else
+                options = ['NONE']
+          end
           # fix double backslash that MySQL prints, so resources match
           table.gsub!("\\\\", "\\")
           # We need to return an array of instances so capture these

--- a/spec/acceptance/types/mysql_grant_spec.rb
+++ b/spec/acceptance/types/mysql_grant_spec.rb
@@ -17,7 +17,7 @@ describe 'mysql_grant' do
   describe 'missing privileges for user' do
     it 'should fail' do
       pp = <<-EOS
-        mysql_user { 'test1@tester':
+        mysql_user { 'test1@tester': 
           ensure => present,
         }
         mysql_grant { 'test1@tester/test.*':
@@ -129,35 +129,7 @@ describe 'mysql_grant' do
     end
   end
 
-  describe 'adding REQUIRE SSL option' do
-    it 'should work without errors' do
-      pp = <<-EOS
-        mysql_user { 'test3@tester':
-          ensure => present,
-        }
-        mysql_grant { 'test3@tester/test.*':
-          ensure     => 'present',
-          table      => 'test.*',
-          user       => 'test3@tester',
-          options    => ['REQUIRE SSL'],
-          privileges => ['SELECT', 'UPDATE'],
-          require    => Mysql_user['test3@tester'],
-        }
-      EOS
-
-      apply_manifest(pp, :catch_failures => true)
-    end
-
-    it 'should find the user' do
-      shell("mysql -NBe \"SHOW GRANTS FOR test3@tester\"") do |r|
-        expect(r.stdout).to match(/GRANT USAGE ON *.* TO 'test3'@'tester' REQUIRE SSL$/)
-        expect(r.stdout).to match(/GRANT SELECT, UPDATE ON `test`.* TO 'test3'@'tester'$/)
-        expect(r.stderr).to be_empty
-      end
-    end
-  end
-
-  describe 'adding GRANT option' do
+  describe 'adding option' do
     it 'should work without errors' do
       pp = <<-EOS
         mysql_user { 'test3@tester':
@@ -178,62 +150,6 @@ describe 'mysql_grant' do
 
     it 'should find the user' do
       shell("mysql -NBe \"SHOW GRANTS FOR test3@tester\"") do |r|
-        expect(r.stdout).to match(/GRANT SELECT, UPDATE ON `test`.* TO 'test3'@'tester' WITH GRANT OPTION$/)
-        expect(r.stderr).to be_empty
-      end
-    end
-  end
-
-  describe 'adding REQUIRE X509 and GRANT option' do
-    it 'should work without errors' do
-      pp = <<-EOS
-        mysql_user { 'test3@tester':
-          ensure => present,
-        }
-        mysql_grant { 'test3@tester/test.*':
-          ensure     => 'present',
-          table      => 'test.*',
-          user       => 'test3@tester',
-          options    => ['REQUIRE X509', 'GRANT'],
-          privileges => ['SELECT', 'UPDATE'],
-          require    => Mysql_user['test3@tester'],
-        }
-      EOS
-
-      apply_manifest(pp, :catch_failures => true)
-    end
-
-    it 'should find the user' do
-      shell("mysql -NBe \"SHOW GRANTS FOR test3@tester\"") do |r|
-        expect(r.stdout).to match(/GRANT USAGE ON *.* TO 'test3'@'tester' REQUIRE X509$/)
-        expect(r.stdout).to match(/GRANT SELECT, UPDATE ON `test`.* TO 'test3'@'tester' WITH GRANT OPTION$/)
-        expect(r.stderr).to be_empty
-      end
-    end
-  end
-
-  describe 'adding GRANT and REQUIRE X509 option' do
-    it 'should work without errors' do
-      pp = <<-EOS
-        mysql_user { 'test3@tester':
-          ensure => present,
-        }
-        mysql_grant { 'test3@tester/test.*':
-          ensure     => 'present',
-          table      => 'test.*',
-          user       => 'test3@tester',
-          options    => ['GRANT', 'REQUIRE X509'],
-          privileges => ['SELECT', 'UPDATE'],
-          require    => Mysql_user['test3@tester'],
-        }
-      EOS
-
-      apply_manifest(pp, :catch_failures => true)
-    end
-
-    it 'should find the user' do
-      shell("mysql -NBe \"SHOW GRANTS FOR test3@tester\"") do |r|
-        expect(r.stdout).to match(/GRANT USAGE ON *.* TO 'test3'@'tester' REQUIRE X509$/)
         expect(r.stdout).to match(/GRANT SELECT, UPDATE ON `test`.* TO 'test3'@'tester' WITH GRANT OPTION$/)
         expect(r.stderr).to be_empty
       end


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-mysql#888

This is not valid on mysql 5.7:
```
mysql> SHOW WARNINGS; GRANT ALL ON `test`.* TO test3@tester REQUIRE SSL;
+---------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Level   | Code | Message                                                                                                                                                                            |
+---------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Warning | 1287 | Using GRANT statement to modify existing user's properties other than privileges is deprecated and will be removed in future release. Use ALTER USER statement for this operation. |
+---------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```