### PR TITLE
Make common environment paths to support most OS paths

### DIFF
--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -4,7 +4,28 @@ class Puppet::Provider::Mysql < Puppet::Provider
   initvars
 
   # Make sure we find mysql commands on CentOS and FreeBSD
-  ENV['PATH'] = ENV['PATH'] + ':/usr/libexec:/usr/local/libexec:/usr/local/bin'
+  ENV['PATH'] = [
+    ENV['PATH'],
+    '/usr/libexec',
+    '/usr/local/libexec',
+    '/usr/local/bin',
+    '/usr/share/mysql/scripts',
+    '/opt/rh/rh-mysql57/root/usr/bin',
+    '/opt/rh/rh-mysql57/root/usr/libexec',
+    '/opt/rh/rh-mysql56/root/usr/bin',
+    '/opt/rh/rh-mysql56/root/usr/libexec',
+    '/opt/rh/rh-mariadb101/root/usr/bin',
+    '/opt/rh/rh-mariadb101/root/usr/libexec',
+    '/opt/rh/rh-mariadb100/root/usr/bin',
+    '/opt/rh/rh-mariadb100/root/usr/libexec',
+    '/opt/rh/mysql55/root/usr/bin',
+    '/opt/rh/mysql55/root/usr/libexec',
+    '/opt/rh/mariadb55/root/usr/bin',
+    '/opt/rh/mariadb55/root/usr/libexec',
+    '/usr/mysql/5.5/bin',
+    '/usr/mysql/5.6/bin',
+    '/usr/mysql/5.7/bin',
+  ].join(':')
 
   # rubocop:disable Style/HashSyntax
   commands :mysql_raw  => 'mysql'

--- a/lib/puppet/provider/mysql_datadir/mysql.rb
+++ b/lib/puppet/provider/mysql_datadir/mysql.rb
@@ -8,6 +8,8 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, parent: Puppet::Provider::Mysq
   ENV['PATH'] = [
     ENV['PATH'],
     '/usr/libexec',
+    '/usr/local/libexec',
+    '/usr/local/bin',
     '/usr/share/mysql/scripts',
     '/opt/rh/rh-mysql57/root/usr/bin',
     '/opt/rh/rh-mysql57/root/usr/libexec',


### PR DESCRIPTION
On Centos 6 with mysql55 packages there is an error:

    Debug: Executing: '/usr/bin/mysql --defaults-extra-file=/root/.my.cnf -NBe SELECT CONCAT(User, '@',Host) AS User FROM mysql.user'
    Error: Could not prefetch mysql_user provider 'mysql': Command mysqld is missing
    Debug: Executing: '/usr/bin/mysql --defaults-extra-file=/root/.my.cnf --database=mysql -e CREATE USER 'root'@'localhost' IDENTIFIED BY PASSWORD '*''
    Error: Execution of '/usr/bin/mysql --defaults-extra-file=/root/.my.cnf --database=mysql -e CREATE USER 'root'@'localhost' IDENTIFIED BY PASSWORD '*'' returned 1: ERROR 1396 (HY000) at line 1: Operation CREATE USER failed for 'root'@'localhost'
    Error: /Stage[main]/Mysql::Server::Root_password/Mysql_user[root@localhost]/ensure: change from absent to present failed: Execution of '/usr/bin/mysql --defaults-extra-file=/root/.my.cnf --database=mysql -e CREATE USER 'root'@'localhost' IDENTIFIED BY PASSWORD '*'' returned 1: ERROR 1396 (HY000) at line 1: Operation CREATE USER failed for 'root'@'localhost'
    Notice: /Stage[main]/Mysql::Server::Root_password/File[/root/.my.cnf]: Dependency Mysql_user[root@localhost] has failures: true

This problem is due to lack of proper paths which are different in ``lib/puppet/provider/mysql.rb`` and `` lib/puppet/provider/mysql_datadir/mysql.rb``.
This change make common both sets.
``mysqld`` is under ``/opt/rh/mysql55/root/usr/libexec/mysqld`` in this case.