### PR TITLE
(PUP-9008) - Temporary workaround for Puppet `upstart` Bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
     -
       bundler_args: 
       dist: trusty
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=docker/ubuntu-14.04 BEAKER_TESTMODE=apply
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=docker/ubuntu-14.04 BEAKER_TESTMODE=apply BEAKER_PUPPET_AGENT_VERSION=5.5.2
       rvm: 2.4.4
       script: bundle exec rake beaker
       services: docker


### PR DESCRIPTION
Currently we are seeing Ubuntu14 failures related to https://tickets.puppetlabs.com/browse/PUP-9008 which was released in puppet-agent 5.5.3. In order to remove our road block this fix is a temporary work around.

This change has been put directly into the travis.yml file, therefore if forgotten about it will be removed on the next pdksync as this change was not put into the templates. 

The following PR has been created to resolve the issue however we are pinning the `BEAKER_PUPPET_AGENT_VERSION` until this change has been released: https://github.com/puppetlabs/puppet/pull/6950