### PR TITLE
(MODULES-6627) Remove unused --host flags from mysqlcaller

### DIFF
--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -89,9 +89,9 @@ class Puppet::Provider::Mysql < Puppet::Provider
     if type.eql? 'system'
       if File.file?("#{Facter.value(:root_home)}/.mylogin.cnf")
         ENV['MYSQL_TEST_LOGIN_FILE'] = "#{Facter.value(:root_home)}/.mylogin.cnf"
-        mysql_raw(['--host=', system_database, '-e', text_of_sql].flatten.compact)
+        mysql_raw([system_database, '-e', text_of_sql].flatten.compact)
       else
-        mysql_raw([defaults_file, '--host=', system_database, '-e', text_of_sql].flatten.compact)
+        mysql_raw([defaults_file, system_database, '-e', text_of_sql].flatten.compact)
       end
     elsif type.eql? 'regular'
       if File.file?("#{Facter.value(:root_home)}/.mylogin.cnf")


### PR DESCRIPTION
Removing these as they were added back into the code by accident.
Original removal: https://github.com/puppetlabs/puppetlabs-mysql/pull/1064/files
Added back by: https://github.com/puppetlabs/puppetlabs-mysql/pull/1061/files