### PR TITLE
Allow changing the mysql-config-file group-ownership

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -96,6 +96,8 @@ class mysql::params {
       $datadir                 = '/var/lib/mysql'
       $root_group              = 'root'
       $mysql_group             = 'mysql'
+      $mycnf_owner             = undef
+      $mycnf_group             = undef
       $socket                  = '/var/lib/mysql/mysql.sock'
       $ssl_ca                  = '/etc/mysql/cacert.pem'
       $ssl_cert                = '/etc/mysql/server-cert.pem'
@@ -152,6 +154,8 @@ class mysql::params {
       }
       $root_group          = 'root'
       $mysql_group         = 'mysql'
+      $mycnf_owner         = undef
+      $mycnf_group         = undef
       $server_service_name = 'mysql'
 
       if $::operatingsystem =~ /(SLES|SLED)/ {
@@ -209,6 +213,8 @@ class mysql::params {
       $pidfile                 = '/var/run/mysqld/mysqld.pid'
       $root_group              = 'root'
       $mysql_group             = 'adm'
+      $mycnf_owner             = undef
+      $mycnf_group             = undef
       $socket                  = '/var/run/mysqld/mysqld.sock'
       $ssl_ca                  = '/etc/mysql/cacert.pem'
       $ssl_cert                = '/etc/mysql/server-cert.pem'
@@ -253,6 +259,8 @@ class mysql::params {
       $pidfile                 = '/var/run/mysqld/mysqld.pid'
       $root_group              = 'root'
       $mysql_group             = 'mysql'
+      $mycnf_owner             = undef
+      $mycnf_group             = undef
       $server_service_name     = 'mysqld'
       $socket                  = '/var/lib/mysql/mysql.sock'
       $ssl_ca                  = '/etc/mysql/cacert.pem'
@@ -278,6 +286,8 @@ class mysql::params {
       $pidfile             = '/run/mysqld/mysqld.pid'
       $root_group          = 'root'
       $mysql_group         = 'mysql'
+      $mycnf_owner         = undef
+      $mycnf_group         = undef
       $server_service_name = 'mysql'
       $socket              = '/run/mysqld/mysqld.sock'
       $ssl_ca              = '/etc/mysql/cacert.pem'
@@ -303,6 +313,8 @@ class mysql::params {
       $pidfile             = '/var/run/mysql.pid'
       $root_group          = 'wheel'
       $mysql_group         = 'mysql'
+      $mycnf_owner         = undef
+      $mycnf_group         = undef
       $server_service_name = 'mysql-server'
       $socket              = '/var/db/mysql/mysql.sock'
       $ssl_ca              = undef
@@ -331,6 +343,8 @@ class mysql::params {
       $pidfile             = '/var/mysql/mysql.pid'
       $root_group          = 'wheel'
       $mysql_group         = '_mysql'
+      $mycnf_owner         = undef
+      $mycnf_group         = undef
       $server_service_name = 'mysqld'
       $socket              = '/var/run/mysql/mysql.sock'
       $ssl_ca              = undef
@@ -386,6 +400,8 @@ class mysql::params {
           $pidfile             = '/run/mysqld/mysqld.pid'
           $root_group          = 'root'
           $mysql_group         = 'mysql'
+          $mycnf_owner         = undef
+          $mycnf_group         = undef
           $server_service_name = 'mariadb'
           $socket              = '/run/mysqld/mysqld.sock'
           $ssl_ca              = '/etc/mysql/cacert.pem'
@@ -411,6 +427,8 @@ class mysql::params {
           $pidfile             = '/var/run/mysqld/mysqld.pid'
           $root_group          = 'root'
           $mysql_group         = 'mysql'
+          $mycnf_owner         = undef
+          $mycnf_group         = undef
           $server_service_name = 'mysqld'
           $socket              = '/var/lib/mysql/mysql.sock'
           $ssl_ca              = '/etc/mysql/cacert.pem'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -41,6 +41,10 @@
 #   The name of the group used for root. Can be a group name or a group ID. See more about the [group](https://docs.puppetlabs.com/references/latest/type.html#file-attribute-group).
 # @param mysql_group
 #   The name of the group of the MySQL daemon user. Can be a group name or a group ID. See more about the [group](https://docs.puppetlabs.com/references/latest/type.html#file-attribute-group).
+# @param mycnf_owner
+#   Name or user-id who owns the mysql-config-file.
+# @param mycnf_group
+#   Name or group-id which owns the mysql-config-file.
 # @param root_password
 #   The MySQL root password. Puppet attempts to set the root password and update `/root/.my.cnf` with it. This is required if `create_root_user` or `create_root_my_cnf` are true. If `root_password` is 'UNSET', then `create_root_user` and `create_root_my_cnf` are assumed to be false --- that is, the MySQL root user and `/root/.my.cnf` are not created. Password changes are supported; however, the old password must be set in `/root/.my.cnf`. Effectively, Puppet uses the old password, configured in `/root/my.cnf`, to set the new password in MySQL, and then updates `/root/.my.cnf` with the new password.
 # @param service_enabled
@@ -85,6 +89,8 @@ class mysql::server (
                   $restart                 = $mysql::params::restart,
                   $root_group              = $mysql::params::root_group,
                   $mysql_group             = $mysql::params::mysql_group,
+                  $mycnf_owner             = $mysql::params::mycnf_owner,
+                  $mycnf_group             = $mysql::params::mycnf_group,
                   $root_password           = $mysql::params::root_password,
                   $service_enabled         = $mysql::params::server_service_enabled,
                   $service_manage          = $mysql::params::server_service_manage,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -38,6 +38,7 @@ class mysql::server::config {
       path                    => $mysql::server::config_file,
       content                 => template('mysql/my.cnf.erb'),
       mode                    => $mysql::server::config_file_mode,
+      group                   => $mysql::server::mysql_group,
       selinux_ignore_defaults => true,
     }
 

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -38,7 +38,8 @@ class mysql::server::config {
       path                    => $mysql::server::config_file,
       content                 => template('mysql/my.cnf.erb'),
       mode                    => $mysql::server::config_file_mode,
-      group                   => $mysql::server::mysql_group,
+      owner                   => $mysql::server::mycnf_owner,
+      group                   => $mysql::server::mycnf_group,
       selinux_ignore_defaults => true,
     }
 

--- a/spec/classes/mycnf_template_spec.rb
+++ b/spec/classes/mycnf_template_spec.rb
@@ -128,6 +128,22 @@ describe 'mysql::server' do
           is_expected.to contain_file('mysql-config-file').with(mode: '0600')
         end
       end
+
+      context 'group owner adm' do
+        let(:params) { { 'mysql_group' => 'adm' } }
+
+        it do
+          is_expected.to contain_file('mysql-config-file').with(group: 'adm')
+        end
+      end
+
+      context 'group owner root' do
+        let(:params) { { 'mysql_group' => 'root' } }
+
+        it do
+          is_expected.to contain_file('mysql-config-file').with(group: 'root')
+        end
+      end
     end
   end
 end

--- a/spec/classes/mycnf_template_spec.rb
+++ b/spec/classes/mycnf_template_spec.rb
@@ -129,19 +129,34 @@ describe 'mysql::server' do
         end
       end
 
-      context 'group owner adm' do
-        let(:params) { { 'mysql_group' => 'adm' } }
+      context 'user owner 12345' do
+        let(:params) { { 'mycnf_owner' => '12345' } }
 
         it do
-          is_expected.to contain_file('mysql-config-file').with(group: 'adm')
+          is_expected.to contain_file('mysql-config-file').with(
+            owner: '12345',
+          )
         end
       end
 
-      context 'group owner root' do
-        let(:params) { { 'mysql_group' => 'root' } }
+      context 'group owner 12345' do
+        let(:params) { { 'mycnf_group' => '12345' } }
 
         it do
-          is_expected.to contain_file('mysql-config-file').with(group: 'root')
+          is_expected.to contain_file('mysql-config-file').with(
+            group: '12345',
+          )
+        end
+      end
+
+      context 'user and group owner 12345' do
+        let(:params) { { 'mycnf_owner' => '12345', 'mycnf_group' => '12345' } }
+
+        it do
+          is_expected.to contain_file('mysql-config-file').with(
+            owner: '12345',
+            group: '12345',
+          )
         end
       end
     end


### PR DESCRIPTION
With my PR #1278 it's now possible to change the file-permission-mode of the mysql-config-file - _e.g._ `my.cnf`.

If you are trying now to apply a rather strict file-mode like `0600` - in combination with Puppet's default file-ownership `root:root` - it will lead to issues with MariaDB not being able to access the config-file after it has switched the processes to the service-user (_e.g._ `mysql`).

Therefor I would propose additionally using `$mysql::server::mysql_group` as the mysql-config-file's group-ownership. Then restricting access would be easy done with a `0640` file-mode.