### PR TITLE
(#4534) Add PROXY grant support to mysql_grant

### DIFF
--- a/lib/puppet/type/mysql_grant.rb
+++ b/lib/puppet/type/mysql_grant.rb
@@ -31,6 +31,7 @@ Puppet::Type.newtype(:mysql_grant) do
 
   validate do
     fail('privileges parameter is required.') if self[:ensure] == :present and self[:privileges].nil?
+    fail('PROXY must be the only privilege specified.') if Array(self[:privileges]).count > 1 and Array(self[:privileges]).include?('PROXY')
     fail('table parameter is required.') if self[:ensure] == :present and self[:table].nil?
     fail('user parameter is required.') if self[:ensure] == :present and self[:user].nil?
     fail('name must match user and table parameters') if self[:name] != "#{self[:user]}/#{self[:table]}"
@@ -50,6 +51,12 @@ Puppet::Type.newtype(:mysql_grant) do
 
   newproperty(:table) do
     desc 'Table to apply privileges to.'
+
+    validate do |value|
+      if Array(@resource[:privileges]).include?('PROXY') and !/^([0-9a-zA-Z$_]*)@([\w%\.:\-\/]+)$/.match(value)
+        raise(ArgumentError, '"table" for PROXY should be specified as proxy_user@proxy_host')
+      end
+    end
 
     munge do |value|
       value.delete("`")

--- a/lib/puppet/type/mysql_grant.rb
+++ b/lib/puppet/type/mysql_grant.rb
@@ -53,7 +53,7 @@ Puppet::Type.newtype(:mysql_grant) do
     desc 'Table to apply privileges to.'
 
     validate do |value|
-      if Array(@resource[:privileges]).include?('PROXY') and !/^([0-9a-zA-Z$_]*)@([\w%\.:\-\/]+)$/.match(value)
+      if Array(@resource[:privileges]).include?('PROXY') and !/^[0-9a-zA-Z$_]*@[\w%\.:\-\/]*$/.match(value)
         raise(ArgumentError, '"table" for PROXY should be specified as proxy_user@proxy_host')
       end
     end
@@ -62,7 +62,7 @@ Puppet::Type.newtype(:mysql_grant) do
       value.delete("`")
     end
 
-    newvalues(/.*\..*/,/@/)
+    newvalues(/.*\..*/,/^[0-9a-zA-Z$_]*@[\w%\.:\-\/]*$/)
   end
 
   newproperty(:user) do

--- a/spec/acceptance/types/mysql_grant_spec.rb
+++ b/spec/acceptance/types/mysql_grant_spec.rb
@@ -510,7 +510,7 @@ describe 'mysql_grant' do
         }
       EOS
 
-      expect(apply_manifest(pp, :expect_failures => true).stderror).to match(/PROXY must be the only privilege specified./)
+      expect(apply_manifest(pp, :expect_failures => true).stderr).to match(/PROXY must be the only privilege specified/)
     end
 
     it 'should not find the user' do
@@ -533,7 +533,7 @@ describe 'mysql_grant' do
         }
       EOS
 
-      expect(apply_manifest(pp, :expect_failures => true).stderror).to match(/"table" for PROXY should be specified as proxy_user@proxy_host/)
+      expect(apply_manifest(pp, :expect_failures => true).stderr).to match(/"table" for PROXY should be specified as proxy_user@proxy_host/)
     end
 
     it 'should not find the user' do

--- a/spec/acceptance/types/mysql_grant_spec.rb
+++ b/spec/acceptance/types/mysql_grant_spec.rb
@@ -16,7 +16,7 @@ describe 'mysql_grant' do
   describe 'missing privileges for user' do
     it 'should fail' do
       pp = <<-EOS
