### PR TITLE
(MODULES-7439) - Implementing beaker-testmode_switcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.git/
 .*.sw[op]
 .metadata
 .yardoc

--- a/.pdkignore
+++ b/.pdkignore
@@ -1,3 +1,4 @@
+.git/
 .*.sw[op]
 .metadata
 .yardoc

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,6 +74,7 @@ RSpec/MessageSpies:
 Style/Documentation:
   Exclude:
   - lib/puppet/parser/functions/**/*
+  - spec/**/*
 Style/WordArray:
   EnforcedStyle: brackets
 Style/CollectionMethods:
@@ -83,6 +84,8 @@ Style/MethodCalledOnDoEndBlock:
 Style/StringMethods:
   Enabled: true
 Layout/EndOfLine:
+  Enabled: false
+Layout/IndentHeredoc:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false

--- a/.sync.yml
+++ b/.sync.yml
@@ -30,6 +30,7 @@ Gemfile:
         from_env: BEAKER_HOSTGENERATOR_VERSION
       - gem: beaker-rspec
         from_env: BEAKER_RSPEC_VERSION
+      - gem: beaker-testmode_switcher
     ':development':
       - gem: puppet-lint-i18n
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
   - 'bundle exec rake $CHECK'
 bundler_args: --without system_tests
 rvm:
-  - 2.4.1
+  - 2.4.4
 env:
   global:
     - BEAKER_PUPPET_COLLECTION=puppet5 PUPPET_GEM_VERSION="~> 5.0"
@@ -23,16 +23,16 @@ matrix:
     -
       bundler_args: 
       dist: trusty
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=docker/centos-7
-      rvm: 2.4.1
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=docker/centos-7 BEAKER_TESTMODE=apply
+      rvm: 2.4.4
       script: bundle exec rake beaker
       services: docker
       sudo: required
     -
       bundler_args: 
       dist: trusty
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=docker/ubuntu-14.04
-      rvm: 2.4.1
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=docker/ubuntu-14.04 BEAKER_TESTMODE=apply
+      rvm: 2.4.4
       script: bundle exec rake beaker
       services: docker
       sudo: required
@@ -45,9 +45,9 @@ matrix:
       rvm: 2.1.9
 branches:
   only:
-    - master
-    - /^v\d/
-    - release
+    - master 
+    - /^v\d/ 
+    - release 
 notifications:
   email: false
 deploy:

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ group :development do
   gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-blacksmith", '~> 3.4',                   require: false, platforms: [:ruby]
   gem "puppet-lint-i18n",                              require: false
 end
 group :system_tests do
@@ -44,6 +43,7 @@ group :system_tests do
   gem "beaker-pe",                                                               require: false
   gem "beaker-hostgenerator"
   gem "beaker-rspec"
+  gem "beaker-testmode_switcher",                                                require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,76 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
+require 'github_changelog_generator/task' if Bundler.rubygems.find_name('github_changelog_generator').any?
 require 'puppet_pot_generator/rake_tasks'
 
+def changelog_user
+  return unless Rake.application.top_level_tasks.include? "changelog"
+  returnVal = nil || JSON.load(File.read('metadata.json'))['author']
+  raise "unable to find the changelog_user in .sync.yml, or the author in metadata.json" if returnVal.nil?
+  puts "GitHubChangelogGenerator user:#{returnVal}"
+  returnVal
+end
+
+def changelog_project
+  return unless Rake.application.top_level_tasks.include? "changelog"
+  returnVal = nil || JSON.load(File.read('metadata.json'))['name']
+  raise "unable to find the changelog_project in .sync.yml or the name in metadata.json" if returnVal.nil?
+  puts "GitHubChangelogGenerator project:#{returnVal}"
+  returnVal
+end
+
+def changelog_future_release
+  return unless Rake.application.top_level_tasks.include? "changelog"
+  returnVal = JSON.load(File.read('metadata.json'))['version']
+  raise "unable to find the future_release (version) in metadata.json" if returnVal.nil?
+  puts "GitHubChangelogGenerator future_release:#{returnVal}"
+  returnVal
+end
+
 PuppetLint.configuration.send('disable_relative')
