### PR TITLE
Allow backup::mysqldump::time to accept monthday, month, weekday

### DIFF
--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -69,12 +69,15 @@ class mysql::backup::mysqldump (
   }
 
   cron { 'mysql-backup':
-    ensure  => $ensure,
-    command => '/usr/local/sbin/mysqlbackup.sh',
-    user    => 'root',
-    hour    => $time[0],
-    minute  => $time[1],
-    require => File['mysqlbackup.sh'],
+    ensure   => $ensure,
+    command  => '/usr/local/sbin/mysqlbackup.sh',
+    user     => 'root',
+    hour     => $time[0],
+    minute   => $time[1],
+    monthday => $time[2],
+    month    => $time[3],
+    weekday  => $time[4],
+    require  => File['mysqlbackup.sh'],
   }
 
   file { 'mysqlbackup.sh':

--- a/spec/classes/mysql_backup_mysqldump_spec.rb
+++ b/spec/classes/mysql_backup_mysqldump_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe 'mysql::backup::mysqldump' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:pre_condition) do
+        <<-EOF
+          class { 'mysql::server': }
+        EOF
+      end
+      let(:facts) do
+        facts.merge(root_home: '/root')
+      end
+
+      let(:default_params) do
+        { 'backupuser'         => 'testuser',
+          'backuppassword'     => 'testpass',
+          'backupdir'          => '/tmp/mysql-backup',
+          'backuprotate'       => '25',
+          'delete_before_dump' => true,
+          'execpath'           => '/usr/bin:/usr/sbin:/bin:/sbin:/opt/zimbra/bin',
+          'maxallowedpacket'   => '1M' }
+      end
+
+      context 'with time included' do
+        let(:params) do
+          { time: [23, 59, 30, 12, 6] }.merge(default_params)
+        end
+
+        it {
+          is_expected.to contain_cron('mysql-backup').with(
+            hour: 23,
+            minute: 59,
+            monthday: 30,
+            month: 12,
+            weekday: 6,
+          )
+        }
+      end
+
+      context 'with defaults' do
+        let(:params) { default_params }
+
+        it {
+          is_expected.to contain_cron('mysql-backup').with(
+            command: '/usr/local/sbin/mysqlbackup.sh',
+            ensure: 'present',
+            hour: 23,
+            minute: 5,
+          )
+        }
+      end
+    end
+  end
+  # rubocop:enable RSpec/NestedGroups
+end


### PR DESCRIPTION
This adds the missing time parameters to backup::mysqldump, thereby
allowing for backup frequency other than daily. It does not change
the other providers, and therefore does not change the documentation
of server::backup.