### PR TITLE
Add a file in /tmp to check when the last backup was successful

### DIFF
--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -91,6 +91,7 @@ mysqldump --defaults-extra-file=$TMPFILE --opt --flush-logs --single-transaction
 <% unless @delete_before_dump -%>
 if [ $? -eq 0 ] ; then
     cleanup
+    touch /tmp/mysqlbackup_success
 fi
 <% end -%>
 


### PR DESCRIPTION
We want to have an easy way to check whether the backup was successful. In my opinion adding a simple flag file is the easiest and universally usable method.

To check whether the backup was successful, we will simply check whether the last modification of the file was longer than the defined backup interval. Such a test can very easily be integrated in most monitoring solutions.