### PR TITLE
Fix to get Travis running green on unit tests

### DIFF
--- a/spec/classes/graceful_failures_spec.rb
+++ b/spec/classes/graceful_failures_spec.rb
@@ -2,15 +2,13 @@ require 'spec_helper'
 
 describe 'mysql::server' do
   context "on an unsupported OS" do
-    # fetch any sets of facts to modify them
-    os, facts = on_supported_os.first
 
-    let(:facts) {
-      facts.merge({
+    let(:facts) do
+      {
         :osfamily => 'UNSUPPORTED',
-        :operatingsystem => 'UNSUPPORTED',
-      })
-    }
+        :operatingsystem => 'UNSUPPORTED'
+      }
+    end
 
     it 'should gracefully fail' do
       is_expected.to compile.and_raise_error(/Unsupported platform:/)


### PR DESCRIPTION
Due to https://github.com/mcanevet/rspec-puppet-facts/pull/53 some of our unti tests are failing
on Travis. This fix averts these errors for the meantime while still running the same test.