### PR TITLE
Fix the contribution guide URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ Puppet modules on the Puppet Forge are open projects, and community contribution
 
 We want to keep it as easy as possible to contribute changes so that our modules work in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
 
-Check out our the complete [module contribution guide](https://docs.puppetlabs.com/forge/contributing.html).
+Check out our the complete [module contribution guide](https://puppet.com/docs/puppet/latest/contributing.html).
 
 ### Authors
 


### PR DESCRIPTION
While checking the README to verify my next PR is according to the contribution guidelines, I noticed that the link to the contribution guidelines is broken.

This PR rectifies that issue.