### PR TITLE
Fixing empty user/password issue

### DIFF
--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -1,8 +1,8 @@
 # See README.me for usage.
 class mysql::backup::xtrabackup (
   $xtrabackup_package_name = $mysql::params::xtrabackup_package_name,
-  $backupuser              = '',
-  $backuppassword          = '',
+  $backupuser              = undef,
+  $backuppassword          = undef,
   $backupdir               = '',
   $maxallowedpacket        = '1M',
   $backupmethod            = 'mysqldump',


### PR DESCRIPTION
With empty strings the template has the --user and --password options, but those are empty.