### PR TITLE
Ticket/3623 centralise my sql calls 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1048,3 +1048,4 @@ This module is based on work by David Schmitt. The following contributors have c
 * Chris Weyl
 * Daniël van Eeden
 * Jan-Otto Kröpke
+* Timothy Sven Nelson

--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -56,9 +56,9 @@ class Puppet::Provider::Mysql < Puppet::Provider
 
   def self.mysql(textOfSQL, type)
     if type.eql? 'system'
-      mysql([defaults_file, '--host=', system_database, '-e', textOfSQL].compact)
-#    else
-#      mysql([defaults_file, '-NBe', textOfSQL].compact)
+      mysql([defaults_file, '--host=', system_database, '-e', textOfSQL].flatten.compact)
+    else
+      mysql([defaults_file, '-NBe', textOfSQL].flatten.compact)
     end
   end
 

--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -54,8 +54,16 @@ class Puppet::Provider::Mysql < Puppet::Provider
     self.class.defaults_file
   end
 
+  def self.mysql(textOfSQL, type)
+    if type.eql? 'system'
+      mysql([defaults_file, '--host=', system_database, '-e', textOfSQL].compact)
+#    else
+#      mysql([defaults_file, '-NBe', textOfSQL].compact)
+    end
+  end
+
   def self.users
