### PR TITLE
(MODULES-9637) Fix Scientific Linux 6 tests can't find mysql

### DIFF
--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 def pre_run
-  apply_manifest("class { 'mysql::server': root_password => 'password' }", catch_failures: true)
+  apply_manifest("class { 'mysql::server': root_password => 'password' }")
 end
 
 def mysql_version


### PR DESCRIPTION
On Scientific Linux 6, certain tests hit errors when checking the
mysql_version in which they were unable to find the mysql binary, even
after it was installed.

This commit includes a minor change to the mysql_version helper which
appears to address the issue.

![Screen Shot 2019-07-30 at 17 02 02](https://user-images.githubusercontent.com/24768276/62146268-f1c8b780-b2ec-11e9-950c-7c1fea86f5d1.png)