+
+if Bundler.rubygems.find_name('github_changelog_generator').any?
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?
+    config.user = "#{changelog_user}"
+    config.project = "#{changelog_project}"
+    config.future_release = "#{changelog_future_release}"
+    config.exclude_labels = ['maintenance']
+    config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
+    config.add_pr_wo_labels = true
+    config.issues = false
+    config.merge_prefix = "### UNCATEGORIZED PRS; GO LABEL THEM"
+    config.configure_sections = {
+      "Changed" => {
+        "prefix" => "### Changed",
+        "labels" => ["backwards-incompatible"],
+      },
+      "Added" => {
+        "prefix" => "### Added",
+        "labels" => ["feature", "enhancement"],
+      },
+      "Fixed" => {
+        "prefix" => "### Fixed",
+        "labels" => ["bugfix"],
+      },
+    }
+  end
+else
+  desc 'Generate a Changelog from GitHub'
+  task :changelog do
+    raise <<EOM
+The changelog tasks depends on unreleased features of the github_changelog_generator gem.
+Please manually add it to your .sync.yml for now, and run `pdk update`:
+---
+Gemfile:
+  optional:
+    ':development':
+      - gem: 'github_changelog_generator'
+        git: 'https://github.com/skywinder/github-changelog-generator'
+        ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')"
+EOM
+  end
+end
 

--- a/metadata.json
+++ b/metadata.json
@@ -83,6 +83,6 @@
   ],
   "description": "MySQL module",
   "template-url": "https://github.com/puppetlabs/pdk-templates",
-  "template-ref": "heads/master-0-g34e3266",
+  "template-ref": "heads/master-0-g6b0d497",
   "pdk-version": "1.5.0"
 }

