### PR TITLE
add package provider and source

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -16,15 +16,21 @@
 #   Whether the MySQL package should be present, absent, or a specific version. Valid values are 'present', 'absent', or 'x.y.z'.
 # @param package_manage
 #   Whether to manage the MySQL client package. Defaults to `true`.
+# @param service_name
+#   The name of the MySQL server service. Defaults are OS dependent, defined in 'params.pp'.
+# @param service_provider
+#   The provider to use to manage the service. For Ubuntu, defaults to 'upstart'; otherwise, default is undefined.
 # @param package_name
 #   The name of the MySQL client package to install.
 #
 class mysql::client (
-  $bindings_enable = $mysql::params::bindings_enable,
-  $install_options = undef,
-  $package_ensure  = $mysql::params::client_package_ensure,
-  $package_manage  = $mysql::params::client_package_manage,
-  $package_name    = $mysql::params::client_package_name,
+  $bindings_enable  = $mysql::params::bindings_enable,
+  $install_options  = undef,
+  $package_ensure   = $mysql::params::client_package_ensure,
+  $package_manage   = $mysql::params::client_package_manage,
+  $package_name     = $mysql::params::client_package_name,
+  $package_provider = undef,
+  $package_source   = undef,
 ) inherits mysql::params {
 
   include '::mysql::client::install'

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -11,6 +11,8 @@ class mysql::client::install {
       ensure          => $mysql::client::package_ensure,
       install_options => $mysql::client::install_options,
       name            => $mysql::client::package_name,
+      provider        => $mysql::client::package_provider,
+      source          => $mysql::client::package_source,
     }
 
   }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -31,6 +31,10 @@
 #   Whether to manage the MySQL server package. Defaults to `true`.
 # @param package_name
 #   The name of the MySQL server package to install.
+# @param package_provider
+#   Define a specific provider for package install.
+# @param package_source
+#   The location of the package source (require for some package provider)
 # @param purge_conf_dir
 #   Whether the `includedir` directory should be purged. Valid values are `true`, `false`. Defaults to `false`.
 # @param remove_default_accounts
@@ -84,6 +88,8 @@ class mysql::server (
                   $package_ensure          = $mysql::params::server_package_ensure,
                   $package_manage          = $mysql::params::server_package_manage,
                   $package_name            = $mysql::params::server_package_name,
+                  $package_provider        = undef,
+                  $package_source          = undef,
                   $purge_conf_dir          = $mysql::params::purge_conf_dir,
                   $remove_default_accounts = false,
                   $restart                 = $mysql::params::restart,

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -1,4 +1,4 @@
-# @summary 
+# @summary
 #   Private class for managing MySQL package.
 #
 # @api private
@@ -11,6 +11,8 @@ class mysql::server::install {
       ensure          => $mysql::server::package_ensure,
       install_options => $mysql::server::install_options,
       name            => $mysql::server::package_name,
+      provider        => $mysql::server::package_provider,
+      source          => $mysql::server::package_source,
     }
   }
 

--- a/spec/classes/mysql_client_spec.rb
+++ b/spec/classes/mysql_client_spec.rb
@@ -30,6 +30,22 @@ describe 'mysql::client' do
 
         it { is_expected.not_to contain_package('mysql_client') }
       end
+
+      context 'with package provider' do
+        let(:params) do
+          {
+            package_provider: 'dpkg',
+            package_source: '/somewhere',
+          }
+        end
+
+        it do
+          is_expected.to contain_package('mysql_client').with(
+            provider: 'dpkg',
+            source: '/somewhere',
+          )
+        end
+      end
     end
   end
 end

--- a/spec/classes/mysql_server_spec.rb
+++ b/spec/classes/mysql_server_spec.rb
@@ -78,6 +78,21 @@ describe 'mysql::server' do
 
           it { is_expected.to contain_mysql_datadir('/tmp') }
         end
+        context 'with package provider' do
+          let(:params) do
+            {
+              package_provider: 'dpkg',
+              package_source: '/somewhere',
+            }
+          end
+
+          it do
+            is_expected.to contain_package('mysql-server').with(
+              provider: 'dpkg',
+              source: '/somewhere',
+            )
+          end
+        end
       end
 
       context 'mysql::server::service' do


### PR DESCRIPTION
Hi,

I require this options for the commercial package. Oracle does not provide package repositories. We need to download the package and install with dpkg/rpm.

Test and validate on Ubuntu 18.04.

Regards,