### PR TITLE
add solaris 11 paths to provider

### DIFF
--- a/lib/puppet/provider/mysql_datadir/mysql.rb
+++ b/lib/puppet/provider/mysql_datadir/mysql.rb
@@ -5,8 +5,8 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, :parent => Puppet::Provider::M
 
   initvars
 
-  # Make sure we find mysqld on CentOS and mysql_install_db on Gentoo
-  ENV['PATH']=ENV['PATH'] + ':/usr/libexec:/usr/share/mysql/scripts:/opt/rh/mysql55/root/usr/bin:/opt/rh/mysql55/root/usr/libexec'
+  # Make sure we find mysqld on CentOS and mysql_install_db on Gentoo and Solaris 11
+  ENV['PATH']=ENV['PATH'] + ':/usr/libexec:/usr/share/mysql/scripts:/opt/rh/mysql55/root/usr/bin:/opt/rh/mysql55/root/usr/libexec:/usr/mysql/5.5/bin:/usr/mysql/5.6/bin:/usr/mysql/5.7/bin'
 
   commands :mysqld => 'mysqld'
   commands :mysql_install_db => 'mysql_install_db'


### PR DESCRIPTION
Our update to 3.10.x broke the solaris support. This adds possible search paths for mysqld and mysql_install_db.

Thanks
Oliver