### PR TITLE
Unconditionally set show_diff to false for .my.cnf (remove puppet3 workaround)

### DIFF
--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -34,15 +34,12 @@ class mysql::server::root_password {
 
   if $mysql::server::create_root_my_cnf == true and $mysql::server::root_password != 'UNSET' {
     file { "${::root_home}/.my.cnf":
-      content => template('mysql/my.cnf.pass.erb'),
-      owner   => 'root',
-      mode    => '0600',
+      content   => template('mysql/my.cnf.pass.erb'),
+      owner     => 'root',
+      mode      => '0600',
+      show_diff => false,
     }
 
-    # show_diff was added with puppet 3.0
-    if versioncmp($::puppetversion, '3.0') >= 0 {
-      File["${::root_home}/.my.cnf"] { show_diff => false }
-    }
     if $mysql::server::create_root_user == true {
       Mysql_user['root@localhost'] -> File["${::root_home}/.my.cnf"]
     }


### PR DESCRIPTION
The show_diff parameter of the file resource was added in Puppet 3.0.
At that time, the module supported previous versions of Puppet so only
set it to false if Puppet was ≥ 3.0.

As of today, the mysql module require Puppet ≥ 5.5.10, so all supported
versions of Puppet support the show_diff parameter.

Remove the conditional logic and always set show_diff to false.