### PR TITLE
Allow authentication plugin to be changed

### DIFF
--- a/lib/puppet/provider/mysql_user/mysql.rb
+++ b/lib/puppet/provider/mysql_user/mysql.rb
@@ -159,6 +159,23 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
     (max_updates_per_hour == int) ? (return true) : (return false)
   end
 
+  def plugin=(string)
+    merged_name = self.class.cmd_user(@resource[:name])
+
+    if (mysqld_type == 'mysql' || mysqld_type == 'percona') && Puppet::Util::Package.versioncmp(mysqld_version, '5.7.6') >= 0
+      sql = "ALTER USER #{merged_name} IDENTIFIED WITH '#{string}'"
+      sql << " AS '#{@resource[:password_hash]}'" if string == 'mysql_native_password'
+    else
+      # See https://bugs.mysql.com/bug.php?id=67449
+      sql = "UPDATE mysql.user SET plugin = '#{string}'"
+      sql << ((string == 'mysql_native_password') ? ", password = '#{@resource[:password_hash]}'" : ", password = ''")
+      sql << " WHERE CONCAT(user, '@', host) = '#{@resource[:name]}'"
+    end
+
+    mysql([defaults_file, system_database, '-e', sql].compact)
+    (plugin == string) ? (return true) : (return false)
+  end
+
   def tls_options=(array)
     merged_name = self.class.cmd_user(@resource[:name])
     merged_tls_options = array.join(' AND ')

--- a/spec/acceptance/types/mysql_user_spec.rb
+++ b/spec/acceptance/types/mysql_user_spec.rb
@@ -36,6 +36,32 @@ describe 'mysql_user' do
         end
       end
     end
+
+    describe 'changing authentication plugin' do
+      it 'should work without errors' do
+        pp = <<-EOS
+          mysql_user { 'ashp@localhost':
+            plugin => 'auth_socket',
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+      end
+
+      it 'should have correct plugin' do
+        shell("mysql -NBe \"select plugin from mysql.user where CONCAT(user, '@', host) = 'ashp@localhost'\"") do |r|
+          expect(r.stdout.rstrip).to eq('auth_socket')
+          expect(r.stderr).to be_empty
+        end
+      end
+
+      it 'should not have a password' do
+        shell("mysql -NBe \"select password from mysql.user where CONCAT(user, '@', host) = 'ashp@localhost'\"") do |r|
+          expect(r.stdout.rstrip).to be_empty
+          expect(r.stderr).to be_empty
+        end
+      end
+    end
   end
 
   context 'using ashp-dash@localhost' do

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -286,6 +286,52 @@ usvn_user@localhost
     end
   end
 
+  describe 'plugin=' do
+    context 'auth_socket' do
+      context 'MySQL < 5.7.6' do
+        it 'changes the authentication plugin' do
+          provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
+          provider.expects(:mysql).with([defaults_file, system_database, '-e', "UPDATE mysql.user SET plugin = 'auth_socket', password = '' WHERE CONCAT(user, '@', host) = 'joe@localhost'"]).returns('0')
+
+          provider.expects(:plugin).returns('auth_socket')
+          provider.plugin = 'auth_socket'
+        end
+      end
+
+      context 'MySQL >= 5.7.6' do
+        it 'changes the authentication plugin' do
+          provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
+          provider.expects(:mysql).with([defaults_file, system_database, '-e', "ALTER USER 'joe'@'localhost' IDENTIFIED WITH 'auth_socket'"]).returns('0')
+
+          provider.expects(:plugin).returns('auth_socket')
+          provider.plugin = 'auth_socket'
+        end
+      end
+    end
+
+    context 'mysql_native_password' do
+      context 'MySQL < 5.7.6' do
+        it 'changes the authentication plugin' do
+          provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
+          provider.expects(:mysql).with([defaults_file, system_database, '-e', "UPDATE mysql.user SET plugin = 'mysql_native_password', password = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4' WHERE CONCAT(user, '@', host) = 'joe@localhost'"]).returns('0')
+
+          provider.expects(:plugin).returns('mysql_native_password')
+          provider.plugin = 'mysql_native_password'
+        end
+      end
+
+      context 'MySQL >= 5.7.6' do
+        it 'changes the authentication plugin' do
+          provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
+          provider.expects(:mysql).with([defaults_file, system_database, '-e', "ALTER USER 'joe'@'localhost' IDENTIFIED WITH 'mysql_native_password' AS '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4'"]).returns('0')
+
+          provider.expects(:plugin).returns('mysql_native_password')
+          provider.plugin = 'mysql_native_password'
+        end
+      end
+    end
+  end
+
   describe 'tls_options=' do
     it 'adds SSL option grant in mysql 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])


### PR DESCRIPTION
Currently changing the `plugin` property of the `mysql_user` resource has no effect.