### PR TITLE
Lookup override_options as a hiera_hash so it can be defined across multiple levels of hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ class { '::mysql::server':
 }
 ```
 
+Or add overrides within your hiera by addin `mysql::server::override_options` eg
+
+```yaml
+mysql::server::override_options:
+  mysqld:
+    pid-file:  '/tmp/mysql.pid'
+```
+
 See [**Customize Server Options**](#customize-server-options) below for examples of the hash structure for $override_options.
 
 ## Usage
@@ -49,7 +57,11 @@ All interaction for the server is done via `mysql::server`. To install the clien
 
 ### Customize server options
 
-To define server options, structure a hash structure of overrides in `mysql::server`. This hash resembles a hash in the my.cnf file:
+To define server options, either structure a hash structure of overrides in `mysql::server` or pass in options via the `mysql::server::override_options` hiera values. The override options are merged together in the order of the default options, override_options hash and finally the `mysql::server::override_options` hiera values. The rightmost values always win.
+
+The `mysql::server::override_options` hiera hash is structured the same as the `mysql::server` override_options hash.
+
+The `mysql::server` hash resembles a hash in the my.cnf file:
 
 ```puppet
 $override_options = {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -52,11 +52,11 @@
 # @param create_root_my_cnf
 #   Whether to create `/root/.my.cnf`. Valid values are `true`, `false`. Defaults to `true`. `create_root_my_cnf` allows creation of `/root/.my.cnf` independently of `create_root_user`. You can use this for a cluster setup with Galera where you want `/root/.my.cnf` to exist on all nodes.
 # @param users
-#   Optional hash of users to create, which are passed to [mysql_user](#mysql_user). 
+#   Optional hash of users to create, which are passed to [mysql_user](#mysql_user).
 # @param grants
-#   Optional hash of grants, which are passed to [mysql_grant](#mysql_grant). 
+#   Optional hash of grants, which are passed to [mysql_grant](#mysql_grant).
 # @param databases
-#   Optional hash of databases to create, which are passed to [mysql_database](#mysql_database). 
+#   Optional hash of databases to create, which are passed to [mysql_database](#mysql_database).
 # @param enabled
 #   _Deprecated_
 # @param manage_service
@@ -114,7 +114,7 @@ class mysql::server (
   }
 
   # Create a merged together set of options.  Rightmost hashes win over left.
-  $options = mysql::deepmerge($mysql::params::default_options, $override_options)
+  $options = mysql::deepmerge($mysql::params::default_options, $override_options, hiera_hash('mysql::server::override_options', {}))
 
   Class['mysql::server::root_password'] -> Mysql::Db <| |>
 


### PR DESCRIPTION
Presently the override options can only be set at one level of hiera. The top level of hiera wins when it does the lookup.

This means that you cannot define it across multiple levels of hiera at all which makes it a pain to manage clusters of MySQL servers.

E.G. usage case: one master server and one slave server in a cluster.

Within a cluster hiera file you can set all of the tuning and server mysql settings to include in my.cnf eg

```
    query_cache_limit: 128M
    query_cache_size:  640M
    join_buffer_size: 64M
    table_cache: 500
```

However since the bind-address & server-id need to be different between the two servers you cannot set those two parameters within the same hiera file.

Moving them into node specific hiera files then makes this possible. However presently the module would then only pickup the server hiera settings.