### PR TITLE
Improve differences between generated mysql service id values

### DIFF
--- a/lib/facter/mysql_server_id.rb
+++ b/lib/facter/mysql_server_id.rb
@@ -1,5 +1,14 @@
 def mysql_id_get
-  Facter.value(:macaddress).split(':')[2..-1].reduce(0) { |total, value| (total << 6) + value.hex }
+  # Convert the existing mac to an integer
+  macval = Facter.value(:macaddress).delete(':').to_i(16)
+
+  # Valid range is from 1 - 4294967295 for replication hosts.
+  # We can not guarantee a fully unique value, this reduces the
+  # full mac value down to into that number space.
+  #
+  # The -1/+1 ensures that we keep above 1 if we get unlucky
+  # enough to hit a mac address that evenly divides.
+  (macval % (4_294_967_295 - 1)) + 1
 end
 
 Facter.add('mysql_server_id') do

--- a/spec/unit/facter/mysql_server_id_spec.rb
+++ b/spec/unit/facter/mysql_server_id_spec.rb
@@ -11,7 +11,7 @@ describe Facter::Util::Fact.to_s do
         Facter.fact(:macaddress).stubs(:value).returns('3c:97:0e:69:fb:e1')
       end
       it do
-        Facter.fact(:mysql_server_id).value.to_s.should == '4116385'
+        Facter.fact(:mysql_server_id).value.to_s.should == '241857808'
       end
     end
 
@@ -20,7 +20,7 @@ describe Facter::Util::Fact.to_s do
         Facter.fact(:macaddress).stubs(:value).returns('00:00:00:00:00:00')
       end
       it do
-        Facter.fact(:mysql_server_id).value.to_s.should == '0'
+        Facter.fact(:mysql_server_id).value.to_s.should == '1'
       end
     end
 


### PR DESCRIPTION
This uses the entire mac address then reduces the value to the
acceptable range for mysql.