### PR TITLE
Binlog must be create for mysqld start

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -77,9 +77,10 @@ class mysql::server (
 
   Anchor['mysql::server::start'] ->
   Class['mysql::server::config'] ->
-  Class['mysql::server::install'] ->
   Class['mysql::server::binarylog'] ->
+  Class['mysql::server::install'] ->
   Class['mysql::server::installdb'] ->
+  Class['mysql::server::binarylog'] ->
   Class['mysql::server::service'] ->
   Class['mysql::server::root_password'] ->
   Class['mysql::server::providers'] ->


### PR DESCRIPTION
When you install a package on Debian, by default it'll start the service, so if you change the binlog dir to a non existent folder, the package fail to install.