### PR TITLE
Ensure that Puppet runs are idempotent

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -76,8 +76,8 @@ class mysql::server (
   }
 
   Anchor['mysql::server::start']
-  -> Class['mysql::server::config']
   -> Class['mysql::server::install']
+  -> Class['mysql::server::config']
   -> Class['mysql::server::binarylog']
   -> Class['mysql::server::installdb']
   -> Class['mysql::server::service']

--- a/spec/acceptance/mysql_server_spec.rb
+++ b/spec/acceptance/mysql_server_spec.rb
@@ -2,14 +2,9 @@ require 'spec_helper_acceptance'
 
 describe 'mysql class' do
   describe 'advanced config' do
-    before(:all) do
-      @tmpdir = default.tmpdir('mysql')
-    end
     let(:pp) do
       <<-EOS
         class { 'mysql::server':
-          config_file             => '#{@tmpdir}/my.cnf',
-          includedir              => '#{@tmpdir}/include',
           manage_config_file      => 'true',
           override_options        => { 'mysqld' => { 'key_buffer_size' => '32M' }},
           package_ensure          => 'present',
@@ -58,8 +53,6 @@ describe 'mysql class' do
     let(:pp) do
       <<-EOS
         class { 'mysql::server':
-          config_file             => '#{@tmpdir}/my.cnf',
-          includedir              => '#{@tmpdir}/include',
           manage_config_file      => 'false',
           override_options        => { 'mysqld' => { 'key_buffer_size' => '32M' }},
           package_ensure          => 'present',


### PR DESCRIPTION
Currently this module requires two executions of `puppet apply` to properly configure MySQL. On an Ubuntu 16.04 instance, I am seeing the second Puppet run produce the following changes:

```
Notice: Compiled catalog for ubuntu-16.04-x64 in environment production in 1.93 seconds
Info: Applying configuration version '1504824440'
Info: Computing checksum on file /etc/mysql/conf.d/mysql.cnf
Info: /Stage[main]/Mysql::Server::Config/File[/etc/mysql/conf.d/mysql.cnf]: Filebucketed /etc/mysql/conf.d/mysql.cnf to puppet with sum c992f7b57d778f607e8d83792936e92b
Notice: /Stage[main]/Mysql::Server::Config/File[/etc/mysql/conf.d/mysql.cnf]/ensure: removed
Notice: /Stage[main]/Mysql::Server::Config/File[mysql-config-file]/ensure: defined content as '{md5}59e52aeed142f9004c9e74ff5e4f1d84'
Info: Class[Mysql::Server::Config]: Scheduling refresh of Class[Mysql::Server::Service]
Info: Class[Mysql::Server::Service]: Scheduling refresh of Service[mysqld]
Info: Class[Mysql::Server::Service]: Scheduling refresh of Exec[wait_for_mysql_socket_to_open]
Notice: /Stage[main]/Mysql::Server::Service/Service[mysqld]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Mysql::Server::Service/Exec[wait_for_mysql_socket_to_open]: Triggered 'refresh' from 1 events
Notice: Applied catalog in 2.49 seconds
```

The problem is that `Class['mysql::server::config']` is included before `Class['mysql::server::install']`. This means that `/etc/mysql/my.cnf` is configured first, but then subsequently overridden by the default configuration that is installed by the `mysql-server` package. This isn't picked up by the existing acceptance tests because they explicitly set `config_file` to `'#{@tmpdir}/my.cnf`.