### PR TITLE
Fix test suite when mysqld is not installed

### DIFF
--- a/spec/unit/facter/mysqld_version_spec.rb
+++ b/spec/unit/facter/mysqld_version_spec.rb
@@ -8,6 +8,7 @@ describe Facter::Util::Fact.to_s do
   describe 'mysqld_version' do
     context 'with value' do
       before :each do
+        Facter::Core::Execution.stubs(:which).with('mysqld').returns('/usr/sbin/mysqld')
         Facter::Util::Resolution.stubs(:exec).with('mysqld --no-defaults -V 2>/dev/null').returns('mysqld  Ver 5.5.49-37.9 for Linux on x86_64 (Percona Server (GPL), Release 37.9, Revision efa0073)')
       end
       it {


### PR DESCRIPTION
The fact being confined, no value was returned when mysqld was not
found.  Also stub the which method to fix the problem.