### PR TITLE
Enhancements to xtrabackup backup provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,10 @@ Sets the server backup implementation. Valid values are:
 
 Defines the maximum SQL statement size for the backup dump script. The default value is 1MB, as this is the default MySQL Server value.
 
+##### `optional_args`
+
+Specifies an array of optional arguments which should be passed through to the backup tool. (Currently only supported by the xtrabackup provider.)
+
 #### mysql::server::monitor
 
 ##### `mysql_monitor_username`

--- a/manifests/backup/mysqlbackup.pp
+++ b/manifests/backup/mysqlbackup.pp
@@ -20,6 +20,7 @@ class mysql::backup::mysqlbackup (
   $prescript          = false,
   $postscript         = false,
   $execpath           = '/usr/bin:/usr/sbin:/bin:/sbin',
+  $optional_args      = [],
 ) inherits mysql::params {
 
   mysql_user { "${backupuser}@localhost":

--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -20,6 +20,7 @@ class mysql::backup::mysqldump (
   $prescript          = false,
   $postscript         = false,
   $execpath           = '/usr/bin:/usr/sbin:/bin:/sbin',
+  $optional_args      = [],
 ) inherits mysql::params {
 
   ensure_packages(['bzip2'])

--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -22,10 +22,27 @@ class mysql::backup::xtrabackup (
   $prescript               = false,
   $postscript              = false,
   $execpath                = '/usr/bin:/usr/sbin:/bin:/sbin',
+  $optional_args           = [],
 ) inherits mysql::params {
 
   package{ $xtrabackup_package_name:
     ensure  => $ensure,
+  }
+
+  if $backupuser and $backuppassword {
+    mysql_user { "${backupuser}@localhost":
+      ensure        => $ensure,
+      password_hash => mysql_password($backuppassword),
+      require       => Class['mysql::server::root_password'],
+    }
+
+    mysql_grant { "${backupuser}@localhost/*.*":
+      ensure     => $ensure,
+      user       => "${backupuser}@localhost",
+      table      => '*.*',
+      privileges => [ 'RELOAD', 'LOCK TABLES', 'REPLICATION CLIENT' ],
+      require    => Mysql_user["${backupuser}@localhost"],
+    }
   }
 
   cron { 'xtrabackup-weekly':

--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -21,6 +21,7 @@ class mysql::server::backup (
   $execpath           = '/usr/bin:/usr/sbin:/bin:/sbin',
   $provider           = 'mysqldump',
   $maxallowedpacket   = '1M',
+  $optional_args      = [],
 ) {
 
   if $prescript and $provider =~ /(mysqldump|mysqlbackup)/ {
@@ -49,6 +50,7 @@ class mysql::server::backup (
       'postscript'         => $postscript,
       'execpath'           => $execpath,
       'maxallowedpacket'   => $maxallowedpacket,
+      'optional_args'      => $optional_args,
     }
   })
 

--- a/spec/classes/mysql_server_backup_spec.rb
+++ b/spec/classes/mysql_server_backup_spec.rb
@@ -362,7 +362,7 @@ describe 'mysql::server::backup' do
 
         it 'should contain the wrapper script' do
           is_expected.to contain_file('xtrabackup.sh').with_content(
-            /^innobackupex\s+"\$@"/
+            /^innobackupex\s+.*?"\$@"/
           )
         end
 

--- a/templates/xtrabackup.sh.erb
+++ b/templates/xtrabackup.sh.erb
@@ -12,7 +12,19 @@
   <%- end -%>
 <% end -%>
 
-innobackupex "$@"
+<%- _innobackupex_args = '' -%>
+
+<%- if @backupuser and @backuppassword -%>
+  <%- _innobackupex_args = '--user="' + @backupuser + '" --password="' + @backuppassword + '"' -%>
+<%- end -%>
+
+<%- if @optional_args and @optional_args.is_a?(Array) -%>
+  <%- @optional_args.each do |arg| -%>
+    <%- _innobackupex_args = _innobackupex_args + ' ' + arg -%>
+  <%- end -%>
+<%- end -%>
+
+innobackupex <%= _innobackupex_args %> "$@"
 
 <% if @postscript -%>
   <%- [@postscript].flatten.compact.each do |script| %>

--- a/templates/xtrabackup.sh.erb
+++ b/templates/xtrabackup.sh.erb
@@ -18,6 +18,10 @@
   <%- _innobackupex_args = '--user="' + @backupuser + '" --password="' + @backuppassword + '"' -%>
 <%- end -%>
 
+<%- if @backupdatabases and @backupdatabases.is_a?(Array) and !@backupdatabases.empty? -%>
+  <%- _innobackupex_args = _innobackupex_args + ' --databases="' + @backupdatabases.join(' ') + '"' -%>
+<%- end -%>
+
 <%- if @optional_args and @optional_args.is_a?(Array) -%>
   <%- @optional_args.each do |arg| -%>
     <%- _innobackupex_args = _innobackupex_args + ' ' + arg -%>


### PR DESCRIPTION
This PR will bring the `xtrabackup` provider up to par with the `mysqldump` provider and adds one other enhancement:
- Add support for existing parameters `$backupuser` and `$backuppassword`
- Automatically create backup user/grants
- Add support for the `databases` parameter to provide a list of databases to back up
- Add support for optional arguments to `innobackupex` by adding the new parameter `$optional_args`

This makes it possible to specify additional arguments to be passed to `innobackupex`:

```
mysql::server::backup:
  provider: 'xtrabackup'
  user: 'backupusr'
  password: 'secret'
  databases:
    - 'foo'
    - 'bar'
  optional_args:
    - '--no-lock'
    - '--parallel=2'
```
