### PR TITLE
(MODULES-6875,MODULES-7487) - Fix mariadb mysql_user password idempotency

### DIFF
--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -81,6 +81,14 @@ class Puppet::Provider::Mysql < Puppet::Provider
     self.class.newer_than(forks_versions)
   end
 
+  def self.older_than(forks_versions)
+    forks_versions.keys.include?(mysqld_type) && Puppet::Util::Package.versioncmp(mysqld_version, forks_versions[mysqld_type]) < 0
+  end
+
+  def older_than(forks_versions)
+    self.class.older_than(forks_versions)
+  end
+
   def defaults_file
     self.class.defaults_file
   end

--- a/lib/puppet/provider/mysql_user/mysql.rb
+++ b/lib/puppet/provider/mysql_user/mysql.rb
@@ -14,7 +14,10 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
         ## Default ...
         # rubocop:disable Metrics/LineLength
         query = "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{name}'"
-      elsif newer_than('mysql' => '5.7.6', 'percona' => '5.7.6', 'mariadb' => '10.2.16')
+      elsif newer_than('mysql' => '5.7.6', 'percona' => '5.7.6') ||
+            # https://jira.mariadb.org/browse/MDEV-16238 https://jira.mariadb.org/browse/MDEV-16774
+            (newer_than('mariadb' => '10.2.16') && older_than('mariadb' => '10.2.19')) ||
+            (newer_than('mariadb' => '10.3.8') && older_than('mariadb' => '10.3.11'))
         query = "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, AUTHENTICATION_STRING, PLUGIN FROM mysql.user WHERE CONCAT(user, '@', host) = '#{name}'"
       else
         query = "SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = '#{name}'"


### PR DESCRIPTION
The change introduced in mariadb 10.2.16 (and 10.3.8) where:

> the `SET PASSWORD` command stores user passwords
in the `mysql_native_password` plugin `authentication_string` instead of
in the `password` column

was addressed in https://github.com/puppetlabs/puppetlabs-mysql/pull/1135

This behaviour was short-lived.  In 10.2.19 and 10.3.11 the old
behaviour was restored.

> The fix in the commit dd6e74c62a2 made sure that the password field is always set, because that was the original issue that broke third-party tools.

See https://jira.mariadb.org/browse/MDEV-16774

This commit is based on
https://tickets.puppetlabs.com/browse/MODULES-6875?focusedCommentId=645260&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-645260