### PR TITLE
MODULES-6027 - enable mysql::server::monitor

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -59,6 +59,7 @@ class mysql::server (
   include '::mysql::server::installdb'
   include '::mysql::server::service'
   include '::mysql::server::root_password'
+  include '::mysql::server::monitor'
   include '::mysql::server::providers'
 
   if $remove_default_accounts {
@@ -82,6 +83,7 @@ class mysql::server (
   -> Class['mysql::server::installdb']
   -> Class['mysql::server::service']
   -> Class['mysql::server::root_password']
+  -> Class['mysql::server::monitor']
   -> Class['mysql::server::providers']
   -> Anchor['mysql::server::end']
 

--- a/manifests/server/monitor.pp
+++ b/manifests/server/monitor.pp
@@ -5,8 +5,6 @@ class mysql::server::monitor (
   $mysql_monitor_hostname = ''
 ) {
 
-  Anchor['mysql::server::end'] -> Class['mysql::server::monitor']
-
   mysql_user { "${mysql_monitor_username}@${mysql_monitor_hostname}":
     ensure        => present,
     password_hash => mysql_password($mysql_monitor_password),


### PR DESCRIPTION
This patch resolves the issue of the Monitor Class not doing it's job in a hiera environment. 