### PR TITLE
(maint) Fail when proxy privilege added on mysql version < 5.5.0

### DIFF
--- a/lib/puppet/type/mysql_grant.rb
+++ b/lib/puppet/type/mysql_grant.rb
@@ -47,6 +47,13 @@ Puppet::Type.newtype(:mysql_grant) do
 
   newproperty(:privileges, :array_matching => :all) do
     desc 'Privileges for user'
+
+    validate do |value|
+      mysql_version = Facter.value(:mysql_version)
+      if value =~ /proxy/i and Puppet::Util::Package.versioncmp(mysql_version, '5.5.0') < 0
+        raise(ArgumentError, "PROXY user not supported on mysql versions < 5.5.0. Current version #{mysql_version}")
+      end
+    end
   end
 
   newproperty(:table) do


### PR DESCRIPTION
I merged PR #934 and it failed CI for older mysql versions because PROXY privileges are not supported until mysql version 5.5.0. Rather than revert this functionality I have added validation to the mysql_grant type and also added an  acceptance test to test for this error.

All PROXY tests within mysql_grant type have been placed in their own describe block where pre_run is called and retrieves the mysql version from the SUT. The remaining PROXY tests are filtered on this musql version to ensure they do not run on mysql versions < 5.5.0