-    mysql([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"].compact).split("\n")
+    self.mysql("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user").split("\n")
   end
 
   # Optional parameter to run a statement on the MySQL system database.

--- a/lib/puppet/provider/mysql_database/mysql.rb
+++ b/lib/puppet/provider/mysql_database/mysql.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::
   def self.instances
     self.mysql('show databases').split("\n").collect do |name|
       attributes = {}
-      self.mysql("show variables like '%_database'").split("\n").each do |line|
+      self.mysql(["show variables like '%_database'", name]).split("\n").each do |line|
         k,v = line.split(/\s/)
         attributes[k] = v
       end

--- a/lib/puppet/provider/mysql_database/mysql.rb
+++ b/lib/puppet/provider/mysql_database/mysql.rb
@@ -5,9 +5,9 @@ Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::
   commands :mysql => 'mysql'
 
   def self.instances
-    mysql([defaults_file, '-NBe', 'show databases'].compact).split("\n").collect do |name|
+    self.mysql('show databases').split("\n").collect do |name|
       attributes = {}
-      mysql([defaults_file, '-NBe', "show variables like '%_database'", name].compact).split("\n").each do |line|
+      self.mysql("show variables like '%_database'").split("\n").each do |line|
         k,v = line.split(/\s/)
         attributes[k] = v
       end
@@ -31,7 +31,7 @@ Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::
   end
 
   def create
-    mysql([defaults_file, '-NBe', "create database if not exists `#{@resource[:name]}` character set `#{@resource[:charset]}` collate `#{@resource[:collate]}`"].compact)
+    self.mysql("create database if not exists `#{@resource[:name]}` character set `#{@resource[:charset]}` collate `#{@resource[:collate]}`")
 
     @property_hash[:ensure]  = :present
     @property_hash[:charset] = @resource[:charset]
@@ -41,7 +41,7 @@ Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::
   end
 
   def destroy
-    mysql([defaults_file, '-NBe', "drop database if exists `#{@resource[:name]}`"].compact)
+    self.mysql("drop database if exists `#{@resource[:name]}`")
 
     @property_hash.clear
     exists? ? (return false) : (return true)
@@ -54,13 +54,13 @@ Puppet::Type.type(:mysql_database).provide(:mysql, :parent => Puppet::Provider::
   mk_resource_methods
 
   def charset=(value)
-    mysql([defaults_file, '-NBe', "alter database `#{resource[:name]}` CHARACTER SET #{value}"].compact)
+    self.mysql("alter database `#{resource[:name]}` CHARACTER SET #{value}")
     @property_hash[:charset] = value
     charset == value ? (return true) : (return false)
   end
 
   def collate=(value)
-    mysql([defaults_file, '-NBe', "alter database `#{resource[:name]}` COLLATE #{value}"].compact)
+    self.mysql("alter database `#{resource[:name]}` COLLATE #{value}")
     @property_hash[:collate] = value
     collate == value ? (return true) : (return false)
   end

--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
       user_string = self.cmd_user(user)
       query = "SHOW GRANTS FOR #{user_string};"
       begin
-        grants = mysql([defaults_file, "-NBe", query].compact)
+        grants = self.mysql(query)
       rescue Puppet::ExecutionFailure => e
         # Silently ignore users with no grants. Can happen e.g. if user is
         # defined with fqdn and server is run with skip-name-resolve. Example:
@@ -85,7 +85,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
     query << " ON #{table_string}"
     query << " TO #{user_string}"
     query << self.class.cmd_options(options) unless options.nil?
-    mysql([defaults_file, system_database, '-e', query].compact)
+    self.mysql(query, 'system')
   end
 
   def create
@@ -111,10 +111,10 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
     # exist to be executed successfully
     if revoke_privileges.include? 'ALL'
       query = "REVOKE GRANT OPTION ON #{table_string} FROM #{user_string}"
-      mysql([defaults_file, system_database, '-e', query].compact)
+      self.mysql(query, 'system')
     end
     query = "REVOKE #{priv_string} ON #{table_string} FROM #{user_string}"
-    mysql([defaults_file, system_database, '-e', query].compact)
+    self.mysql(query, 'system')
   end
 
   def destroy
@@ -134,7 +134,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, :parent => Puppet::Provider::Mys
 
   def flush
     @property_hash.clear
-    mysql([defaults_file, '-NBe', 'FLUSH PRIVILEGES'].compact)
+    self.mysql('FLUSH PRIVILEGES')
   end
 
   mk_resource_methods

--- a/lib/puppet/provider/mysql_plugin/mysql.rb
+++ b/lib/puppet/provider/mysql_plugin/mysql.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:mysql_plugin).provide(:mysql, :parent => Puppet::Provider::My
   commands :mysql => 'mysql'
 
   def self.instances
-    mysql([defaults_file, '-NBe', 'show plugins'].compact).split("\n").collect do |line|
+    self.mysql('show plugins').split("\n").collect do |line|
       name, status, type, library, license = line.split(/\t/)
       new(:name    => name,
           :ensure  => :present,
@@ -29,7 +29,7 @@ Puppet::Type.type(:mysql_plugin).provide(:mysql, :parent => Puppet::Provider::My
     # Use plugin_name.so as soname if it's not specified. This won't work on windows as
     # there it should be plugin_name.dll
     @resource[:soname].nil? ? (soname=@resource[:name] + '.so') : (soname=@resource[:soname])
-    mysql([defaults_file, '-NBe', "install plugin #{@resource[:name]} soname '#{soname}'"].compact)
+    self.mysql("install plugin #{@resource[:name]} soname '#{soname}'")
 
     @property_hash[:ensure]  = :present
     @property_hash[:soname] = @resource[:soname]
@@ -38,7 +38,7 @@ Puppet::Type.type(:mysql_plugin).provide(:mysql, :parent => Puppet::Provider::My
   end
 
   def destroy
-    mysql([defaults_file, '-NBe', "uninstall plugin #{@resource[:name]}"].compact)
+    self.mysql("uninstall plugin #{@resource[:name]}")
 
     @property_hash.clear
     exists? ? (return false) : (return true)

--- a/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
@@ -30,17 +30,17 @@ test
     Facter.stubs(:value).with(:root_home).returns('/root')
     Puppet::Util.stubs(:which).with('mysql').returns('/usr/bin/mysql')
     File.stubs(:file?).with('/root/.my.cnf').returns(true)
-    provider.class.stubs(:mysql).with([defaults_file, '-NBe', 'show databases']).returns('new_database')
-    provider.class.stubs(:mysql).with([defaults_file, '-NBe', "show variables like '%_database'", 'new_database']).returns("character_set_database latin1\ncollation_database latin1_swedish_ci\nskip_show_database OFF")
+    provider.class.stubs(:mysql).with('show databases').returns('new_database')
+    provider.class.stubs(:mysql).with(["show variables like '%_database'", 'new_database']).returns("character_set_database latin1\ncollation_database latin1_swedish_ci\nskip_show_database OFF")
   end
 
   let(:instance) { provider.class.instances.first }
 
   describe 'self.instances' do
     it 'returns an array of databases' do
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', 'show databases']).returns(raw_databases)
+      provider.class.stubs(:mysql).with('show databases').returns(raw_databases)
       raw_databases.each_line do |db|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "show variables like '%_database'", db.chomp]).returns("character_set_database latin1\ncollation_database  latin1_swedish_ci\nskip_show_database  OFF")
+        provider.class.stubs(:mysql).with(["show variables like '%_database'", db.chomp]).returns("character_set_database latin1\ncollation_database  latin1_swedish_ci\nskip_show_database  OFF")
       end
       databases = provider.class.instances.collect {|x| x.name }
       expect(parsed_databases).to match_array(databases)
@@ -56,7 +56,7 @@ test
 
   describe 'create' do
     it 'makes a database' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "create database if not exists `#{resource[:name]}` character set `#{resource[:charset]}` collate `#{resource[:collate]}`"])
+      provider.expects(:mysql).with("create database if not exists `#{resource[:name]}` character set `#{resource[:charset]}` collate `#{resource[:collate]}`")
       provider.expects(:exists?).returns(true)
       expect(provider.create).to be_truthy
     end
@@ -64,7 +64,7 @@ test
 
   describe 'destroy' do
     it 'removes a database if present' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "drop database if exists `#{resource[:name]}`"])
