### PR TITLE
WIP - Adding a test using beaker-testmode_switcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,13 @@ matrix:
   include:
   - rvm: 2.3.1
     dist: trusty
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/ubuntu-14.04
+    env: BEAKER_TESTMODE=agent PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/ubuntu-14.04
     script: bundle exec rake beaker
     services: docker
     sudo: required
   - rvm: 2.3.1
     dist: trusty
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7
+    env: BEAKER_TESTMODE=agent PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7
     script: bundle exec rake beaker
     services: docker
     sudo: required

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :system_tests do
   gem "puppet_pot_generator"
   gem "rubocop-i18n", '~> 1.0'
   gem "beaker-i18n_helper"
+  gem "beaker-testmode_switcher"
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])

--- a/spec/acceptance/locales_spec.rb
+++ b/spec/acceptance/locales_spec.rb
@@ -94,6 +94,23 @@ describe 'mysql localization', if: (fact('osfamily') == 'Debian' || fact('osfami
     end
   end
 
+  context 'when triggering ruby interpolated string error' unless pe_install? do
+    let(:pp) do
+      <<-EOS
+      mysql_user{ 'name@localhost':
+        ensure => 'present',
+        tls_options => ['invalid_option'],
+       }
+      EOS
+    end
+
+    it 'displays Japanese error' do
+      execute_manifest(pp, expect_failures: true) do |r|
+        expect(r.stderr).to match(%r{無効なtlsオプション}i)
+      end
+    end
+  end
+
   after :all do
     hosts.each do |host|
       on(host, 'sed -i "96d" /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb')

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -3,6 +3,8 @@ require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
 require 'beaker/i18n_helper'
+require 'beaker/testmode_switcher'
+require 'beaker/testmode_switcher/dsl'
 
 run_puppet_install_helper
 install_ca_certs unless ENV['PUPPET_INSTALL_TYPE'] =~ %r{pe}i


### PR DESCRIPTION
All current tests are applying the manifest. 
Implementing 'beaker-testmode_switcher' provides us with the capability of injecting the manifest to the master and running 'puppet agent -t' on the agent. This exercises the interface between the master and agent and tests more like an end user. 