### PR TITLE
(MODULES-4743) mysql : cannot initialize database dir not empty

### DIFF
--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -19,11 +19,11 @@ class mysql::server::installdb {
 
   if $options['mysqld']['log-error'] {
     file { $options['mysqld']['log-error']:
-      ensure => present,
-      owner  => $mysqluser,
-      group  => $::mysql::server::mysql_group,
-      mode   => 'u+rw',
-      before => Mysql_datadir[ $datadir ],
+      ensure  => present,
+      owner   => $mysqluser,
+      group   => $::mysql::server::mysql_group,
+      mode    => 'u+rw',
+      require => Mysql_datadir[ $datadir ],
     }
   }
 


### PR DESCRIPTION
(MODULES-4743) puppetlabs-mysql : cannot initialize database dir not empty