### PR TITLE
(MODULES-3623) Centralise MySQL calls...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1324,3 +1324,4 @@ This module is based on work by David Schmitt. The following contributors have c
 * Chris Weyl
 * Daniël van Eeden
 * Jan-Otto Kröpke
+* Timothy Sven Nelson

--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -54,25 +54,18 @@ class Puppet::Provider::Mysql < Puppet::Provider
     self.class.defaults_file
   end
 
-  def self.mysql_caller(textOfSQL, type = 'undefined')
+  def self.mysql_caller(text_of_sql, type)
     if type.eql? 'system'
-      mysql_raw([defaults_file, '--host=', system_database, '-e', textOfSQL].flatten.compact)
+      mysql_raw([defaults_file, '--host=', system_database, '-e', text_of_sql].flatten.compact)
     elsif type.eql? 'regular'
-      mysql_raw([defaults_file, '-NBe', textOfSQL].flatten.compact)
-    elsif type.eql? 'undefined'
-      begin
-        raise Puppet::Error, "#mysql had an error -> did not pass in type parameter"
-      rescue => e
-        puts "Error during processing: #{$!}"
-        puts "Backtrace:\n\t#{e.backtrace.join("\n\t")}"
-      end
+      mysql_raw([defaults_file, '-NBe', text_of_sql].flatten.compact)
     else
-      raise Puppet::Error, "#mysql had an error -> Unrecognised type '#type'"
+      raise Puppet::Error, _("#mysql_caller: Unrecognised type '%{type}'" % { type: type })
     end
   end
 
   def self.users
