### PR TITLE
(MODULES-4604) move name validation in mysql_grant type

### DIFF
--- a/lib/puppet/type/mysql_grant.rb
+++ b/lib/puppet/type/mysql_grant.rb
@@ -34,7 +34,9 @@ Puppet::Type.newtype(:mysql_grant) do
     fail('PROXY must be the only privilege specified.') if Array(self[:privileges]).count > 1 and Array(self[:privileges]).include?('PROXY')
     fail('table parameter is required.') if self[:ensure] == :present and self[:table].nil?
     fail('user parameter is required.') if self[:ensure] == :present and self[:user].nil?
-    fail('name must match user and table parameters') if self[:name] != "#{self[:user]}/#{self[:table]}"
+    if self[:user] and self[:table]
+      fail('name must match user@host/table format') if self[:name] != "#{self[:user]}/#{self[:table]}"
+    end
   end
 
   newparam(:name, :namevar => true) do

--- a/spec/acceptance/types/mysql_grant_spec.rb
+++ b/spec/acceptance/types/mysql_grant_spec.rb
@@ -109,25 +109,6 @@ describe 'mysql_grant' do
     end
   end
 
-  describe 'adding privileges with invalid name' do
-    it 'should fail' do
-      pp = <<-EOS
-        mysql_user { 'test2@tester':
-          ensure => present,
-        }
-        mysql_grant { 'test':
-          ensure     => 'present',
-          table      => 'test.*',
-          user       => 'test2@tester',
-          privileges => ['SELECT', 'UPDATE'],
-          require    => Mysql_user['test2@tester'],
-        }
-      EOS
-
-      expect(apply_manifest(pp, :expect_failures => true).stderr).to match(/name must match user and table parameters/)
-    end
-  end
-
   describe 'adding option' do
     it 'should work without errors' do
       pp = <<-EOS

--- a/spec/unit/puppet/type/mysql_grant_spec.rb
+++ b/spec/unit/puppet/type/mysql_grant_spec.rb
@@ -68,8 +68,11 @@ describe Puppet::Type.type(:mysql_grant) do
 
   it 'should require the name to match the user and table' do
     expect {
+      Puppet::Type.type(:mysql_grant).new(:name => 'foo@localhost/*.*', :privileges => ['ALL'], :table => ['*.*'], :user => 'foo@localhost')
+    }.to_not raise_error
+    expect {
       Puppet::Type.type(:mysql_grant).new(:name => 'foo', :privileges => ['ALL'], :table => ['*.*'], :user => 'foo@localhost')
-    }.to raise_error /name must match user and table parameters/
+    }.to raise_error /name must match user@host\/table format/
   end
 
   describe 'it should munge privileges' do


### PR DESCRIPTION
Users are running into an issue where \`puppet resource mysql_grant\` fails because there is a global name validation using properties that only exist in a compiled catalog and not in the naked type that is instantiated during a \`puppet resource\` run. self[:user] and self[:table] are nil in this use case so there is a failure. This commit surrounds the validation in an if statement so it is not called during \`puppet resource\`. Also, a happy path test is added and the acceptance test is removed."