### PR TITLE
List Debian Stretch as supported

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -56,7 +56,8 @@
       "operatingsystemrelease": [
         "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
db51029d27279e7e4ce46a8ceb61f2e6089aa2c4 added support for Stretch but didn't add this to the metadata.