--- a/spec/acceptance/locales_spec.rb
+++ b/spec/acceptance/locales_spec.rb
@@ -38,7 +38,7 @@ describe 'mysql localization', if: (fact('osfamily') == 'Debian' || fact('osfami
     end
 
     it 'displays Japanese error' do
-      apply_manifest(pp, catch_error: true) do |r|
+      execute_manifest(pp, catch_error: true) do |r|
         expect(r.stderr).to match(%r{`old_root_password`属性は廃止予定であり、今後のリリースで廃止されます。}i)
       end
     end
@@ -61,7 +61,7 @@ describe 'mysql localization', if: (fact('osfamily') == 'Debian' || fact('osfami
     end
 
     it 'displays Japanese failure' do
-      apply_manifest(pp, catch_failures: true) do |r|
+      execute_manifest(pp, catch_failures: true) do |r|
         expect(r.stderr).to match(%r{'prescript'オプションは、現在、mysqldumpバックアッププロバイダ向けには実装されていません。}i)
       end
     end
@@ -80,7 +80,7 @@ describe 'mysql localization', if: (fact('osfamily') == 'Debian' || fact('osfami
     end
 
     it 'displays Japanese failure' do
-      apply_manifest(pp, expect_failures: true) do |r|
+      execute_manifest(pp, expect_failures: true) do |r|
         expect(r.stderr).to match(%r{MySQLユーザ名は最大\d{2}文字に制限されています。}i)
       end
     end
@@ -96,7 +96,7 @@ describe 'mysql localization', if: (fact('osfamily') == 'Debian' || fact('osfami
     end
 
     it 'displays Japanese error' do
-      apply_manifest(pp, expect_failures: true) do |r|
+      execute_manifest(pp, expect_failures: true) do |r|
         expect(r.stderr).to match(%r{無効なデータベースのユーザ"name@localhost}i)
       end
     end

--- a/spec/acceptance/mysql_backup_spec.rb
+++ b/spec/acceptance/mysql_backup_spec.rb
@@ -29,8 +29,8 @@ describe 'mysql::server::backup class' do
         }
     MANIFEST
     it 'when configuring mysql backups' do
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_failures: true)
+      execute_manifest(pp, catch_failures: true)
+      execute_manifest(pp, catch_failures: true)
     end
   end
 
@@ -104,8 +104,8 @@ describe 'mysql::server::backup class' do
           }
       MANIFEST
       it 'when configuring mysql backups' do
-        apply_manifest(pp, catch_failures: true)
-        apply_manifest(pp, catch_failures: true)
+        execute_manifest(pp, catch_failures: true)
+        execute_manifest(pp, catch_failures: true)
       end
     end
 
@@ -187,7 +187,7 @@ describe 'mysql::server::backup class' do
         }
     MANIFEST
     it 'when configuring mysql backups with triggers and routines' do
-      apply_manifest(pp, catch_failures: true)
+      execute_manifest(pp, catch_failures: true)
     end
 
     it 'runs mysqlbackup.sh with no errors' do

--- a/spec/acceptance/mysql_helper.rb
+++ b/spec/acceptance/mysql_helper.rb
@@ -1,5 +1,5 @@
 def pre_run
-  apply_manifest("class { 'mysql::server': root_password => 'password' }", catch_failures: true)
+  execute_manifest("class { 'mysql::server': root_password => 'password' }", catch_failures: true)
   @mysql_version = (on default, 'mysql --version').output.chomp.match(%r{\d+\.\d+\.\d+})[0]
 end
 

--- a/spec/acceptance/mysql_server_spec.rb
+++ b/spec/acceptance/mysql_server_spec.rb
@@ -98,7 +98,7 @@ describe 'mysql class' do
     let(:pp) { "class { 'mysql::server': root_password => '#{password}' }" }
 
     it 'does not display the password' do
-      result = apply_manifest(pp, catch_failures: true)
+      result = execute_manifest(pp, catch_failures: true)
       # this does not actually prove anything, as show_diff in the puppet config defaults to false.
       expect(result.stdout).not_to match %r{#{password}}
     end

--- a/spec/acceptance/sql_task_spec.rb
+++ b/spec/acceptance/sql_task_spec.rb
@@ -12,7 +12,7 @@ describe 'mysql tasks', if: puppet_version =~ %r{(5\.\d\.\d)} && fact('operating
     MANIFEST
 
     it 'sets up a mysql instance' do
-      apply_manifest_on(hosts, pp, catch_failures: true)
+      execute_manifest_on(hosts, pp, catch_failures: true)
     end
 
     it 'execute arbitary sql' do

--- a/spec/acceptance/types/mysql_database_spec.rb
+++ b/spec/acceptance/types/mysql_database_spec.rb
@@ -6,7 +6,7 @@ describe 'mysql_database' do
         class { 'mysql::server': }
     MANIFEST
     it 'works with no errors' do
-      apply_manifest(pp, catch_failures: true)
+      execute_manifest(pp, catch_failures: true)
     end
   end
 
@@ -17,7 +17,7 @@ describe 'mysql_database' do
         }
     MANIFEST
     it 'works without errors' do
-      apply_manifest(pp, catch_failures: true)
+      execute_manifest(pp, catch_failures: true)
     end
 
     it 'finds the database #stdout' do
@@ -44,8 +44,8 @@ describe 'mysql_database' do
         }
     MANIFEST
     it 'creates two db of different types idempotently' do
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+      execute_manifest(pp, catch_failures: true)
+      execute_manifest(pp, catch_changes: true)
     end
 
     it 'finds latin1 db #stdout' do

--- a/spec/acceptance/types/mysql_grant_spec.rb
+++ b/spec/acceptance/types/mysql_grant_spec.rb
@@ -10,7 +10,7 @@ describe 'mysql_grant' do
       }
     MANIFEST
 
-    apply_manifest(pp, catch_failures: true)
+    execute_manifest(pp, catch_failures: true)
   end
 
   describe 'missing privileges for user' do
@@ -26,7 +26,7 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'fails' do
-      expect(apply_manifest(pp, expect_failures: true).stderr).to match(%r{`privileges` `parameter` is required})
+      expect(execute_manifest(pp, expect_failures: true).stderr).to match(%r{`privileges` `parameter` is required})
     end
 
     it 'does not find the user' do
@@ -47,7 +47,7 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'fails' do
-      apply_manifest(pp, expect_failures: true)
+      execute_manifest(pp, expect_failures: true)
     end
 
     it 'does not find the user' do
@@ -69,7 +69,7 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'works without errors' do
-      apply_manifest(pp, catch_failures: true)
+      execute_manifest(pp, catch_failures: true)
     end
 
     it 'finds the user #stdout' do
@@ -98,7 +98,7 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'works without errors' do
-      apply_manifest(pp, catch_failures: true)
+      execute_manifest(pp, catch_failures: true)
     end
 
     it 'finds the user #stdout' do
@@ -128,7 +128,7 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'works without errors' do
-      apply_manifest(pp, catch_failures: true)
+      execute_manifest(pp, catch_failures: true)
     end
 
     it 'finds the user #stdout' do
@@ -157,7 +157,7 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'fails' do
-      expect(apply_manifest(pp, expect_failures: true).stderr).to match(%r{`table` `parameter` is required.})
+      expect(execute_manifest(pp, expect_failures: true).stderr).to match(%r{`table` `parameter` is required.})
     end
   end
 
@@ -176,7 +176,7 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'onlies try to apply ALL' do
-      apply_manifest(pp, catch_failures: true)
+      execute_manifest(pp, catch_failures: true)
     end
 
     it 'finds the user #stdout' do
@@ -246,7 +246,7 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'applies' do
-      apply_manifest(pp, catch_failures: true)
+      execute_manifest(pp, catch_failures: true)
     end
 
     it 'finds short hostname #stdout' do
@@ -383,8 +383,8 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'setup mysql::server' do
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+      execute_manifest(pp, catch_failures: true)
+      execute_manifest(pp, catch_changes: true)
     end
   end
 
@@ -401,7 +401,7 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'create ALL privs' do
-      apply_manifest(pp_one, catch_failures: true)
+      execute_manifest(pp_one, catch_failures: true)
     end
 
     pp_two = <<-MANIFEST
@@ -416,7 +416,7 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'create lowercase all privs' do
-      expect(apply_manifest(pp_two, catch_failures: true).exit_code).to eq(0)
+      expect(execute_manifest(pp_two, catch_failures: true).exit_code).to eq(0)
     end
   end
 
@@ -439,7 +439,7 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'works without errors' do
-      apply_manifest(pp, catch_failures: true)
+      execute_manifest(pp, catch_failures: true)
     end
 
     it 'finds the user #stdout' do
@@ -475,7 +475,7 @@ describe 'mysql_grant' do
         }
       EOS
 
-      apply_manifest(pp, catch_failures: true)
+      execute_manifest(pp, catch_failures: true)
     end
     # rubocop:enable RSpec/ExampleLength
     it 'finds the user' do
@@ -504,7 +504,7 @@ describe 'mysql_grant' do
         }
       MANIFEST
       it 'works without errors when version greater than 5.5.0' do
-        apply_manifest(pp, catch_failures: true)
+        execute_manifest(pp, catch_failures: true)
       end
 
       it 'finds the user #stdout' do
@@ -533,7 +533,7 @@ describe 'mysql_grant' do
         }
       MANIFEST
       it 'works without errors' do
-        apply_manifest(pp, catch_failures: true)
+        execute_manifest(pp, catch_failures: true)
       end
 
       it 'finds the user #stdout' do
@@ -562,7 +562,7 @@ describe 'mysql_grant' do
         }
       MANIFEST
       it 'fails' do
-        expect(apply_manifest(pp, expect_failures: true).stderr).to match(%r{`privileges` `parameter`: PROXY can only be specified by itself})
+        expect(execute_manifest(pp, expect_failures: true).stderr).to match(%r{`privileges` `parameter`: PROXY can only be specified by itself})
       end
 
       it 'does not find the user' do
@@ -584,7 +584,7 @@ describe 'mysql_grant' do
         }
       MANIFEST
       it 'fails' do
