### PR TITLE
Add note about default behavior of server backup

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -740,9 +740,9 @@ Default value: `false`
 
 Data type: `Any`
 
-Databases to backup (if using xtrabackup provider).
+Databases to backup (required if using xtrabackup provider).
 
-Default value: []
+Default value: `[]` (backs up all databases)
 
 ##### `file_per_database`
 


### PR DESCRIPTION
Both mysqldump and mysqlbackup providers by default back up all databases in the database (i.e. when an empty array is specfied).
This patch documents that behavior.
See templates/xtrabackup.sh.erb and templates/mysqlbackup.sh.erb