### PR TITLE
#puppethack allow undef value for bind-address

### DIFF
--- a/spec/classes/mysql_server_spec.rb
+++ b/spec/classes/mysql_server_spec.rb
@@ -97,6 +97,21 @@ describe 'mysql::server' do
 
           it { is_expected.to contain_file('/tmp/error.log') }
         end
+        context 'default bind-address' do
+          let(:params) {  }
+
+          it { is_expected.to contain_file('mysql-config-file').with_content(/^bind-address = 127.0.0.1/) }
+        end
+        context 'with defined bind-address' do
+          let(:params) { { override_options: { 'mysqld' => { 'bind-address' => '1.1.1.1' } } } }
+
+          it { is_expected.to contain_file('mysql-config-file').with_content(/^bind-address = 1.1.1.1/) }
+        end
+        context 'without bind-address' do
+          let(:params) { { override_options: { 'mysqld' => { 'bind-address' => :undef } } } }
+
+          it { is_expected.to contain_file('mysql-config-file').without_content(/^bind-address/) }
+        end
       end
 
       context 'mysql::server::root_password' do

--- a/spec/classes/mysql_server_spec.rb
+++ b/spec/classes/mysql_server_spec.rb
@@ -98,19 +98,17 @@ describe 'mysql::server' do
           it { is_expected.to contain_file('/tmp/error.log') }
         end
         context 'default bind-address' do
-          let(:params) {  }
-
-          it { is_expected.to contain_file('mysql-config-file').with_content(/^bind-address = 127.0.0.1/) }
+          it { is_expected.to contain_file('mysql-config-file').with_content(%r{^bind-address = 127.0.0.1}) }
         end
         context 'with defined bind-address' do
           let(:params) { { override_options: { 'mysqld' => { 'bind-address' => '1.1.1.1' } } } }
 
-          it { is_expected.to contain_file('mysql-config-file').with_content(/^bind-address = 1.1.1.1/) }
+          it { is_expected.to contain_file('mysql-config-file').with_content(%r{^bind-address = 1.1.1.1}) }
         end
         context 'without bind-address' do
           let(:params) { { override_options: { 'mysqld' => { 'bind-address' => :undef } } } }
 
-          it { is_expected.to contain_file('mysql-config-file').without_content(/^bind-address/) }
+          it { is_expected.to contain_file('mysql-config-file').without_content(%r{^bind-address}) }
         end
       end
 

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -6,8 +6,6 @@
 <%     v.sort.map do |ki, vi| -%>
 <%       if ki == 'ssl-disable' or (ki =~ /^ssl/ and v['ssl-disable'] == true) -%>
 <%         next %>
-<%       elsif ki == 'bind-address' and vi == :undef -%>
-<%         next %>
 <%       elsif vi == true or vi == '' -%>
 <%=        ki %>
 <%       elsif vi.is_a?(Array) -%>

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -6,6 +6,8 @@
 <%     v.sort.map do |ki, vi| -%>
 <%       if ki == 'ssl-disable' or (ki =~ /^ssl/ and v['ssl-disable'] == true) -%>
 <%         next %>
+<%       elsif ki == 'bind-address' and vi == :undef -%>
+<%         next %>
 <%       elsif vi == true or vi == '' -%>
 <%=        ki %>
 <%       elsif vi.is_a?(Array) -%>


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/MODULES-3168

If set `bind-address` to `undef` the bind-address will not be set in the mysql-config file so MySQL is listening on all interfaces.

```puppet
class { '::mysql::server':
  override_options => {
    mysqld => {
      bind-address => undef,
    },
}
```