### PR TITLE
(MODULES-7857) Support user creation on galera

### DIFF
--- a/lib/puppet/provider/mysql_user/mysql.rb
+++ b/lib/puppet/provider/mysql_user/mysql.rb
@@ -69,8 +69,8 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
       end
       @property_hash[:ensure] = :present
       @property_hash[:plugin] = plugin
-    elsif newer_than('mysql' => '5.7.6', 'percona' => '5.7.6')
-      self.class.mysql_caller("CREATE USER '#{merged_name}' IDENTIFIED WITH 'mysql_native_password' AS '#{password_hash}'", 'system')
+    elsif newer_than('mysql' => '5.7.6', 'percona' => '5.7.6', 'mariadb' => '10.1.3')
+      self.class.mysql_caller("CREATE USER IF NOT EXISTS '#{merged_name}' IDENTIFIED WITH 'mysql_native_password' AS '#{password_hash}'", 'system')
       @property_hash[:ensure] = :present
       @property_hash[:password_hash] = password_hash
     else

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -174,6 +174,15 @@ usvn_user@localhost
       provider.expects(:exists?).returns(true)
       expect(provider.create).to be_truthy
     end
+    it 'creates a user using IF NOT EXISTS' do
+      provider.class.instance_variable_set(:@mysqld_version_string, '5.7.6')
+
+      provider.class.expects(:mysql_caller).with("CREATE USER IF NOT EXISTS 'joe'@'localhost' IDENTIFIED WITH 'mysql_native_password' AS '*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4'", 'system') # rubocop:disable Metrics/LineLength
+      provider.class.expects(:mysql_caller).with("ALTER USER IF EXISTS 'joe'@'localhost' WITH MAX_USER_CONNECTIONS 10 MAX_CONNECTIONS_PER_HOUR 10 MAX_QUERIES_PER_HOUR 10 MAX_UPDATES_PER_HOUR 10", 'system') # rubocop:disable Metrics/LineLength
+      provider.class.expects(:mysql_caller).with("ALTER USER 'joe'@'localhost' REQUIRE NONE", 'system')
+      provider.expects(:exists?).returns(true)
+      expect(provider.create).to be_truthy
+    end
   end
 
   describe 'destroy' do


### PR DESCRIPTION
Support user creation on galera. Add IF NOT EXISTS to CREATE USER in mysql_user provider
Description of issue in jira - https://tickets.puppetlabs.com/browse/MODULES-7857
