### PR TITLE
Manage directories on Ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -213,6 +213,7 @@ class mysql::params {
       $ssl_cert                = '/etc/mysql/server-cert.pem'
       $ssl_key                 = '/etc/mysql/server-key.pem'
       $tmpdir                  = '/tmp'
+      $managed_dirs            = ['tmpdir','basedir','datadir','innodb_data_home_dir','innodb_log_group_home_dir','innodb_undo_directory','innodb_tmpdir']
       # mysql::bindings
       $java_package_name   = 'libmysql-java'
       $perl_package_name   = 'libdbd-mysql-perl'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -213,7 +213,7 @@ class mysql::params {
       $ssl_cert                = '/etc/mysql/server-cert.pem'
       $ssl_key                 = '/etc/mysql/server-key.pem'
       $tmpdir                  = '/tmp'
-      $managed_dirs            = ['tmpdir','basedir','datadir','innodb_data_home_dir','innodb_log_group_home_dir','innodb_undo_directory','innodb_tmpdir']
+      $managed_dirs            = ['tmpdir','datadir','innodb_data_home_dir','innodb_log_group_home_dir','innodb_undo_directory','innodb_tmpdir']
       # mysql::bindings
       $java_package_name   = 'libmysql-java'
       $perl_package_name   = 'libdbd-mysql-perl'

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -7,7 +7,6 @@ class mysql::server::config {
 
   $options = $mysql::server::options
   $includedir = $mysql::server::includedir
-  $managed_dirs = $mysql::server::managed_dirs
 
   File {
     owner  => 'root',
@@ -15,7 +14,7 @@ class mysql::server::config {
     mode   => '0400',
   }
 
-  if $managed_dirs {
+  if $mysql::server::managed_dirs {
     $managed_dirs.each | $dir | {
       if $options['mysqld']["${dir}"] {
         file {$options['mysqld']["${dir}"]:

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -7,11 +7,25 @@ class mysql::server::config {
 
   $options = $mysql::server::options
   $includedir = $mysql::server::includedir
+  $managed_dirs = $mysql::server::managed_dirs
 
   File {
     owner  => 'root',
     group  => $mysql::server::root_group,
     mode   => '0400',
+  }
+
+  if $managed_dirs {
+    $managed_dirs.each | $dir | {
+      if $options['mysqld']["${dir}"] {
+        file {$options['mysqld']["${dir}"]:
+          ensure => directory,
+          mode   => '0755',
+          owner  => $options['mysqld']['user'],
+          group  => $options['mysqld']['user'],
+        }
+      }
+    }
   }
 
   if $includedir and $includedir != '' {


### PR DESCRIPTION
Specifying path for:
tmpdir
datadir
innodb_data_home_dir
innodb_log_group_home_dir
innodb_undo_directory	
innodb_tmpdir

will cause Puppet to fail at install with: `/usr/sbin/mysqld: Can't create/write to file '/var/lib/mysqltmp/ibJdUlGK' (Errcode: 13 - Permission denied)`

I created a simple check with the config options that contains a dir and make those directories.

Has been tested on:
Puppet 6.0.4 + Ubuntu 16.04LTS + Ubuntu 18.04LTS