-        expect(apply_manifest(pp, expect_failures: true).stderr).to match(%r{PROXY user not supported on mysql versions < 5\.5\.0}i)
+        expect(execute_manifest(pp, expect_failures: true).stderr).to match(%r{PROXY user not supported on mysql versions < 5\.5\.0}i)
       end
 
       it 'does not find the user' do
@@ -606,7 +606,7 @@ describe 'mysql_grant' do
         }
       MANIFEST
       it 'fails' do
-        expect(apply_manifest(pp, expect_failures: true).stderr).to match(%r{`table` `property` for PROXY should be specified as proxy_user@proxy_host.})
+        expect(execute_manifest(pp, expect_failures: true).stderr).to match(%r{`table` `property` for PROXY should be specified as proxy_user@proxy_host.})
       end
 
       it 'does not find the user' do
@@ -625,7 +625,7 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'setup mysql::server' do
-      apply_manifest(pp_one, catch_failures: true)
+      execute_manifest(pp_one, catch_failures: true)
     end
 
     pp_two = <<-MANIFEST
@@ -651,7 +651,7 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'applies' do
-      apply_manifest(pp_two, catch_failures: true)
+      execute_manifest(pp_two, catch_failures: true)
     end
 
     it 'fails with fqdn' do
@@ -687,7 +687,7 @@ describe 'mysql_grant' do
     it 'fails to execute while applying' do
       mysql_cmd = shell('which mysql').stdout.chomp
       shell("mv #{mysql_cmd} #{mysql_cmd}.bak")
