### PR TITLE
(MODULES-5602) remove superfluous backslashes from regular expressions

### DIFF
--- a/lib/puppet/type/mysql_datadir.rb
+++ b/lib/puppet/type/mysql_datadir.rb
@@ -20,7 +20,7 @@ Puppet::Type.newtype(:mysql_datadir) do
 
   newparam(:defaults_extra_file) do
     desc 'MySQL defaults-extra-file with absolute path (*.cnf).'
-    newvalues(%r{^\/.*\.cnf$})
+    newvalues(%r{^/.*\.cnf$})
   end
 
   newparam(:insecure, boolean: true) do
@@ -29,6 +29,6 @@ Puppet::Type.newtype(:mysql_datadir) do
 
   newparam(:log_error) do
     desc 'The path to the mysqld error log file (used with the --log-error option)'
-    newvalues(%r{^\/})
+    newvalues(%r{^/})
   end
 end

--- a/lib/puppet/type/mysql_grant.rb
+++ b/lib/puppet/type/mysql_grant.rb
@@ -63,14 +63,14 @@ Puppet::Type.newtype(:mysql_grant) do
     desc 'Table to apply privileges to.'
 
     validate do |value|
-      raise(ArgumentError, '"table" for PROXY should be specified as proxy_user@proxy_host') if Array(@resource[:privileges]).include?('PROXY') && !%r{^[0-9a-zA-Z$_]*@[\w%\.:\-\/]*$}.match(value)
+      raise(ArgumentError, '"table" for PROXY should be specified as proxy_user@proxy_host') if Array(@resource[:privileges]).include?('PROXY') && !%r{^[0-9a-zA-Z$_]*@[\w%\.:\-/]*$}.match(value)
     end
 
     munge do |value|
       value.delete('`')
     end
 
-    newvalues(%r{.*\..*}, %r{^[0-9a-zA-Z$_]*@[\w%\.:\-\/]*$})
+    newvalues(%r{.*\..*}, %r{^[0-9a-zA-Z$_]*@[\w%\.:\-/]*$})
   end
 
   newproperty(:user) do
@@ -81,10 +81,10 @@ Puppet::Type.newtype(:mysql_grant) do
       # http://stackoverflow.com/questions/8055727/negating-a-backreference-in-regular-expressions/8057827#8057827
       # rubocop:disable Lint/AssignmentInCondition
       # rubocop:disable Lint/UselessAssignment
-      if matches = %r{^(['`"])((?!\1).)*\1@([\w%\.:\-\/]+)$}.match(value)
+      if matches = %r{^(['`"])((?!\1).)*\1@([\w%\.:\-/]+)$}.match(value)
         user_part = matches[2]
         host_part = matches[3]
-      elsif matches = %r{^([0-9a-zA-Z$_]*)@([\w%\.:\-\/]+)$}.match(value)
+      elsif matches = %r{^([0-9a-zA-Z$_]*)@([\w%\.:\-/]+)$}.match(value)
         user_part = matches[1]
         host_part = matches[2]
       elsif matches = %r{^((?!['`"]).*[^0-9a-zA-Z$_].*)@(.+)$}.match(value)

--- a/lib/puppet/type/mysql_user.rb
+++ b/lib/puppet/type/mysql_user.rb
@@ -16,10 +16,10 @@ Puppet::Type.newtype(:mysql_user) do
       mysql_version = Facter.value(:mysql_version)
       # rubocop:disable Lint/AssignmentInCondition
       # rubocop:disable Lint/UselessAssignment
-      if matches = %r{^(['`"])((?:(?!\1).)*)\1@([\w%\.:\-\/]+)$}.match(value)
+      if matches = %r{^(['`"])((?:(?!\1).)*)\1@([\w%\.:\-/]+)$}.match(value)
         user_part = matches[2]
         host_part = matches[3]
-      elsif matches = %r{^([0-9a-zA-Z$_]*)@([\w%\.:\-\/]+)$}.match(value)
+      elsif matches = %r{^([0-9a-zA-Z$_]*)@([\w%\.:\-/]+)$}.match(value)
         user_part = matches[1]
         host_part = matches[2]
       elsif matches = %r{^((?!['`"]).*[^0-9a-zA-Z$_].*)@(.+)$}.match(value)


### PR DESCRIPTION
This is triggering PUP-7925, causing the mysql module being unusable on
all existing puppet versions.