### PR TITLE
MODULES-6018 properly parse/escape whitespace in tls_options

### DIFF
--- a/spec/acceptance/types/mysql_user_spec.rb
+++ b/spec/acceptance/types/mysql_user_spec.rb
@@ -211,4 +211,142 @@ describe 'mysql_user' do
       end
     end
   end
+  context 'using example jeffrey@localhost from MySQL 5.7 Reference manual' do
+    describe 'adding user' do
+      ## What it currently emits:
+      #  GRANT USAGE ON *.* TO 'jeffrey'@'localhost'
+      #    REQUIRE X509
+      #    AND SUBJECT /C=SE/ST=Stockholm/L=Stockholm/O=MySQL demo client certificate/CN=client/emailAddress=client@example.com
+      #    AND ISSUER /C=SE/ST=Stockholm/L=Stockholm/O=MySQL/CN=CA/emailAddress=ca@example.com
+      # returned 1: ERROR 1064 (42000) at line 1: You have an error in your SQL syntax;
+      # check the manual that corresponds to your MySQL server version for the right syntax to use near
+      # 'AND SUBJECT /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddre' at line 1
+      #
+      ## What it should emit:
+      #  GRANT USAGE ON *.* TO 'jeffrey'@'localhost'
+      #    REQUIRE SUBJECT '/C=SE/ST=Stockholm/L=Stockholm/O=MySQL demo client certificate/CN=client/emailAddress=client@example.com'
+      #    AND ISSUER '/C=SE/ST=Stockholm/L=Stockholm/O=MySQL/CN=CA/emailAddress=ca@example.com'
+      #
+      pp_six = <<-MANIFEST
+        mysql_user { 'jeffrey@localhost':
+          password_hash => '*F9A8E96790775D196D12F53BCC88B8048FF62ED5',
+          tls_options   => [
+            'X509',
+            'SUBJECT /C=SE/ST=Stockholm/L=Stockholm/O=MySQL demo client certificate/CN=client/emailAddress=client@example.com',
+            'ISSUER /C=SE/ST=Stockholm/L=Stockholm/O=MySQL/CN=CA/emailAddress=ca@example.com',
+          ],
+        }
+      MANIFEST
+      it 'works without errors' do
+        apply_manifest(pp_six, catch_failures: true)
+      end
+
+      it 'finds the user #stdout' do
+        shell("mysql -NBe \"select '1' from mysql.user where CONCAT(user, '@', host) = 'jeffrey@localhost'\"") do |r|
+          expect(r.stdout).to match(%r{^1$})
+        end
+      end
+      it 'finds the user #stderr' do
+        shell("mysql -NBe \"select '1' from mysql.user where CONCAT(user, '@', host) = 'jeffrey@localhost'\"") do |r|
+          expect(r.stderr).to be_empty
+        end
+      end
+      it 'shows correct ssl_type #stdout' do
+        shell("mysql -NBe \"select SSL_TYPE from mysql.user where CONCAT(user, '@', host) = 'jeffrey@localhost'\"") do |r|
+          expect(r.stdout).to match(%r{^SPECIFIED})
+        end
+      end
+      it 'shows correct ssl_type #stderr' do
+        shell("mysql -NBe \"select SSL_TYPE from mysql.user where CONCAT(user, '@', host) = 'jeffrey@localhost'\"") do |r|
+          expect(r.stderr).to be_empty
+        end
+      end
+      it 'shows correct x509_subject #stdout' do
+        shell("mysql -NBe \"select X509_SUBJECT from mysql.user where CONCAT(user, '@', host) = 'jeffrey@localhost'\"") do |r|
+          expect(r.stdout).to match(%r{^/C=SE/ST=Stockholm/L=Stockholm/O=MySQL demo client certificate/CN=client/emailAddress=client@example.com})
+        end
+      end
+      it 'shows correct x509_subject #stderr' do
+        shell("mysql -NBe \"select X509_SUBJECT from mysql.user where CONCAT(user, '@', host) = 'jeffrey@localhost'\"") do |r|
+          expect(r.stderr).to be_empty
+        end
+      end
+      it 'shows correct x509_issuer #stdout' do
+        shell("mysql -NBe \"select X509_ISSUER from mysql.user where CONCAT(user, '@', host) = 'jeffrey@localhost'\"") do |r|
+          expect(r.stdout).to match(%r{^/C=SE/ST=Stockholm/L=Stockholm/O=MySQL/CN=CA/emailAddress=ca@example.com})
+        end
+      end
+      it 'shows correct x509_issuer #stderr' do
+        shell("mysql -NBe \"select X509_ISSUER from mysql.user where CONCAT(user, '@', host) = 'jeffrey@localhost'\"") do |r|
+          expect(r.stderr).to be_empty
+        end
+      end
+    end
+  end
+  context 'using example someone@localhost from MariaDB documentation' do
+    describe 'adding user' do
+      pp_six = <<-MANIFEST
+        mysql_user { 'someone@localhost':
+          tls_options   => [
+            'SUBJECT /CN=www.mydom.com/O=My Dom, Inc./C=US/ST=Oregon/L=Portland',
+            'ISSUER /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com',
+          ],
+        }
+      MANIFEST
+      ## What it currently emits:
+      # GRANT USAGE ON *.* TO 'someone'@'localhost'
+      #   REQUIRE SUBJECT /CN=www.mydom.com/O=My Dom, Inc./C=US/ST=Oregon/L=Portland
+      #   AND ISSUER /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com
+      #
+      ## What it should emit:
+      # GRANT USAGE ON *.* TO 'someone'@'localhost'
+      #   REQUIRE SUBJECT '/CN=www.mydom.com/O=My Dom, Inc./C=US/ST=Oregon/L=Portland'
+      #   AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'
+      #
+      it 'works without errors' do
+        apply_manifest(pp_six, catch_failures: true)
+      end
+
+      it 'finds the user #stdout' do
+        shell("mysql -NBe \"select '1' from mysql.user where CONCAT(user, '@', host) = 'someone@localhost'\"") do |r|
+          expect(r.stdout).to match(%r{^1$})
+        end
+      end
+      it 'finds the user #stderr' do
+        shell("mysql -NBe \"select '1' from mysql.user where CONCAT(user, '@', host) = 'someone@localhost'\"") do |r|
+          expect(r.stderr).to be_empty
+        end
+      end
+      it 'shows correct ssl_type #stdout' do
+        shell("mysql -NBe \"select SSL_TYPE from mysql.user where CONCAT(user, '@', host) = 'someone@localhost'\"") do |r|
+          expect(r.stdout).to match(%r{^SPECIFIED})
+        end
+      end
+      it 'shows correct ssl_type #stderr' do
+        shell("mysql -NBe \"select SSL_TYPE from mysql.user where CONCAT(user, '@', host) = 'someone@localhost'\"") do |r|
+          expect(r.stderr).to be_empty
+        end
+      end
+      it 'shows correct x509_subject #stdout' do
+        shell("mysql -NBe \"select X509_SUBJECT from mysql.user where CONCAT(user, '@', host) = 'someone@localhost'\"") do |r|
+          expect(r.stdout).to match(%r{^/CN=www.mydom.com/O=My Dom, Inc./C=US/ST=Oregon/L=Portland})
+        end
+      end
+      it 'shows correct x509_subject #stderr' do
+        shell("mysql -NBe \"select X509_SUBJECT from mysql.user where CONCAT(user, '@', host) = 'someone@localhost'\"") do |r|
+          expect(r.stderr).to be_empty
+        end
+      end
+      it 'shows correct x509_issuer #stdout' do
+        shell("mysql -NBe \"select X509_ISSUER from mysql.user where CONCAT(user, '@', host) = 'someone@localhost'\"") do |r|
+          expect(r.stdout).to match(%r{^/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com})
+        end
+      end
+      it 'shows correct x509_issuer #stdout' do
+        shell("mysql -NBe \"select X509_ISSUER from mysql.user where CONCAT(user, '@', host) = 'someone@localhost'\"") do |r|
+          expect(r.stderr).to be_empty
+        end
+      end
+    end
+  end
 end