-      expect(apply_manifest(pp_three, expect_failures: true).stderr).to match(%r{Could not find a suitable provider for mysql_grant})
+      expect(execute_manifest(pp_three, expect_failures: true).stderr).to match(%r{Could not find a suitable provider for mysql_grant})
       shell("mv #{mysql_cmd}.bak #{mysql_cmd}")
     end
 
@@ -697,7 +697,7 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'reset mysql::server config' do
-      apply_manifest(pp_four, catch_failures: true)
+      execute_manifest(pp_four, catch_failures: true)
     end
   end
 
@@ -707,7 +707,7 @@ describe 'mysql_grant' do
         class { 'mysql::server': override_options => { 'root_password' => 'password' } }
     MANIFEST
     it 'setup mysql server' do
-      apply_manifest(pp_one, catch_failures: true)
+      execute_manifest(pp_one, catch_failures: true)
     end
 
     pp_two = <<-MANIFEST
@@ -722,7 +722,7 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'creates grant on missing table will fail' do
-      expect(apply_manifest(pp_two, expect_failures: true).stderr).to match(%r{Table 'grant_spec_db\.grant_spec_table' doesn't exist})
+      expect(execute_manifest(pp_two, expect_failures: true).stderr).to match(%r{Table 'grant_spec_db\.grant_spec_table' doesn't exist})
     end
 
     pp_three = <<-MANIFEST
@@ -738,7 +738,7 @@ describe 'mysql_grant' do
         }
     MANIFEST
     it 'creates table' do
-      apply_manifest(pp_three, catch_failures: true)
+      execute_manifest(pp_three, catch_failures: true)
     end
 
     it 'has the table' do

--- a/spec/acceptance/types/mysql_plugin_spec.rb
+++ b/spec/acceptance/types/mysql_plugin_spec.rb
@@ -37,7 +37,7 @@ describe 'mysql_plugin' do
           class { 'mysql::server': }
         MANIFEST
 
-        apply_manifest(pp, catch_failures: true)
+        execute_manifest(pp, catch_failures: true)
       end
     end
 
@@ -49,7 +49,7 @@ describe 'mysql_plugin' do
           }
       MANIFEST
       it 'works without errors' do
-        apply_manifest(pp, catch_failures: true)
+        execute_manifest(pp, catch_failures: true)
       end
 
       it 'finds the plugin #stdout' do

--- a/spec/acceptance/types/mysql_user_spec.rb
+++ b/spec/acceptance/types/mysql_user_spec.rb
@@ -7,7 +7,7 @@ describe 'mysql_user' do
         class { 'mysql::server': }
     MANIFEST
     it 'works with no errors' do
-      apply_manifest(pp_one, catch_failures: true)
+      execute_manifest(pp_one, catch_failures: true)
     end
   end
 
@@ -19,7 +19,7 @@ describe 'mysql_user' do
           }
       MANIFEST
       it 'works without errors' do
-        apply_manifest(pp_two, catch_failures: true)
+        execute_manifest(pp_two, catch_failures: true)
       end
 
       it 'finds the user #stdout' do
@@ -54,7 +54,7 @@ describe 'mysql_user' do
           }
         EOS
 
