### PR TITLE
No package under FreeBSD

### DIFF
--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -30,9 +30,11 @@ class mysql::backup::mysqldump (
   $mysqlbackupdir_target    = undef,
 ) inherits mysql::params {
 
-  if $backupcompress {
-    ensure_packages(['bzip2'])
-    Package['bzip2'] -> File['mysqlbackup.sh']
+  unless $::osfamily == 'FreeBSD' {
+    if $backupcompress {
+      ensure_packages(['bzip2'])
+      Package['bzip2'] -> File['mysqlbackup.sh']
+    }
   }
 
   mysql_user { "${backupuser}@localhost":


### PR DESCRIPTION
  With FreeBSD bzip2 as part of the system, so it's not need to install
  bzip2 package, and because this package doesn't exist the class go in
  error if it try to install that package.

I put the change inside the mysqldump.pp I'm pretty sure that's not the correct way to do it (should be inside params.pp) but well I think it's the only os who have this difference, and...soon we going to use some hiera.yaml instead of this params.pp :wink: