### PR TITLE
Fix trailing comma syntax error

### DIFF
--- a/lib/puppet/provider/mysql_user/mysql.rb
+++ b/lib/puppet/provider/mysql_user/mysql.rb
@@ -35,7 +35,7 @@ Puppet::Type.type(:mysql_user).provide(:mysql, :parent => Puppet::Provider::Mysq
           :max_connections_per_hour => @max_connections_per_hour,
           :max_queries_per_hour     => @max_queries_per_hour,
           :max_updates_per_hour     => @max_updates_per_hour,
-          :tls_options              => @tls_options,
+          :tls_options              => @tls_options
          )
     end
   end


### PR DESCRIPTION
Fixing this error:

Could not autoload puppet/provider/mysql_user/mysql: /var/lib/puppet/lib/puppet/provider/mysql_user/mysql.rb:39: syntax error, unexpected ')'
/var/lib/puppet/lib/puppet/provider/mysql_user/mysql.rb:197: syntax error, unexpected $end, expecting kEND