### PR TITLE
(MODULES-10114) Confine fact for only when mysql is in PATH

### DIFF
--- a/lib/facter/mysql_version.rb
+++ b/lib/facter/mysql_version.rb
@@ -1,4 +1,5 @@
 Facter.add('mysql_version') do
+  confine { Facter::Core::Execution.which('mysql') }
   setcode do
     mysql_ver = Facter::Util::Resolution.exec('mysql --version')
     mysql_ver.match(%r{\d+\.\d+\.\d+})[0] if mysql_ver


### PR DESCRIPTION
The custom fact should only run when mysql can be found within the PATH environment variable.