### PR TITLE
Allow custom type providers to be noop

### DIFF
--- a/lib/puppet/provider/mysql_database/noop.rb
+++ b/lib/puppet/provider/mysql_database/noop.rb
@@ -1,0 +1,2 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'noop'))
+Puppet::Type.type(:mysql_database).provide(:noop, :parent => Puppet::Provider::Noop)

--- a/lib/puppet/provider/mysql_datadir/noop.rb
+++ b/lib/puppet/provider/mysql_datadir/noop.rb
@@ -1,0 +1,2 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'noop'))
+Puppet::Type.type(:mysql_datadir).provide(:noop, :parent => Puppet::Provider::Noop)

--- a/lib/puppet/provider/mysql_grant/noop.rb
+++ b/lib/puppet/provider/mysql_grant/noop.rb
@@ -1,0 +1,2 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'noop'))
+Puppet::Type.type(:mysql_grant).provide(:noop, :parent => Puppet::Provider::Noop)

--- a/lib/puppet/provider/mysql_plugin/noop.rb
+++ b/lib/puppet/provider/mysql_plugin/noop.rb
@@ -1,0 +1,2 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'noop'))
+Puppet::Type.type(:mysql_plugin).provide(:noop, :parent => Puppet::Provider::Noop)

--- a/lib/puppet/provider/mysql_user/noop.rb
+++ b/lib/puppet/provider/mysql_user/noop.rb
@@ -1,0 +1,2 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'noop'))
+Puppet::Type.type(:mysql_user).provide(:noop, :parent => Puppet::Provider::Noop)

--- a/lib/puppet/provider/noop.rb
+++ b/lib/puppet/provider/noop.rb
@@ -1,0 +1,15 @@
+class Puppet::Provider::Noop < Puppet::Provider
+
+  def create
+    true
+  end
+
+  def destroy
+    true
+  end
+
+  def exists?
+    false
+  end
+
+end


### PR DESCRIPTION
I was trying to run a MySQL catalog in a docker container
to generate config files only like this:

 puppet apply --tags 'file,file_line,concat' ...path to manifest....

I was surprised that --tags didn't exclude the custom mysql_ resources
(mysql_user, mysql_database, etc.). As a work around to that I found
that I can implement a noop shim in the Mysql module itself and
then append this to my catalog on the fly to successfully generate
config files within a docker container:

  Mysql_datadir <| |> { provider => noop}
  Mysql_user <| |> { provider => noop }
  Mysql_database <| |> { provider => noop }