### PR TITLE
Handle cron package from different module

### DIFF
--- a/manifests/backup/mysqlbackup.pp
+++ b/manifests/backup/mysqlbackup.pp
@@ -28,6 +28,7 @@ class mysql::backup::mysqlbackup (
   $execpath                 = '/usr/bin:/usr/sbin:/bin:/sbin',
   $optional_args            = [],
   $incremental_backups      = false,
+  $install_cron             = true,
 ) inherits mysql::params {
 
   mysql_user { "${backupuser}@localhost":
@@ -65,12 +66,14 @@ class mysql::backup::mysqlbackup (
     require    => Mysql_user["${backupuser}@localhost"],
   }
 
-  if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '5' {
-    ensure_packages('crontabs')
-  } elsif $::osfamily == 'RedHat' {
-    ensure_packages('cronie')
-  } elsif $::osfamily != 'FreeBSD' {
-    ensure_packages('cron')
+  if $install_cron {
+    if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '5' {
+      ensure_packages('crontabs')
+    } elsif $::osfamily == 'RedHat' {
+      ensure_packages('cronie')
+    } elsif $::osfamily != 'FreeBSD' {
+      ensure_packages('cron')
+    }
   }
 
   cron { 'mysqlbackup-weekly':

--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -29,6 +29,7 @@ class mysql::backup::mysqldump (
   $mysqlbackupdir_ensure    = 'directory',
   $mysqlbackupdir_target    = undef,
   $incremental_backups      = false,
+  $install_cron             = true,
 ) inherits mysql::params {
 
   unless $::osfamily == 'FreeBSD' {
@@ -58,14 +59,16 @@ class mysql::backup::mysqldump (
     require    => Mysql_user["${backupuser}@localhost"],
   }
 
-  if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '5' {
-    ensure_packages('crontabs')
-  } elsif $::osfamily == 'RedHat' {
-    ensure_packages('cronie')
-  } elsif $::osfamily != 'FreeBSD' {
-    ensure_packages('cron')
+  if $install_cron {
+    if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '5' {
+      ensure_packages('crontabs')
+    } elsif $::osfamily == 'RedHat' {
+      ensure_packages('cronie')
+    } elsif $::osfamily != 'FreeBSD' {
+      ensure_packages('cron')
+    }
   }
-  
+
   cron { 'mysql-backup':
     ensure   => $ensure,
     command  => '/usr/local/sbin/mysqlbackup.sh',

--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -59,19 +59,13 @@ class mysql::backup::mysqldump (
   }
 
   if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '5' {
-    package {'crontabs':
-      ensure => present,
-    }
+    ensure_packages('crontabs')
   } elsif $::osfamily == 'RedHat' {
-    package {'cronie':
-      ensure => present,
-    }
+    ensure_packages('cronie')
   } elsif $::osfamily != 'FreeBSD' {
-    package {'cron':
-      ensure => present,
-    }
+    ensure_packages('cron')
   }
-
+  
   cron { 'mysql-backup':
     ensure   => $ensure,
     command  => '/usr/local/sbin/mysqlbackup.sh',

--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -29,7 +29,8 @@ class mysql::backup::xtrabackup (
   $execpath                 = '/usr/bin:/usr/sbin:/bin:/sbin',
   $optional_args            = [],
   $additional_cron_args     = '--backup',
-  $incremental_backups      = true
+  $incremental_backups      = true,
+  $install_cron             = true,
 ) inherits mysql::params {
 
   ensure_packages($xtrabackup_package_name)
@@ -47,6 +48,16 @@ class mysql::backup::xtrabackup (
       table      => '*.*',
       privileges => [ 'RELOAD', 'PROCESS', 'LOCK TABLES', 'REPLICATION CLIENT' ],
       require    => Mysql_user["${backupuser}@localhost"],
+    }
+  }
+
+  if $install_cron {
+    if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '5' {
+      ensure_packages('crontabs')
+    } elsif $::osfamily == 'RedHat' {
+      ensure_packages('cronie')
+    } elsif $::osfamily != 'FreeBSD' {
+      ensure_packages('cron')
     }
   }
 

--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -65,6 +65,8 @@
 #   Defines the maximum SQL statement size for the backup dump script. The default value is 1MB, as this is the default MySQL Server value.
 # @param optional_args
 #   Specifies an array of optional arguments which should be passed through to the backup tool. (Supported by the xtrabackup and mysqldump providers.)
+# @param install_cron
+#   Manage installation of cron package
 class mysql::server::backup (
   $backupuser               = undef,
   $backuppassword           = undef,
@@ -91,6 +93,7 @@ class mysql::server::backup (
   $maxallowedpacket         = '1M',
   $optional_args            = [],
   $incremental_backups      = true,
+  $install_cron             = true,
 ) inherits mysql::params {
 
   if $prescript and $provider =~ /(mysqldump|mysqlbackup)/ {
@@ -124,6 +127,7 @@ class mysql::server::backup (
       'maxallowedpacket'         => $maxallowedpacket,
       'optional_args'            => $optional_args,
       'incremental_backups'      => $incremental_backups,
+      'install_cron'             => $install_cron,
     }
   })
 }


### PR DESCRIPTION
Backup should only install cron, if one wants it.

based on this https://github.com/puppetlabs/puppetlabs-mysql/pull/1269