### PR TITLE
Fixed Changelog links for 8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
-## [v8.1.0](https://github.com/puppetlabs/puppetlabs-mysql/tree/v8.1.0) (2019-04-02)
+## [8.1.0](https://github.com/puppetlabs/puppetlabs-mysql/tree/8.1.0) (2019-04-02)
 
-[Full Changelog](https://github.com/puppetlabs/puppetlabs-mysql/compare/8.0.1...v8.1.0)
+[Full Changelog](https://github.com/puppetlabs/puppetlabs-mysql/compare/8.0.1...8.1.0)
 
 ### Added
 


### PR DESCRIPTION
The Changelog links assumed the version was tagged as `v8.1.0` while it is `8.1.0`