### PR TITLE
Allow adapting MySQL configuration file's permissions mode

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@
 class mysql::params {
 
   $manage_config_file     = true
+  $config_file_mode       = '0644'
   $purge_conf_dir         = false
   $restart                = false
   $root_password          = 'UNSET'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -11,6 +11,8 @@
 #
 # @param config_file
 #   The location, as a path, of the MySQL configuration file.
+# @param config_file_mode
+#   The MySQL configuration file's permissions mode.
 # @param includedir
 #   The location, as a path, of !includedir for custom configuration overrides.
 # @param install_options
@@ -52,11 +54,11 @@
 # @param create_root_my_cnf
 #   Whether to create `/root/.my.cnf`. Valid values are `true`, `false`. Defaults to `true`. `create_root_my_cnf` allows creation of `/root/.my.cnf` independently of `create_root_user`. You can use this for a cluster setup with Galera where you want `/root/.my.cnf` to exist on all nodes.
 # @param users
-#   Optional hash of users to create, which are passed to [mysql_user](#mysql_user). 
+#   Optional hash of users to create, which are passed to [mysql_user](#mysql_user).
 # @param grants
-#   Optional hash of grants, which are passed to [mysql_grant](#mysql_grant). 
+#   Optional hash of grants, which are passed to [mysql_grant](#mysql_grant).
 # @param databases
-#   Optional hash of databases to create, which are passed to [mysql_database](#mysql_database). 
+#   Optional hash of databases to create, which are passed to [mysql_database](#mysql_database).
 # @param enabled
 #   _Deprecated_
 # @param manage_service
@@ -66,6 +68,7 @@
 #
 class mysql::server (
   $config_file             = $mysql::params::config_file,
+  $config_file_mode        = $mysql::params::config_file_mode,
   $includedir              = $mysql::params::includedir,
   $install_options         = undef,
   $install_secret_file     = $mysql::params::install_secret_file,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -37,7 +37,7 @@ class mysql::server::config {
     file { 'mysql-config-file':
       path                    => $mysql::server::config_file,
       content                 => template('mysql/my.cnf.erb'),
-      mode                    => '0644',
+      mode                    => $mysql::server::config_file_mode,
       selinux_ignore_defaults => true,
     }
 

--- a/spec/classes/mycnf_template_spec.rb
+++ b/spec/classes/mycnf_template_spec.rb
@@ -80,6 +80,54 @@ describe 'mysql::server' do
 
         it { is_expected.to contain_file('mysql-config-file').without_content(%r{!includedir}) }
       end
+
+      context 'with file mode 0644' do
+        let(:params) { { 'config_file_mode' => '0644' } }
+
+        it do
+          is_expected.to contain_file('mysql-config-file').with(mode: '0644')
+        end
+      end
+
+      context 'with file mode 0664' do
+        let(:params) { { 'config_file_mode' => '0664' } }
+
+        it do
+          is_expected.to contain_file('mysql-config-file').with(mode: '0664')
+        end
+      end
+
+      context 'with file mode 0660' do
+        let(:params) { { 'config_file_mode' => '0660' } }
+
+        it do
+          is_expected.to contain_file('mysql-config-file').with(mode: '0660')
+        end
+      end
+
+      context 'with file mode 0641' do
+        let(:params) { { 'config_file_mode' => '0641' } }
+
+        it do
+          is_expected.to contain_file('mysql-config-file').with(mode: '0641')
+        end
+      end
+
+      context 'with file mode 0610' do
+        let(:params) { { 'config_file_mode' => '0610' } }
+
+        it do
+          is_expected.to contain_file('mysql-config-file').with(mode: '0610')
+        end
+      end
+
+      context 'with file 0600' do
+        let(:params) { { 'config_file_mode' => '0600' } }
+
+        it do
+          is_expected.to contain_file('mysql-config-file').with(mode: '0600')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Sometimes more restrictive file-permissions on the MySQL configuration file are required.

e.g. in case of a Galera cluster, where you need to store `wsrep_sst_auth` credentials in the configuration. In that specific case it's a rather powerful MySQL user and you do not want the file to be be world-readable then.

It would be great if we can support this with _puppetlabs-mysql_ too.

PS: In respect of #32, where it was changed from a restrictive permission to `0644`.