### PR TITLE
Fix/fix dependency issue in freebsd with log error file creation from 10.0.0

### DIFF
--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -23,11 +23,11 @@ class mysql::server::installdb {
 
   if $options['mysqld']['log-error'] {
     file { $options['mysqld']['log-error']:
-      ensure  => present,
-      owner   => $mysqluser,
-      group   => $::mysql::server::mysql_group,
-      mode    => 'u+rw',
-      require => Mysql_datadir[ $datadir ],
+      ensure => present,
+      owner  => $mysqluser,
+      group  => $::mysql::server::mysql_group,
+      mode   => 'u+rw',
+      before => Mysql_datadir[ $datadir ],
     }
   }
 


### PR DESCRIPTION
Change relationship between the log-error file and the mysql datadir.  In FreeBSD this file needs to be present before trying to create the datadir and running the initdb step but will only be created if the option exists.

We should probably also have a require on the log-error file resource for `Package[ $mysql::server::package_name ]` so that the `user` and `group` are present, however, this is probably ensured by the chaining elsewhere.