### PR TITLE
Enable module to not use default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ replicate-do-db = base2
 
 To implement version specific parameters, specify the version, such as [mysqld-5.5]. This allows one config for different versions of MySQL.
 
+If you don’t want to use the default configuration, you can also supply your options to the `$options` parameter instead of `$override_options`.
+Please note that `$options` and `$override_options` are mutually exclusive, you can only use one of them.
+
 ### Create a database
 
 To create a database with a user and some assigned privileges:

--- a/locales/puppetlabs-mysql.pot
+++ b/locales/puppetlabs-mysql.pot
@@ -77,6 +77,12 @@ msgid ""
 "future release."
 msgstr ""
 
+#. ./manifests/server.pp:122
+msgid ""
+"You can\'t specify $options and $override_options simultaneously, see the "
+"README section \'Customize server options\'!"
+msgstr ""
+
 #: ./lib/puppet/parser/functions/mysql_deepmerge.rb:22
 msgid ""
 "mysql_deepmerge(): wrong number of arguments (%{args_length}; must be at "

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -19,6 +19,8 @@
 #   Path to secret file containing temporary root password.
 # @param manage_config_file
 #   Whether the MySQL configuration file should be managed. Valid values are `true`, `false`. Defaults to `true`.
+# @param options
+#   A hash of options structured like the override_options, but not merged with the default options. Use this if you don’t want your options merged with the default options.
 # @param override_options
 #   Specifies override options to pass into MySQL. Structured like a hash in the my.cnf file:  See  above for usage details.
 # @param package_ensure
@@ -52,11 +54,11 @@
 # @param create_root_my_cnf
 #   Whether to create `/root/.my.cnf`. Valid values are `true`, `false`. Defaults to `true`. `create_root_my_cnf` allows creation of `/root/.my.cnf` independently of `create_root_user`. You can use this for a cluster setup with Galera where you want `/root/.my.cnf` to exist on all nodes.
 # @param users
-#   Optional hash of users to create, which are passed to [mysql_user](#mysql_user). 
+#   Optional hash of users to create, which are passed to [mysql_user](#mysql_user).
 # @param grants
-#   Optional hash of grants, which are passed to [mysql_grant](#mysql_grant). 
+#   Optional hash of grants, which are passed to [mysql_grant](#mysql_grant).
 # @param databases
-#   Optional hash of databases to create, which are passed to [mysql_database](#mysql_database). 
+#   Optional hash of databases to create, which are passed to [mysql_database](#mysql_database).
 # @param enabled
 #   _Deprecated_
 # @param manage_service