--- a/spec/acceptance/types/mysql_user_spec.rb
+++ b/spec/acceptance/types/mysql_user_spec.rb
@@ -342,7 +342,7 @@ describe 'mysql_user' do
           expect(r.stdout).to match(%r{^/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com})
         end
       end
-      it 'shows correct x509_issuer #stdout' do
+      it 'shows correct x509_issuer #stderr' do
         shell("mysql -NBe \"select X509_ISSUER from mysql.user where CONCAT(user, '@', host) = 'someone@localhost'\"") do |r|
           expect(r.stderr).to be_empty
         end

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -90,14 +90,14 @@ usvn_user@localhost
     Puppet::Util.stubs(:which).with('mysqld').returns('/usr/sbin/mysqld')
     File.stubs(:file?).with('/root/.my.cnf').returns(true)
     provider.class.stubs(:mysql_caller).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns('joe@localhost')
-    provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = 'joe@localhost'", 'regular').returns('10 10 10 10     *6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4') # rubocop:disable Metrics/LineLength
+    provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = 'joe@localhost'", 'regular').returns("10\t10\t10\t10\t\t\t\t\t*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4\n") # rubocop:disable Metrics/LineLength
   end
 
   describe 'self.instances' do
     it 'returns an array of users MySQL 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
       provider.class.stubs(:mysql_caller).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
