### PR TITLE
Use ensure_packages() to install  the cron packages

### DIFF
--- a/manifests/backup/mysqlbackup.pp
+++ b/manifests/backup/mysqlbackup.pp
@@ -66,17 +66,11 @@ class mysql::backup::mysqlbackup (
   }
 
   if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '5' {
-    package {'crontabs':
-      ensure => present,
-    }
+    ensure_packages('crontabs')
   } elsif $::osfamily == 'RedHat' {
-    package {'cronie':
-      ensure => present,
-    }
+    ensure_packages('cronie')
   } elsif $::osfamily != 'FreeBSD' {
-    package {'cron':
-      ensure => present,
-    }
+    ensure_packages('cron')
   }
 
   cron { 'mysqlbackup-weekly':


### PR DESCRIPTION
By default, `mysql::backup::mysqldump` and `mysql::backup::mysqlbackup` classes try to install cron-related packages.

This is pretty annoying, since it makes Puppet fail if any other package tries to do the same thing.

This PR adds a parameter (default: false) to be able to manage this.