### PR TITLE
(FM-8784) Back out CentOS 8 from Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,26 +71,27 @@ matrix:
       services: docker
       stage: acceptance
       sudo: required
-    -
-      before_script: ["bundle exec rake 'litmus:provision_list[travis_el8]'", "bundle exec rake 'litmus:install_agent[puppet5]'", "bundle exec rake litmus:install_module"]
-      bundler_args: 
-      dist: trusty
-      env: PLATFORMS=el8_puppet5
-      rvm: 2.5.3
-      script: ["bundle exec rake litmus:acceptance:parallel"]
-      services: docker
-      stage: acceptance
-      sudo: required
-    -
-      before_script: ["bundle exec rake 'litmus:provision_list[travis_el8]'", "bundle exec rake 'litmus:install_agent[puppet6]'", "bundle exec rake litmus:install_module"]
-      bundler_args: 
-      dist: trusty
-      env: PLATFORM=el8_puppet6
-      rvm: 2.5.3
-      script: ["bundle exec rake litmus:acceptance:parallel"]
-      services: docker
-      stage: acceptance
-      sudo: required
+    # FM-8784: Back out CentOS 8, Puppet 6 tests until image provisioning issue can be resolved
+    # -
+    #   before_script: ["bundle exec rake 'litmus:provision_list[travis_el8]'", "bundle exec rake 'litmus:install_agent[puppet5]'", "bundle exec rake litmus:install_module"]
+    #   bundler_args: 
+    #   dist: trusty
+    #   env: PLATFORMS=el8_puppet5
+    #   rvm: 2.5.3
+    #   script: ["bundle exec rake litmus:acceptance:parallel"]
+    #   services: docker
+    #   stage: acceptance
+    #   sudo: required
+    # -
+    #   before_script: ["bundle exec rake 'litmus:provision_list[travis_el8]'", "bundle exec rake 'litmus:install_agent[puppet6]'", "bundle exec rake litmus:install_module"]
+    #   bundler_args: 
+    #   dist: trusty
+    #   env: PLATFORM=el8_puppet6
+    #   rvm: 2.5.3
+    #   script: ["bundle exec rake litmus:acceptance:parallel"]
+    #   services: docker
+    #   stage: acceptance
+    #   sudo: required
     -
       before_script: ["bundle exec rake 'litmus:provision_list[travis_el6]'", "bundle exec rake 'litmus:install_agent[puppet5]'", "bundle exec rake litmus:install_module"]
       bundler_args: 


### PR DESCRIPTION
## Description
Provisioning of CentOS 8 images using Docker, appears to be failing: https://travis-ci.org/puppetlabs/puppetlabs-mysql/builds/623152079 

Encountered this locally too when provisioning via Docker, however, this may be a different issue where `rpm --rebuilddb` was failing on new containers: https://bugzilla.redhat.com/show_bug.cgi?id=1680124. I ran with a [provision task that disabled `rpm --rebuildb`](https://github.com/puppetlabs/puppetlabs-mysql/pull/1268) - this worked locally, but **NOT** on Travis.

Further investigation and RCA is still required. In order to bypass a release blocker, we should disable the tests running on CentOS 8 and then re-enable when we have determined the root cause of the provisioning issue.