### PR TITLE
 Move requires in installdb from log-error file to mysql_datadir

### DIFF
--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -27,7 +27,6 @@ class mysql::server::installdb {
       owner   => $mysqluser,
       group   => $::mysql::server::mysql_group,
       mode    => 'u+rw',
-      require => Mysql_datadir[ $datadir ],
     }
   }
 
@@ -38,6 +37,7 @@ class mysql::server::installdb {
       user                => $mysqluser,
       log_error           => $log_error,
       defaults_extra_file => $_config_file,
+      require             => File[$options['mysqld']['log-error']],
     }
 
     if $mysql::server::restart {


### PR DESCRIPTION
On FreeBSD I found that I had to ensure that the `log-error` file was in place before the `mysql_datadir` could be run.  The dependency was in reverse but I don't really see a need for that to be the case.  Maybe someone could test with other OSes but for us this fixed the issue where we couldn't get this module to work with Mysql Server 5.7 on FreeBSD 12p8