+      provider.expects(:mysql).with("drop database if exists `#{resource[:name]}`")
       provider.expects(:exists?).returns(false)
       expect(provider.destroy).to be_truthy
     end
@@ -95,7 +95,7 @@ test
 
   describe 'charset=' do
     it 'changes the charset' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "alter database `#{resource[:name]}` CHARACTER SET blah"]).returns('0')
+      provider.expects(:mysql).with("alter database `#{resource[:name]}` CHARACTER SET blah").returns('0')
 
       provider.charset=('blah')
     end
@@ -109,7 +109,7 @@ test
 
   describe 'collate=' do
     it 'changes the collate' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "alter database `#{resource[:name]}` COLLATE blah"]).returns('0')
+      provider.expects(:mysql).with("alter database `#{resource[:name]}` COLLATE blah").returns('0')
 
       provider.collate=('blah')
     end

--- a/spec/unit/puppet/provider/mysql_plugin/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_plugin/mysql_spec.rb
@@ -17,7 +17,7 @@ describe Puppet::Type.type(:mysql_plugin).provider(:mysql) do
     Facter.stubs(:value).with(:root_home).returns('/root')
     Puppet::Util.stubs(:which).with('mysql').returns('/usr/bin/mysql')
     File.stubs(:file?).with('/root/.my.cnf').returns(true)
-    provider.class.stubs(:mysql).with([defaults_file, '-NBe', 'show plugins']).returns('auth_socket	ACTIVE	AUTHENTICATION	auth_socket.so	GPL')
+    provider.class.stubs(:mysql).with('show plugins').returns('auth_socket	ACTIVE	AUTHENTICATION	auth_socket.so	GPL')
   end
 
   let(:instance) { provider.class.instances.first }
@@ -31,7 +31,7 @@ describe Puppet::Type.type(:mysql_plugin).provider(:mysql) do
 
   describe 'create' do
     it 'loads a plugin' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "install plugin #{resource[:name]} soname '#{resource[:soname]}'"])
+      provider.expects(:mysql).with("install plugin #{resource[:name]} soname '#{resource[:soname]}'")
       provider.expects(:exists?).returns(true)
       expect(provider.create).to be_truthy
     end
@@ -39,7 +39,7 @@ describe Puppet::Type.type(:mysql_plugin).provider(:mysql) do
 
   describe 'destroy' do
     it 'unloads a plugin if present' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "uninstall plugin #{resource[:name]}"])
+      provider.expects(:mysql).with("uninstall plugin #{resource[:name]}")
       provider.expects(:exists?).returns(false)
       expect(provider.destroy).to be_truthy
     end

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -87,8 +87,8 @@ usvn_user@localhost
     Puppet::Util.stubs(:which).with('mysql').returns('/usr/bin/mysql')
     Puppet::Util.stubs(:which).with('mysqld').returns('/usr/sbin/mysqld')
     File.stubs(:file?).with('/root/.my.cnf').returns(true)
