### PR TITLE
(MODULES-5528) mysql_install_db should be optional

### DIFF
--- a/lib/puppet/provider/mysql_datadir/mysql.rb
+++ b/lib/puppet/provider/mysql_datadir/mysql.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, :parent => Puppet::Provider::M
   ENV['PATH']=ENV['PATH'] + ':/usr/libexec:/usr/share/mysql/scripts:/opt/rh/mysql55/root/usr/bin:/opt/rh/mysql55/root/usr/libexec:/usr/mysql/5.5/bin:/usr/mysql/5.6/bin:/usr/mysql/5.7/bin'
 
   commands :mysqld => 'mysqld'
-  commands :mysql_install_db => 'mysql_install_db'
+  optional_commands :mysql_install_db => 'mysql_install_db'
 
   def create
     name                     = @resource[:name]


### PR DESCRIPTION
Prior to this PR, `mysql_install_db` was a hard requirement in the
mysql provider. Since this command is not in all versions of MySQL, this
commit removes the hard requirement of `mysql_install_db`. Existing
conditional logic already exists to handle situations where the
`mysql_install_db` is not used.