### PR TITLE
MODULES-6018 properly parse/escape whitespace in tls_options

### DIFF
--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -106,4 +106,15 @@ class Puppet::Provider::Mysql < Puppet::Provider
     end
     option_string
   end
+
+  def self.merge_tls_options(tls_options)
+    # issuer and subject may contain spaces
+    tls_options.map! { |item|
+      parts = item.split(' ', 2)
+      next if parts.length < 2
+      item = "#{parts[0]} '#{parts[1]}'"
+    }
+
+    merged_tls_options = tls_options.join(' AND ')
+  end
 end

--- a/lib/puppet/provider/mysql_user/mysql.rb
+++ b/lib/puppet/provider/mysql_user/mysql.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
       end
       @max_user_connections, @max_connections_per_hour, @max_queries_per_hour,
       @max_updates_per_hour, ssl_type, ssl_cipher, x509_issuer, x509_subject,
-      @password, @plugin = mysql([defaults_file, '-NBe', query].compact).split(%r{\s})
+      @password, @plugin = mysql([defaults_file, '--delimiter=\t', '-NBe', query].compact).split(%r{\t})
       @tls_options = parse_tls_options(ssl_type, ssl_cipher, x509_issuer, x509_subject)
       # rubocop:enable Metrics/LineLength
       new(name: name,
@@ -83,7 +83,7 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
     @property_hash[:max_queries_per_hour] = max_queries_per_hour
     @property_hash[:max_updates_per_hour] = max_updates_per_hour
 
-    merged_tls_options = tls_options.join(' AND ')
+    merged_tls_options = self.class.merge_tls_options(tls_options)
     if ((mysqld_type == 'mysql' || mysqld_type == 'percona') && Puppet::Util::Package.versioncmp(mysqld_version, '5.7.6') >= 0) ||
        (mysqld_type == 'mariadb' && Puppet::Util::Package.versioncmp(mysqld_version, '10.2.0') >= 0)
       mysql([defaults_file, system_database, '-e', "ALTER USER '#{merged_name}' REQUIRE #{merged_tls_options}"].compact)
@@ -161,7 +161,8 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
 
   def tls_options=(array)
     merged_name = self.class.cmd_user(@resource[:name])
-    merged_tls_options = array.join(' AND ')
+    merged_tls_options = self.class.merge_tls_options(array)
+
     if ((mysqld_type == 'mysql' || mysqld_type == 'percona') && Puppet::Util::Package.versioncmp(mysqld_version, '5.7.6') >= 0) ||
        (mysqld_type == 'mariadb' && Puppet::Util::Package.versioncmp(mysqld_version, '10.2.0') >= 0)
       mysql([defaults_file, system_database, '-e', "ALTER USER #{merged_name} REQUIRE #{merged_tls_options}"].compact)


### PR DESCRIPTION
1. use tab to separate fields coming from the mysql.user table.
2. wrap tls_options like subject, issuer and cypher with "..."

see https://tickets.puppetlabs.com/browse/MODULES-6018

fixes #1021