-    provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns('joe@localhost')
-    provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = 'joe@localhost'"]).returns('10 10 10 10     *6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4')
+    provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user").returns('joe@localhost')
+    provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = 'joe@localhost'").returns('10 10 10 10     *6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4')
   end
 
   let(:instance) { provider.class.instances.first }
@@ -96,9 +96,9 @@ usvn_user@localhost
   describe 'self.instances' do
     it 'returns an array of users MySQL 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user").returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'").returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -106,9 +106,9 @@ usvn_user@localhost
     end
     it 'returns an array of users MySQL 5.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user").returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'").returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -116,9 +116,9 @@ usvn_user@localhost
     end
     it 'returns an array of users MySQL >= 5.7.0 < 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user").returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'").returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -126,9 +126,9 @@ usvn_user@localhost
     end
     it 'returns an array of users MySQL >= 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user").returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, AUTHENTICATION_STRING, PLUGIN FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, AUTHENTICATION_STRING, PLUGIN FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'").returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -136,9 +136,9 @@ usvn_user@localhost
     end
     it 'returns an array of users mariadb 10.0' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user").returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'").returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -146,9 +146,9 @@ usvn_user@localhost
     end
     it 'returns an array of users percona 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['percona-5.5'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user").returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ')
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'").returns('10 10 10 10     ')
       end
 
       usernames = provider.class.instances.collect {|x| x.name }
@@ -178,9 +178,9 @@ usvn_user@localhost
 
   describe 'create' do
     it 'makes a user' do
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "CREATE USER 'joe'@'localhost' IDENTIFIED BY PASSWORD '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4'"])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' WITH MAX_USER_CONNECTIONS 10 MAX_CONNECTIONS_PER_HOUR 10 MAX_QUERIES_PER_HOUR 10 MAX_UPDATES_PER_HOUR 10"])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE"])
+      provider.expects(:mysql).with("CREATE USER 'joe'@'localhost' IDENTIFIED BY PASSWORD '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4'", 'system')
+      provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' WITH MAX_USER_CONNECTIONS 10 MAX_CONNECTIONS_PER_HOUR 10 MAX_QUERIES_PER_HOUR 10 MAX_UPDATES_PER_HOUR 10", 'system')
+      provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system')
       provider.expects(:exists?).returns(true)
       expect(provider.create).to be_truthy
     end
@@ -188,7 +188,7 @@ usvn_user@localhost
 
   describe 'destroy' do
     it 'removes a user if present' do
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "DROP USER 'joe'@'localhost'"])
+      provider.expects(:mysql).with("DROP USER 'joe'@'localhost'", 'system')
       provider.expects(:exists?).returns(false)
       expect(provider.destroy).to be_truthy
     end
@@ -244,42 +244,42 @@ usvn_user@localhost
   describe 'password_hash=' do
     it 'changes the hash mysql 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
     end
     it 'changes the hash mysql 5.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
     end
     it 'changes the hash mysql < 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
     end
     it 'changes the hash MySQL >= 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "ALTER USER 'joe'@'localhost' IDENTIFIED WITH mysql_native_password AS '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("ALTER USER 'joe'@'localhost' IDENTIFIED WITH mysql_native_password AS '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
     end
     it 'changes the hash mariadb-10.0' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
     end
     it 'changes the hash percona-5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['percona-5.5'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash=('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
@@ -335,7 +335,7 @@ usvn_user@localhost
 
     describe "#{property}=" do
       it "changes #{property}" do
-        provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' WITH #{property.upcase} 42"]).returns('0')
+        provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' WITH #{property.upcase} 42", 'system').returns('0')
         provider.expects(property.to_sym).returns('42')
         provider.send("#{property}=".to_sym, '42')
       end


### PR DESCRIPTION
```
(MODULES-3623) Centralise MySQL calls, so they can all be modified from one place

The current codebase handles each mysql call via calls to the command-line
mysql client.  There are basically only two sets of options passed, but the
options are repeated separately in various places throughout the code.  The
new self.mysql function now issues the call to the mysql client with one of
the two sets of options (selected via an optional function parameter).

Now the options to all mysql calls can be modified from one place.  This will
be useful when we are converting the module to allow for databases on multiple
remote servers, since we will be able to add the -h switch to all calls at
once.
```
