### PR TITLE
Use provision job that excludes rpm --rebuilddb command

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,8 @@ fixtures:
     "cron_core": "https://github.com/puppetlabs/puppetlabs-cron_core.git"
     "facts": "https://github.com/puppetlabs/puppetlabs-facts.git"
     "puppet_agent": "https://github.com/puppetlabs/puppetlabs-puppet_agent.git"
-    "provision": "https://github.com/puppetlabs/provision.git"
+    "provision": 
+      repo: "https://github.com/puppetlabs/provision.git"
+      branch: "fm-8784"
   symlinks:
     "mysql": "#{source_dir}"


### PR DESCRIPTION
## Description
Encountering an issue with CentOS 8 hosts failing to provision due to this issue: https://bugzilla.redhat.com/show_bug.cgi?id=1680124

The `rpm --rebuilddb` command was introduced as there were  issues attempting to provision CentOS 6 hosts recently and the introduction of that command seem to resolve that issue: https://github.com/puppetlabs/provision/pull/85

Given that workaround, we will not want to remove this command as there are more CentOS 6 hosts in use than CentOS 8. In fact, from what I can see, `puppetlabs-mysql` is the only module using CentOS 8.

See also: https://github.com/puppetlabs/provision/commit/bd4bb1632bfe0ec24fb7a206910e0e9ad00a7a43