### PR TITLE
Use ALTER USER for mariadb 10.2.0 or newer

### DIFF
--- a/lib/puppet/provider/mysql_user/mysql.rb
+++ b/lib/puppet/provider/mysql_user/mysql.rb
@@ -211,7 +211,7 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
         sql << ", authentication_string = '#{@resource[:password_hash]}'"
         sql << " where CONCAT(user, '@', host) = '#{concat_name}'; FLUSH PRIVILEGES"
       end
-    elsif newer_than('mysql' => '5.7.6', 'percona' => '5.7.6')
+    elsif newer_than('mysql' => '5.7.6', 'percona' => '5.7.6', 'mariadb' => '10.2.0')
       sql = "ALTER USER #{merged_name} IDENTIFIED WITH '#{string}'"
       sql << " AS '#{@resource[:password_hash]}'" if string == 'mysql_native_password'
     else


### PR DESCRIPTION
As of MariaDB 10.4.1 the mysql.user table has been replaced by a view
onto the mysql.global_priv table, and the "UPDATE mysql.user" syntax
therefore no longer works.  Support for the newer ALTER USER statement
was added in MariaDB 10.2.0.

Fix the plugin attribute accessor to use ALTER USER for mariadb 10.2.0
or newer.  This matches the existing version check logic within the
password_hash and tls_options accessors.

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>