### PR TITLE
(MODULES-7487) Check authentication string for user password on MariaDB 10.2.16+

### DIFF
--- a/lib/puppet/provider/mysql_user/mysql.rb
+++ b/lib/puppet/provider/mysql_user/mysql.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
         ## Default ...
         # rubocop:disable Metrics/LineLength
         query = "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{name}'"
-      elsif newer_than('mysql' => '5.7.6', 'percona' => '5.7.6')
+      elsif newer_than('mysql' => '5.7.6', 'percona' => '5.7.6', 'mariadb' => '10.2.16')
         query = "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, AUTHENTICATION_STRING, PLUGIN FROM mysql.user WHERE CONCAT(user, '@', host) = '#{name}'"
       else
         query = "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{name}'"


### PR DESCRIPTION
Since [MariaDB 10.2.16](https://github.com/MariaDB/server/commit/5f0510225aa149377b8563f6e96b74d05d41f080), the `SET PASSWORD` command stores user passwords in the `mysql_native_password` plugin `authentication_string` instead of in the `password` column of `mysql.user`.

The module checks the `password` column instead of the `authentication_string` on all versions of MariaDB. In every Puppet run involving MariaDB 10.2.16 and newer, the module attempts to update
managed user passwords even when they haven't changed (`Notice: /Stage[main]/Mysql::Server::Root_password/Mysql_user[root@localhost]/password_hash: changed password`) because the `password` field is always empty.

Update the if statement to check the plugin authentication string on MariaDB 10.2.16 and newer.

See also MariaDB JIRA ticket [MDEV-16774](https://jira.mariadb.org/browse/MDEV-16774).