### PR TITLE
Fix errors for /bin/sh with the xtrabackup cron

### DIFF
--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -63,7 +63,7 @@ class mysql::backup::xtrabackup (
 
   $daily_cron_data = ($incremental_backups) ? {
     true  => {
-      'directories' => "--incremental-basedir=${backupdir} --target-dir=${backupdir}/$(date +%F_%H-%M-%S)",
+      'directories' => "--incremental-basedir=${backupdir} --target-dir=${backupdir}/$(date +\\%F_\\%H-\\%M-\\%S)",
       'weekday'     => '1-6',
     },
     false => {

--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -63,7 +63,7 @@ class mysql::backup::xtrabackup (
 
   $daily_cron_data = ($incremental_backups) ? {
     true  => {
-      'directories' => "--incremental-basedir=${backupdir} --target-dir=${backupdir}/`date +%F_%H-%M-%S`",
+      'directories' => "--incremental-basedir=${backupdir} --target-dir=${backupdir}/$(date +%F_%H-%M-%S)",
       'weekday'     => '1-6',
     },
     false => {

--- a/spec/classes/mysql_backup_xtrabackup_spec.rb
+++ b/spec/classes/mysql_backup_xtrabackup_spec.rb
@@ -44,7 +44,7 @@ describe 'mysql::backup::xtrabackup' do
           is_expected.to contain_cron('xtrabackup-daily')
             .with(
               ensure: 'present',
-              command: '/usr/local/sbin/xtrabackup.sh --incremental-basedir=/tmp --target-dir=/tmp/$(date +%F_%H-%M-%S) --backup',
+              command: '/usr/local/sbin/xtrabackup.sh --incremental-basedir=/tmp --target-dir=/tmp/$(date +\%F_\%H-\%M-\%S) --backup',
               user: 'root',
               hour: '23',
               minute: '5',
@@ -101,7 +101,7 @@ describe 'mysql::backup::xtrabackup' do
           is_expected.to contain_cron('xtrabackup-daily')
             .with(
               ensure: 'present',
-              command: '/usr/local/sbin/xtrabackup.sh --incremental-basedir=/tmp --target-dir=/tmp/$(date +%F_%H-%M-%S) --backup --skip-ssl',
+              command: '/usr/local/sbin/xtrabackup.sh --incremental-basedir=/tmp --target-dir=/tmp/$(date +\%F_\%H-\%M-\%S) --backup --skip-ssl',
               user: 'root',
               hour: '23',
               minute: '5',

--- a/spec/classes/mysql_backup_xtrabackup_spec.rb
+++ b/spec/classes/mysql_backup_xtrabackup_spec.rb
@@ -44,7 +44,7 @@ describe 'mysql::backup::xtrabackup' do
           is_expected.to contain_cron('xtrabackup-daily')
             .with(
               ensure: 'present',
-              command: '/usr/local/sbin/xtrabackup.sh --incremental-basedir=/tmp --target-dir=/tmp/`date +%F_%H-%M-%S` --backup',
+              command: '/usr/local/sbin/xtrabackup.sh --incremental-basedir=/tmp --target-dir=/tmp/$(date +%F_%H-%M-%S) --backup',
               user: 'root',
               hour: '23',
               minute: '5',
@@ -101,7 +101,7 @@ describe 'mysql::backup::xtrabackup' do
           is_expected.to contain_cron('xtrabackup-daily')
             .with(
               ensure: 'present',
-              command: '/usr/local/sbin/xtrabackup.sh --incremental-basedir=/tmp --target-dir=/tmp/`date +%F_%H-%M-%S` --backup --skip-ssl',
+              command: '/usr/local/sbin/xtrabackup.sh --incremental-basedir=/tmp --target-dir=/tmp/$(date +%F_%H-%M-%S) --backup --skip-ssl',
               user: 'root',
               hour: '23',
               minute: '5',


### PR DESCRIPTION
Using Debian's default shell for cron (`/bin/sh`), the xtrabackup incremental cron was failing for me with an error message like:

```
Cron <root@foo> /usr/local/sbin/xtrabackup.sh --incremental-basedir=/foo/mysql-backups --target-dir=/foo/mysql-backups/`date +
/bin/sh: 1: Syntax error: EOF in backquote substitution
```

This is caused by  percent-signs (`%`) not being escaped. With `/bin/sh`, percent-signs (`%`) in the command, unless escaped with backslash \, will be changed into newline characters, and all data after the first % will be sent to the command as standard input. Thus the EOF error.

I also made another small commit to convert backtiks (`) into $(), which is the prefered POSIX way. https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xcu_chap02.html#tag_23_02_06_03 has a good writeup on it.

Happy to make modifications if required.
