### PR TITLE
test whether sql paths/import files exist before import

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -22,7 +22,8 @@ define mysql::db (
     fail('$sql must be either a string or an array.')
   }
 
-  $sql_inputs = join([$sql], ' ')
+  $sql_inputs      = join([$sql], ' ')
+  $sql_paths_exist = inline_template("<%= @sql.all? {|sql_path| File.exists?(sql_path) }%>")
 
   include '::mysql::client'
 
@@ -56,7 +57,7 @@ define mysql::db (
 
     $refresh = ! $enforce_sql
 
-    if $sql {
+    if $sql and $sql_paths_exist {
       exec{ "${dbname}-import":
         command     => "${import_cat_cmd} ${sql_inputs} | mysql ${dbname}",
         logoutput   => true,


### PR DESCRIPTION
because the sql parameter also takes an array, using an `onlyif` in the
exec isn't appropriate. `test -f` fails with multiple paths passed
to it. this may be dirty but should work. if $sql_paths_exist is false,
don't import. perhaps this should fail instead.