### PR TITLE
Fix binarylog by allowing users to specify managed directories

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -103,6 +103,7 @@ class mysql::params {
       $ssl_cert                = '/etc/mysql/server-cert.pem'
       $ssl_key                 = '/etc/mysql/server-key.pem'
       $tmpdir                  = '/tmp'
+      $managed_dirs            = undef
       # mysql::bindings
       $perl_package_name       = 'perl-DBD-MySQL'
       $php_package_name        = 'php-mysql'
@@ -172,6 +173,7 @@ class mysql::params {
       $ssl_cert            = '/etc/mysql/server-cert.pem'
       $ssl_key             = '/etc/mysql/server-key.pem'
       $tmpdir              = '/tmp'
+      $managed_dirs        = undef
       # mysql::bindings
       $java_package_name   = 'mysql-connector-java'
       $perl_package_name   = 'perl-DBD-mysql'
@@ -220,6 +222,8 @@ class mysql::params {
       $ssl_cert                = '/etc/mysql/server-cert.pem'
       $ssl_key                 = '/etc/mysql/server-key.pem'
       $tmpdir                  = '/tmp'
+      $managed_dirs            = ['tmpdir','basedir','datadir','innodb_data_home_dir','innodb_log_group_home_dir','innodb_undo_directory','innodb_tmpdir']
+
       # mysql::bindings
       if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '10') >= 0 {
         $java_package_name   = 'libmariadb-java'
@@ -267,6 +271,7 @@ class mysql::params {
       $ssl_cert                = '/etc/mysql/server-cert.pem'
       $ssl_key                 = '/etc/mysql/server-key.pem'
       $tmpdir                  = '/tmp'
+      $managed_dirs            = undef
       # mysql::bindings
       $java_package_name       = 'mysql-connector-java'
       $perl_package_name       = 'perl-dbd-mysql'
@@ -294,6 +299,7 @@ class mysql::params {
       $ssl_cert            = '/etc/mysql/server-cert.pem'
       $ssl_key             = '/etc/mysql/server-key.pem'
       $tmpdir              = '/tmp'
+      $managed_dirs        = undef
       # mysql::bindings
       $java_package_name   = 'dev-java/jdbc-mysql'
       $perl_package_name   = 'dev-perl/DBD-mysql'
@@ -321,6 +327,7 @@ class mysql::params {
       $ssl_cert            = undef
       $ssl_key             = undef
       $tmpdir              = '/tmp'
+      $managed_dirs        = undef
       # mysql::bindings
       $java_package_name   = 'databases/mysql-connector-java'
       $perl_package_name   = 'p5-DBD-mysql'
@@ -351,6 +358,7 @@ class mysql::params {
       $ssl_cert            = undef
       $ssl_key             = undef
       $tmpdir              = '/tmp'
+      $managed_dirs        = undef
       # mysql::bindings
       $java_package_name   = undef
       $perl_package_name   = 'p5-DBD-mysql'
@@ -377,6 +385,7 @@ class mysql::params {
       $ssl_cert            = undef
       $ssl_key             = undef
       $tmpdir              = '/tmp'
+      $managed_dirs        = undef
       # mysql::bindings
       $java_package_name   = undef
       $perl_package_name   = undef
@@ -408,6 +417,7 @@ class mysql::params {
           $ssl_cert            = '/etc/mysql/server-cert.pem'
           $ssl_key             = '/etc/mysql/server-key.pem'
           $tmpdir              = '/tmp'
+          $managed_dirs        = undef
           $java_package_name   = undef
           $perl_package_name   = 'perl-dbd-mysql'
           $php_package_name    = 'php7-mysqlnd'
@@ -435,6 +445,7 @@ class mysql::params {
           $ssl_cert            = '/etc/mysql/server-cert.pem'
           $ssl_key             = '/etc/mysql/server-key.pem'
           $tmpdir              = '/tmp'
+          $managed_dirs        = undef
           # mysql::bindings
           $java_package_name   = 'mysql-connector-java'
           $perl_package_name   = 'perl-DBD-MySQL'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -141,7 +141,7 @@ class mysql::server (
 
   include '::mysql::server::config'
   include '::mysql::server::install'
-  include '::mysql::server::binarylog'
+  include '::mysql::server::managed_dirs'
   include '::mysql::server::installdb'
   include '::mysql::server::service'
   include '::mysql::server::root_password'
@@ -164,7 +164,7 @@ class mysql::server (
   Anchor['mysql::server::start']
   -> Class['mysql::server::config']
   -> Class['mysql::server::install']
-  -> Class['mysql::server::binarylog']
+  -> Class['mysql::server::managed_dirs']
   -> Class['mysql::server::installdb']
   -> Class['mysql::server::service']
   -> Class['mysql::server::root_password']

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -42,7 +42,7 @@ class mysql::server::config {
       if ( $dir and $dir != '/usr' and $dir != '/tmp' ) {
         exec {"${entry}-managed_dir-mkdir":
           command => "/bin/mkdir -p ${dir}",
-          creates => $dir,
+          unless  => "/usr/bin/dpkg -s ${mysql::server::package_name}",
           notify  =>  Exec["${entry}-managed_dir-chmod"],
         }
         exec {"${entry}-managed_dir-chmod":

--- a/manifests/server/managed_dirs.pp
+++ b/manifests/server/managed_dirs.pp
@@ -30,8 +30,8 @@ class mysql::server::managed_dirs {
   if $logbin {
     $logbindir = dirname($logbin)
 
-    #Stop puppet from managing directory if just a filename/prefix is specified
-    if $logbindir != '.' {
+    #Stop puppet from managing directory if just a filename/prefix is specified or is datadir
+    if ($logbindir != '.' and $logbindir != $mysql::server::options['mysqld']['datadir'] ) {
       file { $logbindir:
         ensure => directory,
         mode   => '0700',

--- a/manifests/server/managed_dirs.pp
+++ b/manifests/server/managed_dirs.pp
@@ -17,7 +17,7 @@ class mysql::server::managed_dirs {
         file {"${entry}-managed_dir":
           ensure => directory,
           path   => $dir,
-          mode   => '0755',
+          mode   => '0700',
           owner  => $options['mysqld']['user'],
           group  => $options['mysqld']['user'],
         }
@@ -34,7 +34,7 @@ class mysql::server::managed_dirs {
     if $logbindir != '.' {
       file { $logbindir:
         ensure => directory,
-        mode   => '0755',
+        mode   => '0700',
         owner  => $options['mysqld']['user'],
         group  => $options['mysqld']['user'],
       }

--- a/manifests/server/managed_dirs.pp
+++ b/manifests/server/managed_dirs.pp
@@ -3,10 +3,27 @@
 #
 # @api private
 #
-class mysql::server::binarylog {
+class mysql::server::managed_dirs {
 
   $options = $mysql::server::_options
   $includedir = $mysql::server::includedir
+  $managed_dirs = $mysql::server::managed_dirs
+
+  #Debian: Fix permission on directories
+  if $managed_dirs {
+    $managed_dirs.each | $entry | {
+      $dir = $options['mysqld']["${entry}"]
+      if ( $dir and $dir != '/usr' and $dir != '/tmp' ) {
+        file {"${entry}-managed_dir":
+          ensure => directory,
+          path   => $dir,
+          mode   => '0755',
+          owner  => $options['mysqld']['user'],
+          group  => $options['mysqld']['user'],
+        }
+      }
+    }
+  }
 
   $logbin = pick($options['mysqld']['log-bin'], $options['mysqld']['log_bin'], false)
 

--- a/manifests/server/managed_dirs.pp
+++ b/manifests/server/managed_dirs.pp
@@ -11,6 +11,7 @@ class mysql::server::managed_dirs {
 
   #Debian: Fix permission on directories
   if $managed_dirs {
+    $managed_dirs_path = $managed_dirs.map |$path| { $options['mysqld']["${path}"] }
     $managed_dirs.each | $entry | {
       $dir = $options['mysqld']["${entry}"]
       if ( $dir and $dir != '/usr' and $dir != '/tmp' ) {
@@ -30,8 +31,8 @@ class mysql::server::managed_dirs {
   if $logbin {
     $logbindir = dirname($logbin)
 
-    #Stop puppet from managing directory if just a filename/prefix is specified or is datadir
-    if ($logbindir != '.' and $logbindir != $mysql::server::options['mysqld']['datadir'] ) {
+    #Stop puppet from managing directory if just a filename/prefix is specified or is not already managed
+    if ($logbindir != '.' and !($logbindir in $managed_dirs_path)) {
       file { $logbindir:
         ensure => directory,
         mode   => '0700',


### PR DESCRIPTION
On Ubuntu/Debian Puppet will fail if specifying path for:
```
tmpdir
basedir
datadir
innodb_data_home_dir
innodb_log_group_home_dir
innodb_undo_directory
innodb_tmpdir
```
deb packages starts mysql service automatically after install with the config provided by Puppet but will fail if the directory has not been created. Creating the directory should be part of the installation process.
  
A solution, less than ideal, is to create the folders (exec) and make them world readable. Then after the package has been installed (and user created) is to fix the permissions and ownership.

If anyone can come up with a more elegant solution...


Has been tested on:
Puppet 6.0.4 + Ubuntu 16.04LTS
