### PR TITLE
(MODULES-6923) Migrate from puppet-staging to puppet-archive

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,7 @@
 fixtures:
   repositories:
     "stdlib": "https://github.com/puppetlabs/puppetlabs-stdlib"
-    "staging": "https://github.com/voxpupuli/puppet-staging"
+    "archive": "https://github.com/voxpupuli/puppet-archive"
     "translate": "https://github.com/puppetlabs/puppetlabs-translate"
   symlinks:
     "mysql": "#{source_dir}"

--- a/manifests/server/mysqltuner.pp
+++ b/manifests/server/mysqltuner.pp
@@ -3,52 +3,19 @@ class mysql::server::mysqltuner(
   $ensure  = 'present',
   $version = 'v1.3.0',
   $source  = undef,
-  $environment = undef, # environment for staging::file
 ) {
 
   if $source {
-    $_version = $source
     $_source  = $source
   } else {
-    $_version = $version
     $_source  = "https://github.com/major/MySQLTuner-perl/raw/${version}/mysqltuner.pl"
   }
 
-  if $ensure == 'present' {
-    # $::puppetversion doesn't exist in puppet 4.x so would break strict
-    # variables
-    if ! $::settings::strict_variables {
-      $_puppetversion = $::puppetversion
-    } else {
-      # defined only works with puppet >= 3.5.0, so don't use it unless we're
-      # actually using strict variables
-      $_puppetversion = defined('$puppetversion') ? {
-        true    => $::puppetversion,
-        default => undef,
-      }
-    }
-    # see https://tickets.puppetlabs.com/browse/ENTERPRISE-258
-    if $_puppetversion and $_puppetversion =~ /Puppet Enterprise/ and versioncmp($_puppetversion, '3.8.0') < 0 {
-      class { '::staging':
-        path => '/opt/mysql_staging',
-      }
-    } else {
-      class { '::staging': }
-    }
-
-    staging::file { "mysqltuner-${_version}":
-      source      => $_source,
-      environment => $environment,
-    }
-    file { '/usr/local/bin/mysqltuner':
-      ensure  => $ensure,
-      mode    => '0550',
-      source  => "${::staging::path}/mysql/mysqltuner-${_version}",
-      require => Staging::File["mysqltuner-${_version}"],
-    }
-  } else {
-    file { '/usr/local/bin/mysqltuner':
-      ensure => $ensure,
-    }
+  archive { '/usr/local/bin/mysqltuner':
+    ensure => $ensure,
+    source => $_source,
+  }
+  file { '/usr/local/bin/mysqltuner':
+    mode   => '0550',
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -17,8 +17,8 @@
       "version_requirement": ">= 3.2.0 < 5.0.0"
     },
     {
-      "name": "puppet/staging",
-      "version_requirement": ">= 1.0.1 < 4.0.0"
+      "name": "puppet/archive",
+      "version_requirement": ">= 2.3.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/mysql_server_mysqltuner_spec.rb
+++ b/spec/classes/mysql_server_mysqltuner_spec.rb
@@ -4,14 +4,13 @@ describe 'mysql::server::mysqltuner' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
-        facts.merge(staging_http_get: 'curl',
-                    root_home: '/root')
+        facts.merge(root_home: '/root')
       end
 
       context 'ensure => present' do
         it { is_expected.to compile }
         it {
-          is_expected.to contain_staging__file('mysqltuner-v1.3.0').with(source: 'https://github.com/major/MySQLTuner-perl/raw/v1.3.0/mysqltuner.pl')
+          is_expected.to contain_archive('/usr/local/bin/mysqltuner').with(source: 'https://github.com/major/MySQLTuner-perl/raw/v1.3.0/mysqltuner.pl')
         }
       end
 
@@ -19,7 +18,7 @@ describe 'mysql::server::mysqltuner' do
         let(:params) { { ensure: 'absent' } }
 
         it { is_expected.to compile }
-        it { is_expected.to contain_file('/usr/local/bin/mysqltuner').with(ensure: 'absent') }
+        it { is_expected.to contain_archive('/usr/local/bin/mysqltuner').with(ensure: 'absent') }
       end
 
       context 'custom version' do
@@ -27,7 +26,7 @@ describe 'mysql::server::mysqltuner' do
 
         it { is_expected.to compile }
         it {
-          is_expected.to contain_staging__file('mysqltuner-v1.2.0').with(source: 'https://github.com/major/MySQLTuner-perl/raw/v1.2.0/mysqltuner.pl')
+          is_expected.to contain_archive('/usr/local/bin/mysqltuner').with(source: 'https://github.com/major/MySQLTuner-perl/raw/v1.2.0/mysqltuner.pl')
         }
       end
 
@@ -36,7 +35,7 @@ describe 'mysql::server::mysqltuner' do
 
         it { is_expected.to compile }
         it {
-          is_expected.to contain_staging__file('mysqltuner-/tmp/foo').with(source: '/tmp/foo')
+          is_expected.to contain_archive('/usr/local/bin/mysqltuner').with(source: '/tmp/foo')
         }
       end
     end


### PR DESCRIPTION
The voxpupuli puppet-staging module is deprecated since ±1y, please see [puppet-staging deprecation notice](https://github.com/voxpupuli/puppet-staging/issues/116), we recomand to migrate to puppet-archive module (also maintained by voxpupuli team).

Staging module is only used for the mysql tunner script.

* <https://tickets.puppetlabs.com/browse/MODULES-6923>