### PR TITLE
Add support for optional__args and prescript to mysqldump backup provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ Defines the maximum SQL statement size for the backup dump script. The default v
 
 ##### `optional_args`
 
-Specifies an array of optional arguments which should be passed through to the backup tool. (Currently only supported by the xtrabackup provider.)
+Specifies an array of optional arguments which should be passed through to the backup tool. (Supported by the xtrabackup and mysqldump providers.)
 
 #### mysql::server::monitor
 

--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -28,6 +28,11 @@ echo "[client]\npassword=$PASS\nuser=$USER\nmax_allowed_packet=$MAX_ALLOWED_PACK
 echo -e "[client]\npassword=$PASS\nuser=$USER\nmax_allowed_packet=$MAX_ALLOWED_PACKET" > $TMPFILE
 <%- end -%>
 
+<% if @prescript -%>
+<%- [@prescript].flatten.compact.each do |script|%>
+<%= script %>
+<%- end -%>
+<% end -%>
 
 # Ensure backup directory exist.
 mkdir -p $DIR

--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -54,6 +54,12 @@ ADDITIONAL_OPTIONS="$ADDITIONAL_OPTIONS --skip-routines"
 <% end -%>
 <% end -%>
 
+<%- if @optional_args and @optional_args.is_a?(Array) -%>
+<%- @optional_args.each do |arg| -%>
+ADDITIONAL_OPTIONS="$ADDITIONAL_OPTIONS <%= arg %>"
+<%- end -%>
+<%- end -%>
+
 ##### STOP CONFIG ####################################################
 PATH=<%= @execpath %>
 


### PR DESCRIPTION
The mysqldump class already has the optional_args and prescript parameters but they were never implemented in the script template.