-        apply_manifest(pp, catch_failures: true)
+        execute_manifest(pp, catch_failures: true)
       end
 
       it 'has the correct plugin' do
@@ -88,7 +88,7 @@ describe 'mysql_user' do
           }
       MANIFEST
       it 'works without errors' do
-        apply_manifest(pp_three, catch_failures: true)
+        execute_manifest(pp_three, catch_failures: true)
       end
 
       it 'finds the user #stdout' do
@@ -112,7 +112,7 @@ describe 'mysql_user' do
           }
       MANIFEST
       it 'works without errors' do
-        apply_manifest(pp_four, catch_failures: true)
+        execute_manifest(pp_four, catch_failures: true)
       end
 
       it 'finds the user #stdout' do
@@ -150,7 +150,7 @@ describe 'mysql_user' do
           }
       MANIFEST
       it 'works without errors' do
-        apply_manifest(pp_five, catch_failures: true)
+        execute_manifest(pp_five, catch_failures: true)
       end
 
       it 'finds the user #stdout' do
@@ -185,7 +185,7 @@ describe 'mysql_user' do
           }
       MANIFEST
       it 'works without errors' do
-        apply_manifest(pp_six, catch_failures: true)
+        execute_manifest(pp_six, catch_failures: true)
       end
 
       it 'finds the user #stdout' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,4 +34,13 @@ RSpec.configure do |c|
     Puppet.settings[:strict] = :warning
   end
 end
+
+def ensure_module_defined(module_name)
+  module_name.split('::').reduce(Object) do |last_module, next_module|
+    last_module.const_set(next_module, Module.new) unless last_module.const_defined?(next_module)
+    last_module.const_get(next_module)
+  end
+end
+
+# 'spec_overrides' from sync.yml will appear below this line
 require 'spec_helper_local'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -4,6 +4,8 @@ require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
 require 'beaker/i18n_helper'
 require 'beaker-task_helper'
+require 'beaker/testmode_switcher'
+require 'beaker/testmode_switcher/dsl'
 
 run_puppet_install_helper
 install_ca_certs unless pe_install?
@@ -48,10 +50,10 @@ end
 
 shared_examples 'a idempotent resource' do
   it 'applies with no errors' do
-    apply_manifest(pp, catch_failures: true)
+    execute_manifest(pp, catch_failures: true)
   end
 
   it 'applies a second time without changes', :skip_pup_5016 do
-    apply_manifest(pp, catch_changes: true)
+    execute_manifest(pp, catch_changes: true)
   end
 end

--- a/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
@@ -13,7 +13,6 @@ describe Puppet::Type.type(:mysql_database).provider(:mysql) do
     )
   end
   let(:raw_databases) do
-    # rubocop:disable Layout/IndentHeredoc
     <<-SQL_OUTPUT
 information_schema
 mydb

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -52,7 +52,6 @@ describe Puppet::Type.type(:mysql_user).provider(:mysql) do
   let(:newhash) { '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF5' }
 
   let(:raw_users) do
-    # rubocop:disable Layout/IndentHeredoc
     <<-SQL_OUTPUT
 root@127.0.0.1
 root@::1


### PR DESCRIPTION
Implementing `beaker-testmode_switcher` in this module allows us to test in a more realistic method and more like how customers use puppet as a tool. 

When there is an agent only setup this module will continue to use `puppet apply <manifest>` however where there are masters present the manifest will now be injected onto the master and agents will run `puppet agent --test`. 

This will give us the capability of testing the master agent integration and ensure that all information and settings are sent over as expected. This will also allow us to ensure scenarios like the following do not reoccur: https://tickets.puppetlabs.com/browse/PUP-8026