### PR TITLE
Removing query_cache ops that are no longer supported in MySQL >= 8.0

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -455,12 +455,18 @@ class mysql::params {
     },
     'mysqld-5.5'       => {
       'myisam-recover' => 'BACKUP',
+      'query_cache_limit'     => '1M',
+      'query_cache_size'      => '16M',
     },
     'mysqld-5.6'              => {
       'myisam-recover-options' => 'BACKUP',
+      'query_cache_limit'     => '1M',
+      'query_cache_size'      => '16M',
     },
     'mysqld-5.7'              => {
       'myisam-recover-options' => 'BACKUP',
+      'query_cache_limit'     => '1M',
+      'query_cache_size'      => '16M',
     },
     'mysqld'                  => {
       'basedir'               => $mysql::params::basedir,
@@ -474,8 +480,6 @@ class mysql::params {
       'max_connections'       => '151',
       'pid-file'              => $mysql::params::pidfile,
       'port'                  => '3306',
-      'query_cache_limit'     => '1M',
-      'query_cache_size'      => '16M',
       'skip-external-locking' => true,
       'socket'                => $mysql::params::socket,
       'ssl'                   => false,


### PR DESCRIPTION
While using MySQL 8.0, the configuration options in the mysqld params section had `query_cache_limit` and `query_cache_size` variables which are no longer supported for MySQL >= 8.0

Moving these into the version-specific hashes, rather than the `mysqld` default hash.  I didn't love having to duplicate those entries, but it does follow the same pattern of the `myisam-recover` option. 🤷‍♂️ 

This results in MySQL 8.0.12 actually starting up, rather than throwing the following error example:

```
[ERROR] [MY-011071] [Server] unknown variable 'query_cache_limit=1M'
```