### PR TITLE
(maint) update install_language_pack_on method

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -26,11 +26,11 @@ RSpec.configure do |c|
     hosts.each do |host|
       # This will be removed, this is temporary to test localisation.
       if fact('osfamily') == 'Debian'
-        # install language pack on debian systems
-        install_language_pack_on(host, 'ja_JP.utf-8')
+        # install language on debian systems
+        install_language_on(host, 'ja_JP.utf-8') if not_controller(host)
         # This will be removed, this is temporary to test localisation.
-        on(host, 'sudo mkdir /opt/puppetlabs/puppet/share/locale/ja')
-        on(host, 'sudo touch /opt/puppetlabs/puppet/share/locale/ja/puppet.po')
+        on(host, 'mkdir /opt/puppetlabs/puppet/share/locale/ja')
+        on(host, 'touch /opt/puppetlabs/puppet/share/locale/ja/puppet.po')
       end
       # Required for binding tests.
       if fact('osfamily') == 'RedHat'


### PR DESCRIPTION
the latest version of the i18n_helper changes install_language_pack_on to install_language_on so this makes that change in spec_helper_acceptance. it also removes sudo from a couple host commands in the same file to resolve an error i was getting there