### PR TITLE
fix install ordering for innodb data size

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -143,8 +143,8 @@ class mysql::server (
   }
 
   Anchor['mysql::server::start']
-  -> Class['mysql::server::install']
   -> Class['mysql::server::config']
+  -> Class['mysql::server::install']
   -> Class['mysql::server::binarylog']
   -> Class['mysql::server::installdb']
   -> Class['mysql::server::service']


### PR DESCRIPTION
Hi,

Since release 5.4.0 MySQL package was install with default configuration, and after the configuration was set.

So we can not change innodb data size configuration for example (the default size is 12Mo and if you change this size MySQL can't be restart).

Someone have notify this conportement on the commit: https://github.com/puppetlabs/puppetlabs-mysql/commit/d13c06b9561d2c216bb9c5b48913ff2b4ac0b41b

I think it's better to rollback the ordering, and eventually change the resource `/etc/mysql/conf.d/mysql.cnf` in post-install class if it's needed