### PR TITLE
versioncmp parameter compatibility

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -385,7 +385,9 @@ class mysql::params {
 
   case $::operatingsystem {
     'Ubuntu': {
+      # lint:ignore:only_variable_string
       if versioncmp("${::operatingsystemmajrelease}", '14.10') > 0 {
+      # lint:endignore
         $server_service_provider = 'systemd'
       } else {
         $server_service_provider = 'upstart'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -385,7 +385,7 @@ class mysql::params {
 
   case $::operatingsystem {
     'Ubuntu': {
-      if versioncmp($::operatingsystemmajrelease, '14.10') > 0 {
+      if versioncmp("${::operatingsystemmajrelease}", '14.10') > 0 {
         $server_service_provider = 'systemd'
       } else {
         $server_service_provider = 'upstart'


### PR DESCRIPTION
The error I was getting was:
```
Error: Evaluation Error: Error while evaluating a Function Call, 'versioncmp' parameter 'a' expects a String value, got Undef at '/puppetlabs-mysql/manifest/params.pp'....
```
Puppet 4 introduces strong type checking so after this change it will work on puppet 4 and puppet 3
from
`if versioncmp($::operatingsystemmajrelease, '14.10') > 0 {`
to
`if versioncmp("${::operatingsystemmajrelease}", '14.10') > 0 {`