@@ -65,32 +67,33 @@
 #   This parameter no longer does anything. It exists only for backwards compatibility. See the `root_password` parameter above for details on changing the root password.
 #
 class mysql::server (
-  $config_file             = $mysql::params::config_file,
-  $includedir              = $mysql::params::includedir,
-  $install_options         = undef,
-  $install_secret_file     = $mysql::params::install_secret_file,
-  $manage_config_file      = $mysql::params::manage_config_file,
-  $override_options        = {},
-  $package_ensure          = $mysql::params::server_package_ensure,
-  $package_manage          = $mysql::params::server_package_manage,
-  $package_name            = $mysql::params::server_package_name,
-  $purge_conf_dir          = $mysql::params::purge_conf_dir,
-  $remove_default_accounts = false,
-  $restart                 = $mysql::params::restart,
-  $root_group              = $mysql::params::root_group,
-  $mysql_group             = $mysql::params::mysql_group,
-  $root_password           = $mysql::params::root_password,
-  $service_enabled         = $mysql::params::server_service_enabled,
-  $service_manage          = $mysql::params::server_service_manage,
-  $service_name            = $mysql::params::server_service_name,
-  $service_provider        = $mysql::params::server_service_provider,
-  $create_root_user        = $mysql::params::create_root_user,
-  $create_root_my_cnf      = $mysql::params::create_root_my_cnf,
-  $create_root_login_file  = $mysql::params::create_root_login_file,
-  $login_file              = $mysql::params::login_file,
-  $users                   = {},
-  $grants                  = {},
-  $databases               = {},
+                  $config_file             = $mysql::params::config_file,
+                  $includedir              = $mysql::params::includedir,
+                  $install_options         = undef,
+                  $install_secret_file     = $mysql::params::install_secret_file,
+                  $manage_config_file      = $mysql::params::manage_config_file,
+  Mysql::Options  $options                 = {},
+                  $override_options        = {},
+                  $package_ensure          = $mysql::params::server_package_ensure,
+                  $package_manage          = $mysql::params::server_package_manage,
+                  $package_name            = $mysql::params::server_package_name,
+                  $purge_conf_dir          = $mysql::params::purge_conf_dir,
+                  $remove_default_accounts = false,
+                  $restart                 = $mysql::params::restart,
+                  $root_group              = $mysql::params::root_group,
+                  $mysql_group             = $mysql::params::mysql_group,
+                  $root_password           = $mysql::params::root_password,
+                  $service_enabled         = $mysql::params::server_service_enabled,
+                  $service_manage          = $mysql::params::server_service_manage,
+                  $service_name            = $mysql::params::server_service_name,
+                  $service_provider        = $mysql::params::server_service_provider,
+                  $create_root_user        = $mysql::params::create_root_user,
+                  $create_root_my_cnf      = $mysql::params::create_root_my_cnf,
+                  $create_root_login_file  = $mysql::params::create_root_login_file,
+                  $login_file              = $mysql::params::login_file,
+                  $users                   = {},
+                  $grants                  = {},
+                  $databases               = {},
 
   # Deprecated parameters
   $enabled                 = undef,
@@ -115,8 +118,16 @@ class mysql::server (
     warning(translate('The `old_root_password` attribute is no longer used and will be removed in a future release.'))
   }
 
-  # Create a merged together set of options.  Rightmost hashes win over left.
-  $options = mysql::normalise_and_deepmerge($mysql::params::default_options, $override_options)
+  if ! empty($options) and ! empty($override_options) {
+    fail(translate('You can\'t specify $options and $override_options simultaneously, see the README section \'Customize server options\'!'))
+  }
+
+  # If override_options are set, create a merged together set of options. Rightmost hashes win over left.
+  # If options are set, just use them.
+  $_options = empty($options) ? {
+    true  => mysql::normalise_and_deepmerge($mysql::params::default_options, $override_options),
+    false => $options,
+  }
 
   Class['mysql::server::root_password'] -> Mysql::Db <| |>
 

--- a/manifests/server/binarylog.pp
+++ b/manifests/server/binarylog.pp
@@ -5,7 +5,7 @@
 #
 class mysql::server::binarylog {
 
-  $options = $mysql::server::options
+  $options = $mysql::server::_options
   $includedir = $mysql::server::includedir
 
   $logbin = pick($options['mysqld']['log-bin'], $options['mysqld']['log_bin'], false)

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -5,7 +5,7 @@
 #
 class mysql::server::config {
 
-  $options = $mysql::server::options
+  $options = $mysql::server::_options
   $includedir = $mysql::server::includedir
 
   File {

--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -1,19 +1,19 @@
-# @summary 
+# @summary
 #   Builds initial databases on installation.
 #
 # @api private
 #
 class mysql::server::installdb {
-  $options = $mysql::server::options
+  $options = $mysql::server::_options
 
   if $mysql::server::package_manage {
 
     # Build the initial databases.
-    $mysqluser = $mysql::server::options['mysqld']['user']
-    $datadir = $mysql::server::options['mysqld']['datadir']
-    $basedir = $mysql::server::options['mysqld']['basedir']
+    $mysqluser = $mysql::server::_options['mysqld']['user']
+    $datadir = $mysql::server::_options['mysqld']['datadir']
+    $basedir = $mysql::server::_options['mysqld']['basedir']
     $config_file = $mysql::server::config_file
-    $log_error = $mysql::server::options['mysqld']['log-error']
+    $log_error = $mysql::server::_options['mysqld']['log-error']
 
     if $mysql::server::manage_config_file and $config_file != $mysql::params::config_file {
       $_config_file=$config_file

--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -5,7 +5,7 @@
 #
 class mysql::server::root_password {
 
-  $options = $mysql::server::options
+  $options = $mysql::server::_options
   $secret_file = $mysql::server::install_secret_file
   $login_file = $mysql::server::login_file
 

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -4,7 +4,7 @@
 # @api private
 #
 class mysql::server::service {
-  $options = $mysql::server::options
+  $options = $mysql::server::_options
 
   if $mysql::server::real_service_manage {
     if $mysql::server::real_service_enabled {

--- a/spec/classes/mysql_server_spec.rb
+++ b/spec/classes/mysql_server_spec.rb
@@ -34,6 +34,31 @@ describe 'mysql::server' do
         it { is_expected.not_to contain_service('mysqld') }
       end
 
+      context 'configuration options' do
+        context 'when specifying both $override_options and $options' do
+          let(:params) do
+            {
+              override_options: { 'mysqld' => { 'datadir' => '/tmp' } },
+              options: { 'mysqld' => { 'max_allowed_packet' => '12M' } },
+            }
+          end
+
+          it { is_expected.to compile.and_raise_error(%r{You can't specify \$options and \$override_options simultaneously, see the README section 'Customize server options'!}) }
+        end
+
+        context 'when specifying $options' do
+          let(:params) do
+            {
+              options: { 'mysqld' => { 'datadir' => '/tmp' } },
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_mysql_datadir('/tmp') }
+          it { is_expected.not_to contain_mysql_bind_addr('127.0.0.1') }
+        end
+      end
+
       context 'mysql::server::install' do
         it 'contains the package by default' do
           is_expected.to contain_package('mysql-server').with(ensure: :present)

--- a/types/options.pp
+++ b/types/options.pp
@@ -1,0 +1,4 @@
+type Mysql::Options = Hash[
+  String,
+  Hash,
+]


### PR DESCRIPTION
This PR enables you to either use:

* `override_options` as it was the case previously. Those options are merged with the default options
* `options`. Those options won’t be merged with the default options.

Both are mutually exclusive in usage, meaning that one of them has to be empty.

I wrote this PR because we want to get rid of the version specific configuration options as it makes our workflows for changes of default parameters in our profiles easier.

I wrote it like this so that it has clean semantics: 

* override_options tells you that defaults are overridden
* options tells you that options will be set

Therefore, this PR is fully backwards compatible.