### PR TITLE
documentation: provide a more useful Hiera example

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,66 +320,29 @@ Class['apt::update'] ->
 Class['::mysql::client']
 ```
 
-### Install MySQL Community server on CentOS
+### Using the module with Hiera
 
-You can install MySQL Community Server on CentOS using the mysql module and Hiera. This example was tested with the following versions:
-
-* MySQL Community Server 5.6
-* Centos 7.3
-* Puppet 3.8.7 using Hiera
-* puppetlabs-mysql module v3.9.0
-
-In Puppet:
-
-```puppet
-include ::mysql::server
-
-create_resources(yumrepo, hiera('yumrepo', {}))
-
-Yumrepo['repo.mysql.com'] -> Anchor['mysql::server::start']
-Yumrepo['repo.mysql.com'] -> Package['mysql_client']
-
-create_resources(mysql::db, hiera('mysql::server::db', {}))
-```
-
-In Hiera:
+This example shows how to configure the module in Hiera.
 
 ```yaml
----
+mysql::server::root_password: 'change_me_i_am_insecure'
+mysql::server::remove_default_accounts: true
 
-# Centos 7.3
-yumrepo:
-  'repo.mysql.com':
-    baseurl: "http://repo.mysql.com/yum/mysql-5.6-community/el/%{::operatingsystemmajrelease}/$basearch/"
-    descr: 'repo.mysql.com'
-    enabled: 1
-    gpgcheck: true
-    gpgkey: 'http://repo.mysql.com/RPM-GPG-KEY-mysql'
+mysql::server::databases:
+  'devdb':
+    ensure: 'present'
 
-mysql::client::package_name: "mysql-community-client" # required for proper MySQL installation
-mysql::server::package_name: "mysql-community-server" # required for proper MySQL installation
-mysql::server::package_ensure: 'installed' # do not specify version here, unfortunately yum fails with error that package is already installed
-mysql::server::root_password: "change_me_i_am_insecure"
-mysql::server::manage_config_file: true
-mysql::server::service_name: 'mysqld' # required for puppet module
-mysql::server::override_options:
-  'mysqld':
-    'bind-address': '127.0.0.1'
-    'log-error': '/var/log/mysqld.log' # required for proper MySQL installation
-  'mysqld_safe':
-    'log-error': '/var/log/mysqld.log'  # required for proper MySQL installation
+mysql::server::users:
+  'dev@127.0.0.1':
+    password_hash: '*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19'
 
-# create database + account with access, passwords are not encrypted
-mysql::server::db:
-  "dev":
-    user: "dev"
-    password: "devpass"
-    host: "127.0.0.1"
-    grant:
-      - "ALL"
-
+mysql::server::grants:
+  'dev@127.0.0.1/devdb.*':
+    user: 'dev@127.0.0.1'
+    table: 'devdb.*'
+    privileges:
+      - 'ALL'
 ```
-
 
 ## Reference
 
@@ -1324,6 +1287,6 @@ This module is based on work by David Schmitt. The following contributors have c
 * William Van Hevelingen
 * Michael Arnold
 * Chris Weyl
-* Daniël van Eeden
-* Jan-Otto Kröpke
+* Dani??l van Eeden
+* Jan-Otto Kr??pke
 * Timothy Sven Nelson


### PR DESCRIPTION
The previous example for configuring the module with Hiera wasn't a pure Hiera example but required additional custom module code. It also overwrote default settings for a specific OS and use-case which isn't necessary when using the module.

My example shows the use-case which 95% of users have:
* Configure the minimal server settings necessary to run.
* Set up a user, a DB and a grant on it for the user.

Note: The password of the password hash in the example is `password`, a hash has to be used because the provider doesn't allow a plaintext password. For me this is acceptable but unfortunately inconsistent with the configuration of the `root_password`.
Sadly I don't have time to implement a real solution: Making `myql::db` configurable from Hiera.