### PR TITLE
create the folder for the logfile, not the logfile itself

### DIFF
--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -1,4 +1,4 @@
-# @summary 
+# @summary
 #   Builds initial databases on installation.
 #
 # @api private
@@ -21,15 +21,27 @@ class mysql::server::installdb {
       $_config_file=undef
     }
 
-  if $options['mysqld']['log-error'] {
-    file { $options['mysqld']['log-error']:
-      ensure => present,
-      owner  => $mysqluser,
-      group  => $::mysql::server::mysql_group,
-      mode   => 'u+rw',
-      before => Mysql_datadir[ $datadir ],
+    # create the folder for the logfile
+    if dirname($options['mysqld']['log-error']) or $options['mysqld_safe']['log-error']{
+      file { dirname($options['mysqld']['log-error']):
+        ensure => present,
+        owner  => $mysqluser,
+        group  => $::mysql::server::mysql_group,
+        mode   => 'u+rw',
+        before => Mysql_datadir[ $datadir ],
+      }
     }
-  }
+
+    # create the folder for the pid-file
+    if $options['mysqld']['pid-file'] {
+      file { dirname($options['mysqld']['pid-file']):
+        ensure => present,
+        owner  => $mysqluser,
+        group  => $::mysql::server::mysql_group,
+        mode   => 'u+rw',
+        before => Mysql_datadir[ $datadir ],
+      }
+    }
 
     mysql_datadir { $datadir:
       ensure              => 'present',

--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -24,7 +24,7 @@ class mysql::server::installdb {
     # create the folder for the logfile
     if dirname($options['mysqld']['log-error']) or $options['mysqld_safe']['log-error']{
       file { dirname($options['mysqld']['log-error']):
-        ensure => present,
+        ensure => directory,
         owner  => $mysqluser,
         group  => $::mysql::server::mysql_group,
         mode   => 'u+rw',
@@ -35,7 +35,7 @@ class mysql::server::installdb {
     # create the folder for the pid-file
     if $options['mysqld']['pid-file'] {
       file { dirname($options['mysqld']['pid-file']):
-        ensure => present,
+        ensure => directory,
         owner  => $mysqluser,
         group  => $::mysql::server::mysql_group,
         mode   => 'u+rw',


### PR DESCRIPTION
i have the manifest for my server:

```
  -> class { '::mysql::server':
    package_name            => 'mariadb-server',
    package_ensure          => latest,
    remove_default_accounts => true,
    root_password           => '<password>',
    restart                 => true,
    override_options        => {
      mysqld => {
        log-error => '/var/log/mariadb/mariadb.log',
        pid-file  => '/var/run/mariadb/mariadb.pid',
      },
      mysqld_safe => {
        log-error => '/var/log/mariadb/mariadb.log',
      },
    }
  }
```

and when running the puppet agent i get this error

```
Error: Could not set 'present' on ensure: No such file or directory @ rb_sysopen - /var/log/mariadb/mariadb.log (file: /etc/puppetlabs/code/environments/linuxtesting/modules/mysql/manifests/server/installdb.pp, line: 25)
Error: Could not set 'present' on ensure: No such file or directory @ rb_sysopen - /var/log/mariadb/mariadb.log (file: /etc/puppetlabs/code/environments/linuxtesting/modules/mysql/manifests/server/installdb.pp, line: 25)
```

It seems like the file "/var/log/mariadb/mariadb.log" cannot be created.(because the folder "/var/log/mariadb/" does not exist.

But that is not what we want, we want to create the folder "/var/log/mariadb/"
so in "installdb" i now use the "dirname" to get the foldername instead of the filename

`file { dirname($options['mysqld']['pid-file']):`