-      parsed_users.each { |user| provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') } # rubocop:disable Metrics/LineLength
+      parsed_users.each { |user| provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns("10\t10\t10\t10\t\t\t\t\t\n") } # rubocop:disable Metrics/LineLength
 
       usernames = provider.class.instances.map { |x| x.name }
       expect(parsed_users).to match_array(usernames)
@@ -105,7 +105,7 @@ usvn_user@localhost
     it 'returns an array of users MySQL 5.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
       provider.class.stubs(:mysql_caller).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
-      parsed_users.each { |user| provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') } # rubocop:disable Metrics/LineLength
+      parsed_users.each { |user| provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns("10\t10\t10\t10\t\t\t\t\t\n") } # rubocop:disable Metrics/LineLength
 
       usernames = provider.class.instances.map { |x| x.name }
       expect(parsed_users).to match_array(usernames)
@@ -113,7 +113,7 @@ usvn_user@localhost
     it 'returns an array of users MySQL >= 5.7.0 < 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
       provider.class.stubs(:mysql_caller).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
-      parsed_users.each { |user| provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') } # rubocop:disable Metrics/LineLength
+      parsed_users.each { |user| provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns("10\t10\t10\t10\t\t\t\t\t\n") } # rubocop:disable Metrics/LineLength
 
       usernames = provider.class.instances.map { |x| x.name }
       expect(parsed_users).to match_array(usernames)
@@ -121,7 +121,7 @@ usvn_user@localhost
     it 'returns an array of users MySQL >= 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
       provider.class.stubs(:mysql_caller).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
-      parsed_users.each { |user| provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, AUTHENTICATION_STRING, PLUGIN FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') } # rubocop:disable Metrics/LineLength
+      parsed_users.each { |user| provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, AUTHENTICATION_STRING, PLUGIN FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns("10\t10\t10\t10\t\t\t\t\t\n") } # rubocop:disable Metrics/LineLength
 
       usernames = provider.class.instances.map { |x| x.name }
       expect(parsed_users).to match_array(usernames)
@@ -129,7 +129,7 @@ usvn_user@localhost
     it 'returns an array of users mariadb 10.0' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
       provider.class.stubs(:mysql_caller).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
-      parsed_users.each { |user| provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') } # rubocop:disable Metrics/LineLength
+      parsed_users.each { |user| provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns("10\t10\t10\t10\t\t\t\t\t\n") } # rubocop:disable Metrics/LineLength
 
       usernames = provider.class.instances.map { |x| x.name }
       expect(parsed_users).to match_array(usernames)
@@ -137,7 +137,7 @@ usvn_user@localhost
     it 'returns an array of users percona 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['percona-5.5'][:string])
       provider.class.stubs(:mysql_caller).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
-      parsed_users.each { |user| provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') } # rubocop:disable Metrics/LineLength
+      parsed_users.each { |user| provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns("10\t10\t10\t10\t\t\t\t\t\n") } # rubocop:disable Metrics/LineLength
 
       usernames = provider.class.instances.map { |x| x.name }
       expect(parsed_users).to match_array(usernames)
@@ -372,35 +372,35 @@ usvn_user@localhost
       provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
       provider.expects(:tls_options).returns(['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
-      provider.tls_options = ['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+      provider.tls_options = ['ISSUER /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com']
     end
     it 'adds SSL option issuer in mysql 5.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
       provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
       provider.expects(:tls_options).returns(['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
-      provider.tls_options = ['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+      provider.tls_options = ['ISSUER /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com']
     end
     it 'adds SSL option issuer in mysql < 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
       provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
       provider.expects(:tls_options).returns(['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
-      provider.tls_options = ['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+      provider.tls_options = ['ISSUER /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com']
     end
     it 'adds SSL option issuer in mysql >= 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
       provider.class.expects(:mysql_caller).with("ALTER USER 'joe'@'localhost' REQUIRE ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
       provider.expects(:tls_options).returns(['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
-      provider.tls_options = ['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+      provider.tls_options = ['ISSUER /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com']
     end
     it 'adds SSL option issuer in mariadb-10.0' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
       provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
       provider.expects(:tls_options).returns(['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
-      provider.tls_options = ['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+      provider.tls_options = ['ISSUER /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com']
     end
 
     it 'adds SSL option subject in mysql 5.5' do
@@ -408,35 +408,35 @@ usvn_user@localhost
       provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
       provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
-      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+      provider.tls_options = ['SUBJECT /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com']
     end
     it 'adds SSL option subject in mysql 5.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
       provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
       provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
-      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+      provider.tls_options = ['SUBJECT /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com']
     end
     it 'adds SSL option subject in mysql < 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
       provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
       provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
-      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+      provider.tls_options = ['SUBJECT /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com']
     end
     it 'adds SSL option subject in mysql >= 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
       provider.class.expects(:mysql_caller).with("ALTER USER 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
       provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
-      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+      provider.tls_options = ['SUBJECT /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com']
     end
     it 'adds SSL option subject in mariadb-10.0' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
       provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
       provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
-      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+      provider.tls_options = ['SUBJECT /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com']
     end
 
     it 'adds SSL option cipher in mysql 5.5' do
@@ -444,71 +444,165 @@ usvn_user@localhost
       provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
 
       provider.expects(:tls_options).returns(['\'CIPHER SHA-DES-CBC3-EDH-RSA\''])
-      provider.tls_options = ['CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+      provider.tls_options = ['CIPHER SHA-DES-CBC3-EDH-RSA']
     end
     it 'adds SSL option cipher in mysql 5.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
       provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
 
       provider.expects(:tls_options).returns(['CIPHER SHA-DES-CBC3-EDH-RSA'])
-      provider.tls_options = ['CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+      provider.tls_options = ['CIPHER SHA-DES-CBC3-EDH-RSA']
     end
     it 'adds SSL option cipher in mysql < 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
       provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
 
       provider.expects(:tls_options).returns(['CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
-      provider.tls_options = ['CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+      provider.tls_options = ['CIPHER SHA-DES-CBC3-EDH-RSA']
     end
     it 'adds SSL option cipher in mysql >= 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
       provider.class.expects(:mysql_caller).with("ALTER USER 'joe'@'localhost' REQUIRE CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
 
       provider.expects(:tls_options).returns(['CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
-      provider.tls_options = ['CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+      provider.tls_options = ['CIPHER SHA-DES-CBC3-EDH-RSA']
     end
     it 'adds SSL option cipher in mariadb-10.0' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
       provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
 
       provider.expects(:tls_options).returns(['CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
-      provider.tls_options = ['CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+      provider.tls_options = ['CIPHER SHA-DES-CBC3-EDH-RSA']
     end
 
     it 'adds SSL options subject, issuer, cipher in mysql 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
-      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
-      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
-      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']) # rubocop:disable Metrics/LineLength
+      provider.tls_options = [
+        'SUBJECT /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com',
+        'ISSUER /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com',
+        'CIPHER SHA-DES-CBC3-EDH-RSA',
+      ]
     end
     it 'adds SSL options subject, issuer, cipher in mysql 5.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
-      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
-      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
-      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']) # rubocop:disable Metrics/LineLength
+      provider.tls_options = [
+        'SUBJECT /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com',
+        'ISSUER /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com',
+        'CIPHER SHA-DES-CBC3-EDH-RSA',
+      ]
     end
     it 'adds SSL options subject, issuer, cipher in mysql < 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
-      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
-      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
-      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']) # rubocop:disable Metrics/LineLength
+      provider.tls_options = [
+        'SUBJECT /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com',
+        'ISSUER /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com',
+        'CIPHER SHA-DES-CBC3-EDH-RSA',
+      ]
     end
     it 'adds SSL options subject, issuer, cipher in mysql >= 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
-      provider.class.expects(:mysql_caller).with("ALTER USER 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+      provider.class.expects(:mysql_caller).with("ALTER USER 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
-      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
-      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']) # rubocop:disable Metrics/LineLength
+      provider.tls_options = [
+        'SUBJECT /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com',
+        'ISSUER /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com',
+        'CIPHER SHA-DES-CBC3-EDH-RSA',
+      ]
     end
     it 'adds SSL options subject, issuer, cipher in mariadb-10.0' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
-      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
-      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
-      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']) # rubocop:disable Metrics/LineLength
+      provider.tls_options = [
+        'SUBJECT /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com',
+        'ISSUER /C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com',
+        'CIPHER SHA-DES-CBC3-EDH-RSA',
+      ]
+    end
+    it 'does not doublewrap the value part of subject, issuer and cipher' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']) # rubocop:disable Metrics/LineLength
+      provider.tls_options = [
+        'SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'',
+        'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'',
+        'CIPHER \'SHA-DES-CBC3-EDH-RSA\'',
+      ]
+    end
+    it 'ignores ANY keyword if subject is provided' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
+      provider.tls_options = ['ANY', 'SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+    end
+    it 'ignores ANY keyword if issuer is provided' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
+      provider.tls_options = ['ANY', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+    end
+    it 'ignores ANY keyword if a cipher is provided' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+
+      provider.expects(:tls_options).returns(['CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
+      provider.tls_options = ['ANY', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+    end
+    it 'ignores SSL keyword if subject is provided' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
+      provider.tls_options = ['SSL', 'SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+    end
+    it 'ignores SSL keyword if issuer is provided' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
+      provider.tls_options = ['SSL', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+    end
+    it 'ignores SSL keyword if a cipher is provided' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+
+      provider.expects(:tls_options).returns(['CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
+      provider.tls_options = ['SSL', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+    end
+    it 'ignores X509 keyword if subject is provided' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
+      provider.tls_options = ['X509', 'SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+    end
+    it 'ignores X509 keyword if issuer is provided' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
+      provider.tls_options = ['X509', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+    end
+    it 'ignores X509 keyword if a cipher is provided' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+
+      provider.expects(:tls_options).returns(['CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
+      provider.tls_options = ['X509', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
     end
   end
 

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -366,6 +366,150 @@ usvn_user@localhost
       provider.expects(:tls_options).returns(['NONE'])
       provider.tls_options = ['NONE']
     end
+
+    it 'adds SSL option issuer in mysql 5.5' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
+      provider.tls_options = ['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+    end
+    it 'adds SSL option issuer in mysql 5.6' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
+      provider.tls_options = ['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+    end
+    it 'adds SSL option issuer in mysql < 5.7.6' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
+      provider.tls_options = ['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+    end
+    it 'adds SSL option issuer in mysql >= 5.7.6' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
+      provider.class.expects(:mysql_caller).with("ALTER USER 'joe'@'localhost' REQUIRE ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
+      provider.tls_options = ['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+    end
+    it 'adds SSL option issuer in mariadb-10.0' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
+      provider.tls_options = ['ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+    end
+
+    it 'adds SSL option subject in mysql 5.5' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
+      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+    end
+    it 'adds SSL option subject in mysql 5.6' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
+      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+    end
+    it 'adds SSL option subject in mysql < 5.7.6' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
+      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+    end
+    it 'adds SSL option subject in mysql >= 5.7.6' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
+      provider.class.expects(:mysql_caller).with("ALTER USER 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
+      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+    end
+    it 'adds SSL option subject in mariadb-10.0' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\''])
+      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'']
+    end
+
+    it 'adds SSL option cipher in mysql 5.5' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+
+      provider.expects(:tls_options).returns(['\'CIPHER SHA-DES-CBC3-EDH-RSA\''])
+      provider.tls_options = ['CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+    end
+    it 'adds SSL option cipher in mysql 5.6' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+
+      provider.expects(:tls_options).returns(['CIPHER SHA-DES-CBC3-EDH-RSA'])
+      provider.tls_options = ['CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+    end
+    it 'adds SSL option cipher in mysql < 5.7.6' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+
+      provider.expects(:tls_options).returns(['CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
+      provider.tls_options = ['CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+    end
+    it 'adds SSL option cipher in mysql >= 5.7.6' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
+      provider.class.expects(:mysql_caller).with("ALTER USER 'joe'@'localhost' REQUIRE CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+
+      provider.expects(:tls_options).returns(['CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
+      provider.tls_options = ['CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+    end
+    it 'adds SSL option cipher in mariadb-10.0' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+
+      provider.expects(:tls_options).returns(['CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
+      provider.tls_options = ['CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+    end
+
+    it 'adds SSL options subject, issuer, cipher in mysql 5.5' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
+      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+    end
+    it 'adds SSL options subject, issuer, cipher in mysql 5.6' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
+      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+    end
+    it 'adds SSL options subject, issuer, cipher in mysql < 5.7.6' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
+      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+    end
+    it 'adds SSL options subject, issuer, cipher in mysql >= 5.7.6' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
+      provider.class.expects(:mysql_caller).with("ALTER USER 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
+      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+    end
+    it 'adds SSL options subject, issuer, cipher in mariadb-10.0' do
+      provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE SUBJECT '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND ISSUER '/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com' AND CIPHER 'SHA-DES-CBC3-EDH-RSA'", 'system').returns('0')
+
+      provider.expects(:tls_options).returns(['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\''])
+      provider.tls_options = ['SUBJECT \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'ISSUER \'/C=FI/ST=Somewhere/L=City/ O=Some Company/CN=Peter Parker/emailAddress=p.parker@marvel.com\'', 'CIPHER \'SHA-DES-CBC3-EDH-RSA\'']
+    end
   end
 
   ['max_user_connections', 'max_connections_per_hour', 'max_queries_per_hour', 'max_updates_per_hour'].each do |property|


### PR DESCRIPTION
1. ~~use tab to separate fields coming from the mysql.user table.~~ mysql produces tab-separation by default. adapted the system mysql caller to split by tabs and not whitespace.
2. wrap tls_options like subject, issuer and cypher with "..."
3. ~~adapted existing tests to usage of --delimiter=\t~~
4. added missing tests for tls_options issuer, subject and cypher

replaces #1022 

@pmcmaw added some tests for all tls_options. 
rake release_checks now returns 2713 examples, 0 failures