### PR TITLE
(MODULES-10023) expose $incremental_backups parameter

### DIFF
--- a/manifests/backup/mysqlbackup.pp
+++ b/manifests/backup/mysqlbackup.pp
@@ -27,6 +27,7 @@ class mysql::backup::mysqlbackup (
   $postscript               = false,
   $execpath                 = '/usr/bin:/usr/sbin:/bin:/sbin',
   $optional_args            = [],
+  $incremental_backups      = false,
 ) inherits mysql::params {
 
   mysql_user { "${backupuser}@localhost":

--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -28,6 +28,7 @@ class mysql::backup::mysqldump (
   $optional_args            = [],
   $mysqlbackupdir_ensure    = 'directory',
   $mysqlbackupdir_target    = undef,
+  $incremental_backups      = false,
 ) inherits mysql::params {
 
   unless $::osfamily == 'FreeBSD' {

--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -48,6 +48,8 @@
 #   Dump stored routines (procedures and functions) from dumped databases when doing a `file_per_database` backup.
 # @param include_triggers
 #   Dump triggers for each dumped table when doing a `file_per_database` backup.
+# @param incremental_backups
+#   A flag to activate/deactivate incremental backups. Currently only supported by the xtrabackup provider.
 # @param ensure
 # @param time
 #   An array of two elements to set the backup time. Allows ['23', '5'] (i.e., 23:05) or ['3', '45'] (i.e., 03:45) for HH:MM times.
@@ -88,6 +90,7 @@ class mysql::server::backup (
   $provider                 = 'mysqldump',
   $maxallowedpacket         = '1M',
   $optional_args            = [],
+  $incremental_backups      = true,
 ) inherits mysql::params {
 
   if $prescript and $provider =~ /(mysqldump|mysqlbackup)/ {
@@ -120,6 +123,7 @@ class mysql::server::backup (
       'execpath'                 => $execpath,
       'maxallowedpacket'         => $maxallowedpacket,
       'optional_args'            => $optional_args,
+      'incremental_backups'      => $incremental_backups,
     }
   })
 }


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/MODULES-10023

In #1188 a new parameter `$incremental_backups` was added to the private class `mysql::backup::xtrabackup`.

However, in order to be actually useful and for more convenience this parameter should also be added to the parent class `mysql::server::backup` from which the private class is usually called with the appropiate parameters.