-    self.mysql_caller("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').split("\n")
+    mysql_caller("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').split("\n")
   end
 
   # Optional parameter to run a statement on the MySQL system database.

--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -7,7 +7,7 @@ class Puppet::Provider::Mysql < Puppet::Provider
   ENV['PATH'] = ENV['PATH'] + ':/usr/libexec:/usr/local/libexec:/usr/local/bin'
 
   # rubocop:disable Style/HashSyntax
-  commands :mysql      => 'mysql'
+  commands :mysql_raw  => 'mysql'
   commands :mysqld     => 'mysqld'
   commands :mysqladmin => 'mysqladmin'
   # rubocop:enable Style/HashSyntax
@@ -54,8 +54,25 @@ class Puppet::Provider::Mysql < Puppet::Provider
     self.class.defaults_file
   end
 
+  def self.mysql_caller(textOfSQL, type = 'undefined')
+    if type.eql? 'system'
+      mysql_raw([defaults_file, '--host=', system_database, '-e', textOfSQL].flatten.compact)
+    elsif type.eql? 'regular'
+      mysql_raw([defaults_file, '-NBe', textOfSQL].flatten.compact)
+    elsif type.eql? 'undefined'
+      begin
+        raise Puppet::Error, "#mysql had an error -> did not pass in type parameter"
+      rescue => e
+        puts "Error during processing: #{$!}"
+        puts "Backtrace:\n\t#{e.backtrace.join("\n\t")}"
+      end
+    else
+      raise Puppet::Error, "#mysql had an error -> Unrecognised type '#type'"
+    end
+  end
+
   def self.users
-    mysql([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"].compact).split("\n")
+    self.mysql_caller("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').split("\n")
   end
 
   # Optional parameter to run a statement on the MySQL system database.

--- a/lib/puppet/provider/mysql_database/mysql.rb
+++ b/lib/puppet/provider/mysql_database/mysql.rb
@@ -2,12 +2,12 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'mysql'))
 Puppet::Type.type(:mysql_database).provide(:mysql, parent: Puppet::Provider::Mysql) do
   desc 'Manages MySQL databases.'
 
-  commands mysql: 'mysql'
+  commands mysql_raw: 'mysql'
 
   def self.instances
-    mysql([defaults_file, '-NBe', 'show databases'].compact).split("\n").map do |name|
+    self.mysql_caller('show databases', 'regular').split("\n").map do |name|
       attributes = {}
-      mysql([defaults_file, '-NBe', "show variables like '%_database'", name].compact).split("\n").each do |line|
+      self.mysql_caller(["show variables like '%_database'", name], 'regular').split("\n").each do |line|
         k, v = line.split(%r{\s})
         attributes[k] = v
       end
@@ -29,7 +29,7 @@ Puppet::Type.type(:mysql_database).provide(:mysql, parent: Puppet::Provider::Mys
   end
 
   def create
-    mysql([defaults_file, '-NBe', "create database if not exists `#{@resource[:name]}` character set `#{@resource[:charset]}` collate `#{@resource[:collate]}`"].compact)
+    self.class.mysql_caller("create database if not exists `#{@resource[:name]}` character set `#{@resource[:charset]}` collate `#{@resource[:collate]}`", 'regular')
 
     @property_hash[:ensure]  = :present
     @property_hash[:charset] = @resource[:charset]
@@ -39,7 +39,7 @@ Puppet::Type.type(:mysql_database).provide(:mysql, parent: Puppet::Provider::Mys
   end
 
   def destroy
-    mysql([defaults_file, '-NBe', "drop database if exists `#{@resource[:name]}`"].compact)
+    self.class.mysql_caller("drop database if exists `#{@resource[:name]}`", 'regular')
 
     @property_hash.clear
     exists? ? (return false) : (return true)
@@ -52,13 +52,13 @@ Puppet::Type.type(:mysql_database).provide(:mysql, parent: Puppet::Provider::Mys
   mk_resource_methods
 
   def charset=(value)
-    mysql([defaults_file, '-NBe', "alter database `#{resource[:name]}` CHARACTER SET #{value}"].compact)
+    self.class.mysql_caller("alter database `#{resource[:name]}` CHARACTER SET #{value}", 'regular')
     @property_hash[:charset] = value
     (charset == value) ? (return true) : (return false)
   end
 
   def collate=(value)
-    mysql([defaults_file, '-NBe', "alter database `#{resource[:name]}` COLLATE #{value}"].compact)
+    self.class.mysql_caller("alter database `#{resource[:name]}` COLLATE #{value}", 'regular')
     @property_hash[:collate] = value
     (collate == value) ? (return true) : (return false)
   end

--- a/lib/puppet/provider/mysql_database/mysql.rb
+++ b/lib/puppet/provider/mysql_database/mysql.rb
@@ -5,9 +5,9 @@ Puppet::Type.type(:mysql_database).provide(:mysql, parent: Puppet::Provider::Mys
   commands mysql_raw: 'mysql'
 
   def self.instances
-    self.mysql_caller('show databases', 'regular').split("\n").map do |name|
+    mysql_caller('show databases', 'regular').split("\n").map do |name|
       attributes = {}
-      self.mysql_caller(["show variables like '%_database'", name], 'regular').split("\n").each do |line|
+      mysql_caller(["show variables like '%_database'", name], 'regular').split("\n").each do |line|
         k, v = line.split(%r{\s})
         attributes[k] = v
       end

--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, parent: Puppet::Provider::Mysql)
       user_string = cmd_user(user)
       query = "SHOW GRANTS FOR #{user_string};"
       begin
-        grants = self.mysql_caller(query, 'regular')
+        grants = mysql_caller(query, 'regular')
       rescue Puppet::ExecutionFailure => e
         # Silently ignore users with no grants. Can happen e.g. if user is
         # defined with fqdn and server is run with skip-name-resolve. Example:

--- a/lib/puppet/provider/mysql_plugin/mysql.rb
+++ b/lib/puppet/provider/mysql_plugin/mysql.rb
@@ -2,10 +2,10 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'mysql'))
 Puppet::Type.type(:mysql_plugin).provide(:mysql, parent: Puppet::Provider::Mysql) do
   desc 'Manages MySQL plugins.'
 
-  commands mysql: 'mysql'
+  commands mysql_raw: 'mysql'
 
   def self.instances
-    mysql([defaults_file, '-NBe', 'show plugins'].compact).split("\n").map do |line|
+    self.mysql_caller('show plugins', 'regular').split("\n").map do |line|
       name, _status, _type, library, _license = line.split(%r{\t})
       new(name: name,
           ensure: :present,
@@ -28,7 +28,7 @@ Puppet::Type.type(:mysql_plugin).provide(:mysql, parent: Puppet::Provider::Mysql
     # Use plugin_name.so as soname if it's not specified. This won't work on windows as
     # there it should be plugin_name.dll
     @resource[:soname].nil? ? (soname = @resource[:name] + '.so') : (soname = @resource[:soname])
-    mysql([defaults_file, '-NBe', "install plugin #{@resource[:name]} soname '#{soname}'"].compact)
+    self.class.mysql_caller("install plugin #{@resource[:name]} soname '#{soname}'", 'regular')
 
     @property_hash[:ensure] = :present
     @property_hash[:soname] = @resource[:soname]
@@ -37,7 +37,7 @@ Puppet::Type.type(:mysql_plugin).provide(:mysql, parent: Puppet::Provider::Mysql
   end
 
   def destroy
-    mysql([defaults_file, '-NBe', "uninstall plugin #{@resource[:name]}"].compact)
+    self.class.mysql_caller("uninstall plugin #{@resource[:name]}", 'regular')
 
     @property_hash.clear
     exists? ? (return false) : (return true)

--- a/lib/puppet/provider/mysql_plugin/mysql.rb
+++ b/lib/puppet/provider/mysql_plugin/mysql.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:mysql_plugin).provide(:mysql, parent: Puppet::Provider::Mysql
   commands mysql_raw: 'mysql'
 
   def self.instances
-    self.mysql_caller('show plugins', 'regular').split("\n").map do |line|
+    mysql_caller('show plugins', 'regular').split("\n").map do |line|
       name, _status, _type, library, _license = line.split(%r{\t})
       new(name: name,
           ensure: :present,

--- a/lib/puppet/provider/mysql_user/mysql.rb
+++ b/lib/puppet/provider/mysql_user/mysql.rb
@@ -1,13 +1,12 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'mysql'))
 Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) do
   desc 'manage users for a mysql database.'
-  commands mysql: 'mysql'
+  commands mysql_raw: 'mysql'
 
   # Build a property_hash containing all the discovered information about MySQL
   # users.
   def self.instances
-    users = mysql([defaults_file, '-NBe',
-                   "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"].compact).split("\n")
+    users = self.mysql_caller("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').split("\n")
     # To reduce the number of calls to MySQL we collect all the properties in
     # one big swoop.
     users.map do |name|
@@ -22,7 +21,7 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
       end
       @max_user_connections, @max_connections_per_hour, @max_queries_per_hour,
       @max_updates_per_hour, ssl_type, ssl_cipher, x509_issuer, x509_subject,
-      @password, @plugin = mysql([defaults_file, '-NBe', query].compact).split(%r{\s})
+      @password, @plugin = self.mysql_caller(query, 'regular').split(%r{\s})
       @tls_options = parse_tls_options(ssl_type, ssl_cipher, x509_issuer, x509_subject)
       # rubocop:enable Metrics/LineLength
       new(name: name,
@@ -64,19 +63,19 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
     # This is also required if you want to specify a authentication plugin
     if !plugin.nil?
       if plugin == 'sha256_password' && !password_hash.nil?
-        mysql([defaults_file, system_database, '-e', "CREATE USER '#{merged_name}' IDENTIFIED WITH '#{plugin}' AS '#{password_hash}'"].compact)
+        self.class.mysql_caller("CREATE USER '#{merged_name}' IDENTIFIED WITH '#{plugin}' AS '#{password_hash}'", 'system')
       else
-        mysql([defaults_file, system_database, '-e', "CREATE USER '#{merged_name}' IDENTIFIED WITH '#{plugin}'"].compact)
+        self.class.mysql_caller("CREATE USER '#{merged_name}' IDENTIFIED WITH '#{plugin}'", 'system')
       end
       @property_hash[:ensure] = :present
       @property_hash[:plugin] = plugin
     else
-      mysql([defaults_file, system_database, '-e', "CREATE USER '#{merged_name}' IDENTIFIED BY PASSWORD '#{password_hash}'"].compact)
+      self.class.mysql_caller("CREATE USER '#{merged_name}' IDENTIFIED BY PASSWORD '#{password_hash}'", 'system')
       @property_hash[:ensure] = :present
       @property_hash[:password_hash] = password_hash
     end
     # rubocop:disable Metrics/LineLength
-    mysql([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO '#{merged_name}' WITH MAX_USER_CONNECTIONS #{max_user_connections} MAX_CONNECTIONS_PER_HOUR #{max_connections_per_hour} MAX_QUERIES_PER_HOUR #{max_queries_per_hour} MAX_UPDATES_PER_HOUR #{max_updates_per_hour}"].compact)
+    self.class.mysql_caller("GRANT USAGE ON *.* TO '#{merged_name}' WITH MAX_USER_CONNECTIONS #{max_user_connections} MAX_CONNECTIONS_PER_HOUR #{max_connections_per_hour} MAX_QUERIES_PER_HOUR #{max_queries_per_hour} MAX_UPDATES_PER_HOUR #{max_updates_per_hour}", 'system')
     # rubocop:enable Metrics/LineLength
     @property_hash[:max_user_connections] = max_user_connections
     @property_hash[:max_connections_per_hour] = max_connections_per_hour
@@ -86,9 +85,9 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
     merged_tls_options = tls_options.join(' AND ')
     if ((mysqld_type == 'mysql' || mysqld_type == 'percona') && Puppet::Util::Package.versioncmp(mysqld_version, '5.7.6') >= 0) ||
        (mysqld_type == 'mariadb' && Puppet::Util::Package.versioncmp(mysqld_version, '10.2.0') >= 0)
-      mysql([defaults_file, system_database, '-e', "ALTER USER '#{merged_name}' REQUIRE #{merged_tls_options}"].compact)
+      self.class.mysql_caller("ALTER USER '#{merged_name}' REQUIRE #{merged_tls_options}", 'system')
     else
-      mysql([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO '#{merged_name}' REQUIRE #{merged_tls_options}"].compact)
+      self.class.mysql_caller("GRANT USAGE ON *.* TO '#{merged_name}' REQUIRE #{merged_tls_options}", 'system')
     end
     @property_hash[:tls_options] = tls_options
 
@@ -97,7 +96,7 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
 
   def destroy
     merged_name = @resource[:name].sub('@', "'@'")
-    mysql([defaults_file, system_database, '-e', "DROP USER '#{merged_name}'"].compact)
+    self.class.mysql_caller("DROP USER '#{merged_name}'", 'system')
 
     @property_hash.clear
     exists? ? (return false) : (return true)
@@ -120,12 +119,12 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
     # We have a fact for the mysql version ...
     if mysqld_version.nil?
       # default ... if mysqld_version does not work
-      mysql([defaults_file, system_database, '-e', "SET PASSWORD FOR #{merged_name} = '#{string}'"].compact)
+      self.class.mysql_caller("SET PASSWORD FOR #{merged_name} = '#{string}'", 'system')
     elsif (mysqld_type == 'mysql' || mysqld_type == 'percona') && Puppet::Util::Package.versioncmp(mysqld_version, '5.7.6') >= 0
       raise ArgumentError, _('Only mysql_native_password (*ABCD...XXX) hashes are supported.') unless string =~ %r{^\*}
-      mysql([defaults_file, system_database, '-e', "ALTER USER #{merged_name} IDENTIFIED WITH mysql_native_password AS '#{string}'"].compact)
+      self.class.mysql_caller("ALTER USER #{merged_name} IDENTIFIED WITH mysql_native_password AS '#{string}'", 'system')
     else
-      mysql([defaults_file, system_database, '-e', "SET PASSWORD FOR #{merged_name} = '#{string}'"].compact)
+      self.class.mysql_caller("SET PASSWORD FOR #{merged_name} = '#{string}'", 'system')
     end
 
     (password_hash == string) ? (return true) : (return false)
@@ -133,28 +132,28 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
 
   def max_user_connections=(int)
     merged_name = self.class.cmd_user(@resource[:name])
-    mysql([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO #{merged_name} WITH MAX_USER_CONNECTIONS #{int}"].compact).chomp
+    self.class.mysql_caller("GRANT USAGE ON *.* TO #{merged_name} WITH MAX_USER_CONNECTIONS #{int}", 'system').chomp
 
     (max_user_connections == int) ? (return true) : (return false)
   end
 
   def max_connections_per_hour=(int)
     merged_name = self.class.cmd_user(@resource[:name])
-    mysql([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO #{merged_name} WITH MAX_CONNECTIONS_PER_HOUR #{int}"].compact).chomp
+    self.class.mysql_caller("GRANT USAGE ON *.* TO #{merged_name} WITH MAX_CONNECTIONS_PER_HOUR #{int}", 'system').chomp
 
     (max_connections_per_hour == int) ? (return true) : (return false)
   end
 
   def max_queries_per_hour=(int)
     merged_name = self.class.cmd_user(@resource[:name])
-    mysql([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO #{merged_name} WITH MAX_QUERIES_PER_HOUR #{int}"].compact).chomp
+    self.class.mysql_caller("GRANT USAGE ON *.* TO #{merged_name} WITH MAX_QUERIES_PER_HOUR #{int}", 'system').chomp
 
     (max_queries_per_hour == int) ? (return true) : (return false)
   end
 
   def max_updates_per_hour=(int)
     merged_name = self.class.cmd_user(@resource[:name])
-    mysql([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO #{merged_name} WITH MAX_UPDATES_PER_HOUR #{int}"].compact).chomp
+    self.class.mysql_caller("GRANT USAGE ON *.* TO #{merged_name} WITH MAX_UPDATES_PER_HOUR #{int}", 'system').chomp
 
     (max_updates_per_hour == int) ? (return true) : (return false)
   end
@@ -164,9 +163,9 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
     merged_tls_options = array.join(' AND ')
     if ((mysqld_type == 'mysql' || mysqld_type == 'percona') && Puppet::Util::Package.versioncmp(mysqld_version, '5.7.6') >= 0) ||
        (mysqld_type == 'mariadb' && Puppet::Util::Package.versioncmp(mysqld_version, '10.2.0') >= 0)
-      mysql([defaults_file, system_database, '-e', "ALTER USER #{merged_name} REQUIRE #{merged_tls_options}"].compact)
+      self.class.mysql_caller("ALTER USER #{merged_name} REQUIRE #{merged_tls_options}", 'system')
     else
-      mysql([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO #{merged_name} REQUIRE #{merged_tls_options}"].compact)
+      self.class.mysql_caller("GRANT USAGE ON *.* TO #{merged_name} REQUIRE #{merged_tls_options}", 'system')
     end
 
     (tls_options == array) ? (return true) : (return false)

--- a/lib/puppet/provider/mysql_user/mysql.rb
+++ b/lib/puppet/provider/mysql_user/mysql.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
   # Build a property_hash containing all the discovered information about MySQL
   # users.
   def self.instances
-    users = self.mysql_caller("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').split("\n")
+    users = mysql_caller("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').split("\n")
     # To reduce the number of calls to MySQL we collect all the properties in
     # one big swoop.
     users.map do |name|
@@ -21,7 +21,7 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
       end
       @max_user_connections, @max_connections_per_hour, @max_queries_per_hour,
       @max_updates_per_hour, ssl_type, ssl_cipher, x509_issuer, x509_subject,
-      @password, @plugin = self.mysql_caller(query, 'regular').split(%r{\s})
+      @password, @plugin = mysql_caller(query, 'regular').split(%r{\s})
       @tls_options = parse_tls_options(ssl_type, ssl_cipher, x509_issuer, x509_subject)
       # rubocop:enable Metrics/LineLength
       new(name: name,

--- a/spec/acceptance/types/mysql_grant_spec.rb
+++ b/spec/acceptance/types/mysql_grant_spec.rb
@@ -617,7 +617,7 @@ describe 'mysql_grant' do
 
       mysql_cmd = shell('which mysql').stdout.chomp
       shell("mv #{mysql_cmd} #{mysql_cmd}.bak")
-      expect(apply_manifest(pp, expect_failures: true).stderr).to match(%r{Command mysql is missing})
+      expect(apply_manifest(pp, expect_failures: true).stderr).to match(%r{Could not find a suitable provider for mysql_grant})
       shell("mv #{mysql_cmd}.bak #{mysql_cmd}")
     end
 

--- a/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
@@ -30,17 +30,17 @@ test
     Facter.stubs(:value).with(:root_home).returns('/root')
     Puppet::Util.stubs(:which).with('mysql').returns('/usr/bin/mysql')
     File.stubs(:file?).with('/root/.my.cnf').returns(true)
-    provider.class.stubs(:mysql).with('show databases', 'regular').returns('new_database')
-    provider.class.stubs(:mysql).with(["show variables like '%_database'", 'new_database'], 'regular').returns("character_set_database latin1\ncollation_database latin1_swedish_ci\nskip_show_database OFF") # rubocop:disable Metrics/LineLength
+    provider.class.stubs(:mysql_caller).with('show databases', 'regular').returns('new_database')
+    provider.class.stubs(:mysql_caller).with(["show variables like '%_database'", 'new_database'], 'regular').returns("character_set_database latin1\ncollation_database latin1_swedish_ci\nskip_show_database OFF") # rubocop:disable Metrics/LineLength
   end
 
   let(:instance) { provider.class.instances.first }
 
   describe 'self.instances' do
     it 'returns an array of databases' do
-      provider.class.stubs(:mysql).with('show databases', 'regular').returns(raw_databases)
+      provider.class.stubs(:mysql_caller).with('show databases', 'regular').returns(raw_databases)
       raw_databases.each_line do |db|
-        provider.class.stubs(:mysql).with(["show variables like '%_database'", db.chomp], 'regular').returns("character_set_database latin1\ncollation_database  latin1_swedish_ci\nskip_show_database  OFF") # rubocop:disable Metrics/LineLength
+        provider.class.stubs(:mysql_caller).with(["show variables like '%_database'", db.chomp], 'regular').returns("character_set_database latin1\ncollation_database  latin1_swedish_ci\nskip_show_database  OFF") # rubocop:disable Metrics/LineLength
       end
       databases = provider.class.instances.map { |x| x.name }
       expect(parsed_databases).to match_array(databases)
@@ -56,7 +56,7 @@ test
 
   describe 'create' do
     it 'makes a database' do
-      provider.expects(:mysql).with("create database if not exists `#{resource[:name]}` character set `#{resource[:charset]}` collate `#{resource[:collate]}`", 'regular')
+      provider.class.expects(:mysql_caller).with("create database if not exists `#{resource[:name]}` character set `#{resource[:charset]}` collate `#{resource[:collate]}`", 'regular')
       provider.expects(:exists?).returns(true)
       expect(provider.create).to be_truthy
     end
@@ -64,7 +64,7 @@ test
 
   describe 'destroy' do
     it 'removes a database if present' do
-      provider.expects(:mysql).with("drop database if exists `#{resource[:name]}`", 'regular')
+      provider.class.expects(:mysql_caller).with("drop database if exists `#{resource[:name]}`", 'regular')
       provider.expects(:exists?).returns(false)
       expect(provider.destroy).to be_truthy
     end
@@ -95,7 +95,7 @@ test
 
   describe 'charset=' do
     it 'changes the charset' do
-      provider.expects(:mysql).with("alter database `#{resource[:name]}` CHARACTER SET blah", 'regular').returns('0')
+      provider.class.expects(:mysql_caller).with("alter database `#{resource[:name]}` CHARACTER SET blah", 'regular').returns('0')
 
       provider.charset = 'blah'
     end
@@ -109,7 +109,7 @@ test
 
   describe 'collate=' do
     it 'changes the collate' do
-      provider.expects(:mysql).with("alter database `#{resource[:name]}` COLLATE blah", 'regular').returns('0')
+      provider.class.expects(:mysql_caller).with("alter database `#{resource[:name]}` COLLATE blah", 'regular').returns('0')
 
       provider.collate = 'blah'
     end

--- a/spec/unit/puppet/provider/mysql_plugin/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_plugin/mysql_spec.rb
@@ -17,7 +17,7 @@ describe Puppet::Type.type(:mysql_plugin).provider(:mysql) do
     Facter.stubs(:value).with(:root_home).returns('/root')
     Puppet::Util.stubs(:which).with('mysql').returns('/usr/bin/mysql')
     File.stubs(:file?).with('/root/.my.cnf').returns(true)
-    provider.class.stubs(:mysql).with([defaults_file, '-NBe', 'show plugins']).returns('auth_socket	ACTIVE	AUTHENTICATION	auth_socket.so	GPL')
+    provider.class.stubs(:mysql).with('show plugins', 'regular').returns('auth_socket	ACTIVE	AUTHENTICATION	auth_socket.so	GPL')
   end
 
   let(:instance) { provider.class.instances.first }
@@ -31,7 +31,7 @@ describe Puppet::Type.type(:mysql_plugin).provider(:mysql) do
 
   describe 'create' do
     it 'loads a plugin' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "install plugin #{resource[:name]} soname '#{resource[:soname]}'"])
+      provider.expects(:mysql).with("install plugin #{resource[:name]} soname '#{resource[:soname]}'", 'regular')
       provider.expects(:exists?).returns(true)
       expect(provider.create).to be_truthy
     end
@@ -39,7 +39,7 @@ describe Puppet::Type.type(:mysql_plugin).provider(:mysql) do
 
   describe 'destroy' do
     it 'unloads a plugin if present' do
-      provider.expects(:mysql).with([defaults_file, '-NBe', "uninstall plugin #{resource[:name]}"])
+      provider.expects(:mysql).with("uninstall plugin #{resource[:name]}", 'regular')
       provider.expects(:exists?).returns(false)
       expect(provider.destroy).to be_truthy
     end

--- a/spec/unit/puppet/provider/mysql_plugin/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_plugin/mysql_spec.rb
@@ -17,7 +17,7 @@ describe Puppet::Type.type(:mysql_plugin).provider(:mysql) do
     Facter.stubs(:value).with(:root_home).returns('/root')
     Puppet::Util.stubs(:which).with('mysql').returns('/usr/bin/mysql')
     File.stubs(:file?).with('/root/.my.cnf').returns(true)
-    provider.class.stubs(:mysql).with('show plugins', 'regular').returns('auth_socket	ACTIVE	AUTHENTICATION	auth_socket.so	GPL')
+    provider.class.stubs(:mysql_caller).with('show plugins', 'regular').returns('auth_socket	ACTIVE	AUTHENTICATION	auth_socket.so	GPL')
   end
 
   let(:instance) { provider.class.instances.first }
@@ -31,7 +31,7 @@ describe Puppet::Type.type(:mysql_plugin).provider(:mysql) do
 
   describe 'create' do
     it 'loads a plugin' do
-      provider.expects(:mysql).with("install plugin #{resource[:name]} soname '#{resource[:soname]}'", 'regular')
+      provider.class.expects(:mysql_caller).with("install plugin #{resource[:name]} soname '#{resource[:soname]}'", 'regular')
       provider.expects(:exists?).returns(true)
       expect(provider.create).to be_truthy
     end
@@ -39,7 +39,7 @@ describe Puppet::Type.type(:mysql_plugin).provider(:mysql) do
 
   describe 'destroy' do
     it 'unloads a plugin if present' do
-      provider.expects(:mysql).with("uninstall plugin #{resource[:name]}", 'regular')
+      provider.class.expects(:mysql_caller).with("uninstall plugin #{resource[:name]}", 'regular')
       provider.expects(:exists?).returns(false)
       expect(provider.destroy).to be_truthy
     end

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -87,8 +87,8 @@ usvn_user@localhost
     Puppet::Util.stubs(:which).with('mysql').returns('/usr/bin/mysql')
     Puppet::Util.stubs(:which).with('mysqld').returns('/usr/sbin/mysqld')
     File.stubs(:file?).with('/root/.my.cnf').returns(true)
-    provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns('joe@localhost')
-    provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = 'joe@localhost'", 'regular').returns('10 10 10 10     *6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4') # rubocop:disable Metrics/LineLength
+    provider.class.stubs(:mysql_caller).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns('joe@localhost')
+    provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = 'joe@localhost'", 'regular').returns('10 10 10 10     *6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4') # rubocop:disable Metrics/LineLength
   end
 
   let(:instance) { provider.class.instances.first }
@@ -96,9 +96,9 @@ usvn_user@localhost
   describe 'self.instances' do
     it 'returns an array of users MySQL 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
-      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
+      provider.class.stubs(:mysql_caller).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
+        provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
       end
 
       usernames = provider.class.instances.map { |x| x.name }
@@ -106,9 +106,9 @@ usvn_user@localhost
     end
     it 'returns an array of users MySQL 5.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
-      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
+      provider.class.stubs(:mysql_caller).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
+        provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
       end
 
       usernames = provider.class.instances.map { |x| x.name }
@@ -116,9 +116,9 @@ usvn_user@localhost
     end
     it 'returns an array of users MySQL >= 5.7.0 < 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
-      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
+      provider.class.stubs(:mysql_caller).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
+        provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
       end
 
       usernames = provider.class.instances.map { |x| x.name }
@@ -126,9 +126,9 @@ usvn_user@localhost
     end
     it 'returns an array of users MySQL >= 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
-      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
+      provider.class.stubs(:mysql_caller).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, AUTHENTICATION_STRING, PLUGIN FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
+        provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, AUTHENTICATION_STRING, PLUGIN FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
       end
 
       usernames = provider.class.instances.map { |x| x.name }
@@ -136,9 +136,9 @@ usvn_user@localhost
     end
     it 'returns an array of users mariadb 10.0' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
-      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
+      provider.class.stubs(:mysql_caller).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
+        provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
       end
 
       usernames = provider.class.instances.map { |x| x.name }
@@ -146,9 +146,9 @@ usvn_user@localhost
     end
     it 'returns an array of users percona 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['percona-5.5'][:string])
-      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
+      provider.class.stubs(:mysql_caller).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
+        provider.class.stubs(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
       end
 
       usernames = provider.class.instances.map { |x| x.name }
@@ -178,9 +178,9 @@ usvn_user@localhost
 
   describe 'create' do
     it 'makes a user' do
-      provider.expects(:mysql).with("CREATE USER 'joe'@'localhost' IDENTIFIED BY PASSWORD '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4'", 'system')
-      provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' WITH MAX_USER_CONNECTIONS 10 MAX_CONNECTIONS_PER_HOUR 10 MAX_QUERIES_PER_HOUR 10 MAX_UPDATES_PER_HOUR 10", 'system') # rubocop:disable Metrics/LineLength
-      provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system')
+      provider.class.expects(:mysql_caller).with("CREATE USER 'joe'@'localhost' IDENTIFIED BY PASSWORD '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4'", 'system')
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' WITH MAX_USER_CONNECTIONS 10 MAX_CONNECTIONS_PER_HOUR 10 MAX_QUERIES_PER_HOUR 10 MAX_UPDATES_PER_HOUR 10", 'system') # rubocop:disable Metrics/LineLength
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system')
       provider.expects(:exists?).returns(true)
       expect(provider.create).to be_truthy
     end
@@ -188,7 +188,7 @@ usvn_user@localhost
 
   describe 'destroy' do
     it 'removes a user if present' do
-      provider.expects(:mysql).with("DROP USER 'joe'@'localhost'", 'system')
+      provider.class.expects(:mysql_caller).with("DROP USER 'joe'@'localhost'", 'system')
       provider.expects(:exists?).returns(false)
       expect(provider.destroy).to be_truthy
     end
@@ -244,42 +244,42 @@ usvn_user@localhost
   describe 'password_hash=' do
     it 'changes the hash mysql 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
-      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
+      provider.class.expects(:mysql_caller).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'
     end
     it 'changes the hash mysql 5.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
-      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
+      provider.class.expects(:mysql_caller).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'
     end
     it 'changes the hash mysql < 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
-      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
+      provider.class.expects(:mysql_caller).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'
     end
     it 'changes the hash MySQL >= 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
-      provider.expects(:mysql).with("ALTER USER 'joe'@'localhost' IDENTIFIED WITH mysql_native_password AS '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0') # rubocop:disable Metrics/LineLength
+      provider.class.expects(:mysql_caller).with("ALTER USER 'joe'@'localhost' IDENTIFIED WITH mysql_native_password AS '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'
     end
     it 'changes the hash mariadb-10.0' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
-      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
+      provider.class.expects(:mysql_caller).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'
     end
     it 'changes the hash percona-5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['percona-5.5'][:string])
-      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
+      provider.class.expects(:mysql_caller).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'
@@ -289,35 +289,35 @@ usvn_user@localhost
   describe 'tls_options=' do
     it 'adds SSL option grant in mysql 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
-      provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system').returns('0')
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system').returns('0')
 
       provider.expects(:tls_options).returns(['NONE'])
       provider.tls_options = ['NONE']
     end
     it 'adds SSL option grant in mysql 5.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
-      provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system').returns('0')
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system').returns('0')
 
       provider.expects(:tls_options).returns(['NONE'])
       provider.tls_options = ['NONE']
     end
     it 'adds SSL option grant in mysql < 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
-      provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system').returns('0')
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system').returns('0')
 
       provider.expects(:tls_options).returns(['NONE'])
       provider.tls_options = ['NONE']
     end
     it 'adds SSL option grant in mysql >= 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
-      provider.expects(:mysql).with("ALTER USER 'joe'@'localhost' REQUIRE NONE", 'system').returns('0')
+      provider.class.expects(:mysql_caller).with("ALTER USER 'joe'@'localhost' REQUIRE NONE", 'system').returns('0')
 
       provider.expects(:tls_options).returns(['NONE'])
       provider.tls_options = ['NONE']
     end
     it 'adds SSL option grant in mariadb-10.0' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
-      provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system').returns('0')
+      provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system').returns('0')
 
       provider.expects(:tls_options).returns(['NONE'])
       provider.tls_options = ['NONE']
@@ -335,7 +335,7 @@ usvn_user@localhost
 
     describe "#{property}=" do
       it "changes #{property}" do
-        provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' WITH #{property.upcase} 42", 'system').returns('0')
+        provider.class.expects(:mysql_caller).with("GRANT USAGE ON *.* TO 'joe'@'localhost' WITH #{property.upcase} 42", 'system').returns('0')
         provider.expects(property.to_sym).returns('42')
         provider.send("#{property}=".to_sym, '42')
       end

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -87,8 +87,8 @@ usvn_user@localhost
     Puppet::Util.stubs(:which).with('mysql').returns('/usr/bin/mysql')
     Puppet::Util.stubs(:which).with('mysqld').returns('/usr/sbin/mysqld')
     File.stubs(:file?).with('/root/.my.cnf').returns(true)
-    provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns('joe@localhost')
-    provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = 'joe@localhost'"]).returns('10 10 10 10     *6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4') # rubocop:disable Metrics/LineLength
+    provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns('joe@localhost')
+    provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = 'joe@localhost'", 'regular').returns('10 10 10 10     *6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4') # rubocop:disable Metrics/LineLength
   end
 
   let(:instance) { provider.class.instances.first }
@@ -96,9 +96,9 @@ usvn_user@localhost
   describe 'self.instances' do
     it 'returns an array of users MySQL 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
       end
 
       usernames = provider.class.instances.map { |x| x.name }
@@ -106,9 +106,9 @@ usvn_user@localhost
     end
     it 'returns an array of users MySQL 5.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
       end
 
       usernames = provider.class.instances.map { |x| x.name }
@@ -116,9 +116,9 @@ usvn_user@localhost
     end
     it 'returns an array of users MySQL >= 5.7.0 < 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
       end
 
       usernames = provider.class.instances.map { |x| x.name }
@@ -126,9 +126,9 @@ usvn_user@localhost
     end
     it 'returns an array of users MySQL >= 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, AUTHENTICATION_STRING, PLUGIN FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, AUTHENTICATION_STRING, PLUGIN FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
       end
 
       usernames = provider.class.instances.map { |x| x.name }
@@ -136,9 +136,9 @@ usvn_user@localhost
     end
     it 'returns an array of users mariadb 10.0' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
       end
 
       usernames = provider.class.instances.map { |x| x.name }
@@ -146,9 +146,9 @@ usvn_user@localhost
     end
     it 'returns an array of users percona 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['percona-5.5'][:string])
-      provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT CONCAT(User, '@',Host) AS User FROM mysql.user"]).returns(raw_users)
+      provider.class.stubs(:mysql).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user", 'regular').returns(raw_users)
       parsed_users.each do |user|
-        provider.class.stubs(:mysql).with([defaults_file, '-NBe', "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'"]).returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
+        provider.class.stubs(:mysql).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{user}'", 'regular').returns('10 10 10 10     ') # rubocop:disable Metrics/LineLength
       end
 
       usernames = provider.class.instances.map { |x| x.name }
@@ -178,9 +178,9 @@ usvn_user@localhost
 
   describe 'create' do
     it 'makes a user' do
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "CREATE USER 'joe'@'localhost' IDENTIFIED BY PASSWORD '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4'"])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' WITH MAX_USER_CONNECTIONS 10 MAX_CONNECTIONS_PER_HOUR 10 MAX_QUERIES_PER_HOUR 10 MAX_UPDATES_PER_HOUR 10"]) # rubocop:disable Metrics/LineLength
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE"])
+      provider.expects(:mysql).with("CREATE USER 'joe'@'localhost' IDENTIFIED BY PASSWORD '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4'", 'system')
+      provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' WITH MAX_USER_CONNECTIONS 10 MAX_CONNECTIONS_PER_HOUR 10 MAX_QUERIES_PER_HOUR 10 MAX_UPDATES_PER_HOUR 10", 'system') # rubocop:disable Metrics/LineLength
+      provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system')
       provider.expects(:exists?).returns(true)
       expect(provider.create).to be_truthy
     end
@@ -188,7 +188,7 @@ usvn_user@localhost
 
   describe 'destroy' do
     it 'removes a user if present' do
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "DROP USER 'joe'@'localhost'"])
+      provider.expects(:mysql).with("DROP USER 'joe'@'localhost'", 'system')
       provider.expects(:exists?).returns(false)
       expect(provider.destroy).to be_truthy
     end
@@ -244,42 +244,42 @@ usvn_user@localhost
   describe 'password_hash=' do
     it 'changes the hash mysql 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'
     end
     it 'changes the hash mysql 5.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'
     end
     it 'changes the hash mysql < 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'
     end
     it 'changes the hash MySQL >= 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "ALTER USER 'joe'@'localhost' IDENTIFIED WITH mysql_native_password AS '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0') # rubocop:disable Metrics/LineLength
+      provider.expects(:mysql).with("ALTER USER 'joe'@'localhost' IDENTIFIED WITH mysql_native_password AS '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0') # rubocop:disable Metrics/LineLength
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'
     end
     it 'changes the hash mariadb-10.0' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'
     end
     it 'changes the hash percona-5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['percona-5.5'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'"]).returns('0')
+      provider.expects(:mysql).with("SET PASSWORD FOR 'joe'@'localhost' = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'", 'system').returns('0')
 
       provider.expects(:password_hash).returns('*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5')
       provider.password_hash = '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5'
@@ -289,35 +289,35 @@ usvn_user@localhost
   describe 'tls_options=' do
     it 'adds SSL option grant in mysql 5.5' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.5'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE"]).returns('0')
+      provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system').returns('0')
 
       provider.expects(:tls_options).returns(['NONE'])
       provider.tls_options = ['NONE']
     end
     it 'adds SSL option grant in mysql 5.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.6'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE"]).returns('0')
+      provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system').returns('0')
 
       provider.expects(:tls_options).returns(['NONE'])
       provider.tls_options = ['NONE']
     end
     it 'adds SSL option grant in mysql < 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.1'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE"]).returns('0')
+      provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system').returns('0')
 
       provider.expects(:tls_options).returns(['NONE'])
       provider.tls_options = ['NONE']
     end
     it 'adds SSL option grant in mysql >= 5.7.6' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mysql-5.7.6'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "ALTER USER 'joe'@'localhost' REQUIRE NONE"]).returns('0')
+      provider.expects(:mysql).with("ALTER USER 'joe'@'localhost' REQUIRE NONE", 'system').returns('0')
 
       provider.expects(:tls_options).returns(['NONE'])
       provider.tls_options = ['NONE']
     end
     it 'adds SSL option grant in mariadb-10.0' do
       provider.class.instance_variable_set(:@mysqld_version_string, mysql_version_string_hash['mariadb-10.0'][:string])
-      provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE"]).returns('0')
+      provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' REQUIRE NONE", 'system').returns('0')
 
       provider.expects(:tls_options).returns(['NONE'])
       provider.tls_options = ['NONE']
@@ -335,7 +335,7 @@ usvn_user@localhost
 
     describe "#{property}=" do
       it "changes #{property}" do
-        provider.expects(:mysql).with([defaults_file, system_database, '-e', "GRANT USAGE ON *.* TO 'joe'@'localhost' WITH #{property.upcase} 42"]).returns('0')
+        provider.expects(:mysql).with("GRANT USAGE ON *.* TO 'joe'@'localhost' WITH #{property.upcase} 42", 'system').returns('0')
         provider.expects(property.to_sym).returns('42')
         provider.send("#{property}=".to_sym, '42')
       end


### PR DESCRIPTION
...so they can all be modified from one place.

> The current codebase handles each mysql call via calls to the command-line mysql client.  There are basically only two sets of options passed, but the options are repeated separately in various places throughout the code.  The new self.mysql function now issues the call to the mysql client with one of the two sets of options (selected via an optional function parameter).
> 
> Now the options to all mysql calls can be modified from one place.  This will be useful when we are converting the module to allow for databases on multiple remote servers, since we will be able to add the -h switch to all calls at once.

Rebase and squash of #904