### PR TITLE
merge from upstream master

### DIFF
--- a/templates/xtrabackup.sh.erb
+++ b/templates/xtrabackup.sh.erb
@@ -14,7 +14,7 @@
 
 <%- _innobackupex_args = '' -%>
 
-<%- if @backupuser and @backuppassword -%>
+<%- unless @backupuser.emtpy? or @backuppassword.empty? -%>
   <%- _innobackupex_args = '--user="' + @backupuser + '" --password="' + @backuppassword + '"' -%>
 <%- end -%>
 


### PR DESCRIPTION
Because both variables exist, but are empty, --user and
--password options are added. This causes backups to stop
if you are using xtrabackup.