### PR TITLE
Allow mysqltuner to be downloaded via a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,9 +626,9 @@ Ensures that the resource exists. Valid values are `present`, `absent`. Defaults
 
 The version to install from the major/MySQLTuner-perl github repository. Must be a valid tag. Defaults to 'v1.3.0'.
 
-##### `source`
+##### `environment`
 
-Specifies the source. If not specified, defaults to `https://github.com/major/MySQLTuner-perl/raw/${version}/mysqltuner.pl`
+Environment variables acive during download, e.g. to download via proxies: environment => 'https_proxy=http://proxy.example.com:80'
 
 #### mysql::bindings
 

--- a/manifests/server/mysqltuner.pp
+++ b/manifests/server/mysqltuner.pp
@@ -37,7 +37,7 @@ class mysql::server::mysqltuner(
     }
 
     staging::file { "mysqltuner-${_version}":
-      source => $_source,
+      source      => $_source,
       environment => $environment,
     }
     file { '/usr/local/bin/mysqltuner':

--- a/manifests/server/mysqltuner.pp
+++ b/manifests/server/mysqltuner.pp
@@ -3,6 +3,7 @@ class mysql::server::mysqltuner(
   $ensure  = 'present',
   $version = 'v1.3.0',
   $source  = undef,
+  $environment = undef, # environment for staging::file
 ) {
 
   if $source {
@@ -37,6 +38,7 @@ class mysql::server::mysqltuner(
 
     staging::file { "mysqltuner-${_version}":
       source => $_source,
+      environment => $environment,
     }
     file { '/usr/local/bin/mysqltuner':
       ensure  => $ensure,


### PR DESCRIPTION
Extend mysql::server::mysqltuner with an $environment, which is then passed onto staging::file, so that a proxy variable can be passed that allows mysqltuner to be downloaded. Example usage.
```
  class { 'mysql::server::mysqltuner':
    environment => 'https_proxy=http://myproxy.example.ch:80',    # for download
  }
```