### PR TITLE
Add --incremental-basedir option to xtrabackup cron job

### DIFF
--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -57,7 +57,7 @@ class mysql::backup::xtrabackup (
 
   cron { 'xtrabackup-daily':
     ensure  => $ensure,
-    command => "/usr/local/sbin/xtrabackup.sh --incremental ${backupdir}",
+    command => "/usr/local/sbin/xtrabackup.sh --incremental ${backupdir} --incremental-basedir ${backupdir}/$(ls -1rt ${backupdir} | tail -1)",
     user    => 'root',
     hour    => $time[0],
     minute  => $time[1],


### PR DESCRIPTION
Incremental backup with xtrabackup is not working unless the option --incremental-basedir is passed on to the cronjob.
It will also take the last created backup within $backupdir as the base for the new incremental backup.