-        mysql_user { 'test1@tester': 
+        mysql_user { 'test1@tester':
           ensure => present,
         }
         mysql_grant { 'test1@tester/test.*':
@@ -440,6 +440,104 @@ describe 'mysql_grant' do
         expect(r.stdout).to match(/GRANT EXECUTE ON PROCEDURE `mysql`.`simpleproc` TO 'test2'@'tester'/)
         expect(r.stderr).to be_empty
       end
+    end
+  end
+
+  describe 'adding proxy privileges' do
+    it 'should work without errors' do
+      pp = <<-EOS
+        mysql_user { 'proxy1@tester':
+          ensure => present,
+        }
+        mysql_grant { 'proxy1@tester/proxy_user@proxy_host':
+          ensure     => 'present',
+          table      => 'proxy_user@proxy_host',
+          user       => 'proxy1@tester',
+          privileges => ['PROXY'],
+          require    => Mysql_user['proxy1@tester'],
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    it 'should find the user' do
+      shell("mysql -NBe \"SHOW GRANTS FOR proxy1@tester\"") do |r|
+        expect(r.stdout).to match(/GRANT PROXY ON 'proxy_user'@'proxy_host' TO 'proxy1'@'tester'/)
+        expect(r.stderr).to be_empty
+      end
+    end
+  end
+
+  describe 'removing proxy privileges' do
+    it 'should work without errors' do
+      pp = <<-EOS
+        mysql_user { 'proxy1@tester':
+          ensure => present,
+        }
+        mysql_grant { 'proxy1@tester/proxy_user@proxy_host':
+          ensure     => 'absent',
+          table      => 'proxy_user@proxy_host',
+          user       => 'proxy1@tester',
+          privileges => ['PROXY'],
+          require    => Mysql_user['proxy1@tester'],
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    it 'should find the user' do
+      shell("mysql -NBe \"SHOW GRANTS FOR proxy1@tester\"") do |r|
+        expect(r.stdout).to_not match(/GRANT PROXY ON 'proxy_user'@'proxy_host' TO 'proxy1'@'tester'/)
+        expect(r.stderr).to be_empty
+      end
+    end
+  end
+
+  describe 'adding proxy privileges with other privileges' do
+    it 'should fail' do
+      pp = <<-EOS
+        mysql_user { 'proxy2@tester':
+          ensure => present,
+        }
+        mysql_grant { 'proxy2@tester/proxy_user@proxy_host':
+          ensure     => 'present',
+          table      => 'proxy_user@proxy_host',
+          user       => 'proxy2@tester',
+          privileges => ['PROXY', 'SELECT'],
+          require    => Mysql_user['proxy2@tester'],
+        }
+      EOS
+
+      expect(apply_manifest(pp, :expect_failures => true).stderror).to match(/PROXY must be the only privilege specified./)
+    end
+
+    it 'should not find the user' do
+      expect(shell("mysql -NBe \"SHOW GRANTS FOR proxy2@tester\"", { :acceptable_exit_codes => 1}).stderr).to match(/There is no such grant defined for user 'proxy2' on host 'tester'/)
+    end
+  end
+
+  describe 'adding proxy privileges with invalid proxy user' do
+    it 'should fail' do
+      pp = <<-EOS
+        mysql_user { 'proxy3@tester':
+          ensure => present,
+        }
+        mysql_grant { 'proxy3@tester/invalid_proxy_user':
+          ensure     => 'present',
+          table      => 'invalid_proxy_user',
+          user       => 'proxy3@tester',
+          privileges => ['PROXY'],
+          require    => Mysql_user['proxy3@tester'],
+        }
+      EOS
+
+      expect(apply_manifest(pp, :expect_failures => true).stderror).to match(/"table" for PROXY should be specified as proxy_user@proxy_host/)
+    end
+
+    it 'should not find the user' do
+      expect(shell("mysql -NBe \"SHOW GRANTS FOR proxy3@tester\"", { :acceptable_exit_codes => 1}).stderr).to match(/There is no such grant defined for user 'proxy3' on host 'tester'/)
     end
   end
 

--- a/spec/unit/puppet/type/mysql_grant_spec.rb
+++ b/spec/unit/puppet/type/mysql_grant_spec.rb
@@ -3,13 +3,13 @@ require 'puppet/type/mysql_grant'
 describe Puppet::Type.type(:mysql_grant) do
 
   before :each do
-    @user = Puppet::Type.type(:mysql_grant).new(:name => 'foo@localhost/*.*', :privileges => ['ALL', 'PROXY'], :table => ['*.*','@'], :user => 'foo@localhost')
+    @user = Puppet::Type.type(:mysql_grant).new(:name => 'foo@localhost/*.*', :privileges => ['ALL'], :table => ['*.*'], :user => 'foo@localhost')
   end
 
   it 'should accept a grant name' do
     expect(@user[:name]).to eq('foo@localhost/*.*')
   end
-  
+
   it 'should accept ALL privileges' do
     @user[:privileges] = 'ALL'
     expect(@user[:privileges]).to eq(['ALL'])
@@ -17,24 +17,30 @@ describe Puppet::Type.type(:mysql_grant) do
 
   it 'should accept PROXY privilege' do
     @user[:privileges] = 'PROXY'
+    @user[:table]      = 'proxy_user@proxy_host'
     expect(@user[:privileges]).to eq(['PROXY'])
   end
-  
+
   it 'should accept a table' do
     @user[:table] = '*.*'
     expect(@user[:table]).to eq('*.*')
   end
-  
+
   it 'should accept @ for table' do
     @user[:table] = '@'
     expect(@user[:table]).to eq('@')
   end
-  
+
+  it 'should accept proxy user for table' do
+    @user[:table] = 'proxy_user@proxy_host'
+    expect(@user[:table]).to eq('proxy_user@proxy_host')
+  end
+
   it 'should accept a user' do
     @user[:user] = 'foo@localhost'
     expect(@user[:user]).to eq('foo@localhost')
   end
-  
+
   it 'should require a name' do
     expect {
       Puppet::Type.type(:mysql_grant).new({})
@@ -43,7 +49,7 @@ describe Puppet::Type.type(:mysql_grant) do
 
   it 'should require the name to match the user and table' do
     expect {
-      Puppet::Type.type(:mysql_grant).new(:name => 'foo', :privileges => ['ALL', 'PROXY'], :table => ['*.*','@'], :user => 'foo@localhost')
+      Puppet::Type.type(:mysql_grant).new(:name => 'foo', :privileges => ['ALL'], :table => ['*.*'], :user => 'foo@localhost')
     }.to raise_error /name must match user and table parameters/
   end
 
@@ -51,21 +57,21 @@ describe Puppet::Type.type(:mysql_grant) do
 
     it 'to just ALL' do
       @user = Puppet::Type.type(:mysql_grant).new(
-        :name => 'foo@localhost/*.*',  :table => ['*.*','@'], :user => 'foo@localhost',
-        :privileges => ['ALL', 'PROXY'] )
+        :name => 'foo@localhost/*.*',  :table => ['*.*'], :user => 'foo@localhost',
+        :privileges => ['ALL'] )
       expect(@user[:privileges]).to eq(['ALL'])
     end
 
     it 'to upcase and ordered' do
       @user = Puppet::Type.type(:mysql_grant).new(
-        :name => 'foo@localhost/*.*',  :table => ['*.*','@'], :user => 'foo@localhost',
+        :name => 'foo@localhost/*.*',  :table => ['*.*'], :user => 'foo@localhost',
         :privileges => ['select', 'Insert'] )
       expect(@user[:privileges]).to eq(['INSERT', 'SELECT'])
     end
 
     it 'ordered including column privileges' do
       @user = Puppet::Type.type(:mysql_grant).new(
-        :name => 'foo@localhost/*.*',  :table => ['*.*','@'], :user => 'foo@localhost',
+        :name => 'foo@localhost/*.*',  :table => ['*.*'], :user => 'foo@localhost',
         :privileges => ['SELECT(Host,Address)', 'Insert'] )
       expect(@user[:privileges]).to eq(['INSERT', 'SELECT (Address, Host)'])
     end


### PR DESCRIPTION
The mysql_grant type does not currently support PROXY grants. The only real difference between PROXY and other grants is that the "table" is actually a user (proxy_user@proxy_host). This patch adds this support and allows for the following:

```puppet
mysql_grant { 'foo@bar/baz@blah':
  ensure     => present, # or absent
  user       => 'foo@bar',
  table      => 'baz@blah',
  privileges => 'PROXY',
}
```