### PR TITLE
(maint) - Change versioning comparison

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -31,7 +31,8 @@ RSpec.configure do |c|
     run_puppet_access_login(user: 'admin') if pe_install? && puppet_version =~ %r{(5\.\d\.\d)}
     hosts.each do |host|
       # This will be removed, this is temporary to test localisation.
-      if (fact('osfamily') == 'Debian' || fact('osfamily') == 'RedHat') && (puppet_version >= '4.10.5' && puppet_version < '5.2.0')
+      if (fact('osfamily') == 'Debian' || fact('osfamily') == 'RedHat') && (Gem::Version.new(puppet_version) >= Gem::Version.new('4.10.5') &&
+          Gem::Version.new(puppet_version) < Gem::Version.new('5.2.0'))
         on(host, 'mkdir /opt/puppetlabs/puppet/share/locale/ja')
         on(host, 'touch /opt/puppetlabs/puppet/share/locale/ja/puppet.po')
       end


### PR DESCRIPTION
Changed comparison of versions from default string comparisons to Gem::Version as the string comparisons use lexicographical ordering which can fail on certain cases e.g. '4.10.5' > '4.10.12' resolves to true which is incorrect as 4.10.12 is a later version than 4.10.5 . 