### PR TITLE
Allow multiple backupmethods

### DIFF
--- a/manifests/backup/mysqlbackup.pp
+++ b/manifests/backup/mysqlbackup.pp
@@ -101,12 +101,10 @@ class mysql::backup::mysqlbackup (
     mode    => '0600',
   }
 
-  file { 'mysqlbackupdir':
+  file { $backupdir:
     ensure => 'directory',
-    path   => $backupdir,
     mode   => $backupdirmode,
     owner  => $backupdirowner,
     group  => $backupdirgroup,
   }
-
 }

--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -70,12 +70,10 @@ class mysql::backup::mysqldump (
     content => template('mysql/mysqlbackup.sh.erb'),
   }
 
-  file { 'mysqlbackupdir':
+  file { $backupdir:
     ensure => 'directory',
-    path   => $backupdir,
     mode   => $backupdirmode,
     owner  => $backupdirowner,
     group  => $backupdirgroup,
   }
-
 }

--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -67,9 +67,8 @@ class mysql::backup::xtrabackup (
     require => Package[$xtrabackup_package_name],
   }
 
-  file { 'mysqlbackupdir':
+  file { $backupdir:
     ensure => 'directory',
-    path   => $backupdir,
     mode   => $backupdirmode,
     owner  => $backupdirowner,
     group  => $backupdirgroup,

--- a/spec/classes/mysql_server_backup_spec.rb
+++ b/spec/classes/mysql_server_backup_spec.rb
@@ -15,7 +15,7 @@ describe 'mysql::server::backup' do
       let(:default_params) do
         { 'backupuser'         => 'testuser',
           'backuppassword'     => 'testpass',
-          'backupdir'          => '/tmp',
+          'backupdir'          => '/tmp/mysql-backup',
           'backuprotate'       => '25',
           'delete_before_dump' => true,
           'execpath'           => '/usr/bin:/usr/sbin:/bin:/sbin:/opt/zimbra/bin',
@@ -65,8 +65,7 @@ describe 'mysql::server::backup' do
         }
 
         it {
-          is_expected.to contain_file('mysqlbackupdir').with(
-            path: '/tmp',
+          is_expected.to contain_file('/tmp/mysql-backup').with(
             ensure: 'directory',
           )
         }
@@ -113,10 +112,11 @@ describe 'mysql::server::backup' do
         end
 
         it {
-          is_expected.to contain_file('mysqlbackupdir').with(
-            path: '/tmp', ensure: 'directory',
-            mode: '0750', owner: 'testuser',
-            group: 'testgrp'
+          is_expected.to contain_file('/tmp/mysql-backup').with(
+            ensure: 'directory',
+            mode: '0750',
+            owner: 'testuser',
+            group: 'testgrp',
           )
         }
       end


### PR DESCRIPTION
At this Time, this is not possible because a dupplicate resource error
occurs. With this change it is possible to generate a daily xtrabackup
and also a weekly mysqldump for example.