### PR TITLE
(FM-6362) Install i18n gems from RubyGems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,16 +44,16 @@ end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}",                            :require => false, :platforms => "ruby"
   gem "puppet-module-win-system-r#{minor_version}",                              :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')                  
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')
   gem "beaker-pe",                                                               :require => false
-  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])                
+  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
-  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
+  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
   gem "puppet-blacksmith", '~> 3.4',                                             :require => false
-  gem "puppet-lint-i18n", :git => 'https://github.com/puppetlabs/puppet-lint-i18n.git'
-  gem "puppet_pot_generator", :git => 'https://github.com/puppetlabs/puppet_pot_generator.git'
+  gem "puppet-lint-i18n"
+  gem "puppet_pot_generator"
   gem "rubocop-i18n", '~> 1.0'
-  gem "beaker-i18n_helper", :git => 'https://github.com/eputnam/beaker-i18n_helper.git'
+  gem "beaker-i18n_helper"
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "http://github.com/puppetlabs/puppetlabs-mysql",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
-    {"name":"puppetlabs/translate","version_requirement":">= 0.0.1 < 1.0.0"},
+    {"name":"puppetlabs/translate","version_requirement":">= 1.0.0 < 2.0.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 5.0.0"},
     {"name":"puppet/staging","version_requirement":">= 1.0.1 < 3.0.0"}
   ],

--- a/spec/acceptance/locales_spec.rb
+++ b/spec/acceptance/locales_spec.rb
@@ -5,7 +5,7 @@ describe 'mysql localization', if: fact('osfamily') == 'Debian' do
   before :all do
     hosts.each do |host|
       on(host, "sed -i \"96i FastGettext.locale='ja'\" /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb")
-      change_locale_on(host, 'ja_JP')
+      change_locale_on(host, 'ja_JP.utf-8')
     end
   end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -27,7 +27,7 @@ RSpec.configure do |c|
       # This will be removed, this is temporary to test localisation.
       if fact('osfamily') == 'Debian'
         # install language pack on debian systems
-        install_language_pack_on(host, 'ja_JP')
+        install_language_pack_on(host, 'ja_JP.utf-8')
         # This will be removed, this is temporary to test localisation.
         on(host, 'sudo mkdir /opt/puppetlabs/puppet/share/locale/ja')
         on(host, 'sudo touch /opt/puppetlabs/puppet/share/locale/ja/puppet.po')


### PR DESCRIPTION
Prior to this commit, our i18n gems were being installed from git
as they were not yet released. Now that they've been released,
just install them from RubyGems.

_This PR is queued up in advance but shouldn't be merged until all the gems have been released._