### PR TITLE
Fix java and ruby binding packages for Debian 10

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -214,7 +214,11 @@ class mysql::params {
       $ssl_key                 = '/etc/mysql/server-key.pem'
       $tmpdir                  = '/tmp'
       # mysql::bindings
-      $java_package_name   = 'libmysql-java'
+      if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '10') >= 0 {
+        $java_package_name   = 'libmariadb-java'
+      } else {
+        $java_package_name   = 'libmysql-java'
+      }
       $perl_package_name   = 'libdbd-mysql-perl'
       if  ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0) or
           ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9') >= 0) {
@@ -227,6 +231,7 @@ class mysql::params {
       $ruby_package_name   = $::lsbdistcodename ? {
         'jessie'           => 'ruby-mysql',
         'stretch'          => 'ruby-mysql2',
+        'buster'           => 'ruby-mysql2',
         'trusty'           => 'ruby-mysql',
         'xenial'           => 'ruby-mysql',
         'bionic'           => 'ruby-mysql2',


### PR DESCRIPTION
Debian 10 does not have `libmysql-java`, it's actually `libmariadb-java`. Also the Ruby package name matches Debian 9.