### PR TITLE
Remove non printable characters

### DIFF
--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -101,16 +101,16 @@ class Puppet::Provider::Mysql < Puppet::Provider
     if type.eql? 'system'
       if File.file?("#{Facter.value(:root_home)}/.mylogin.cnf")
         ENV['MYSQL_TEST_LOGIN_FILE'] = "#{Facter.value(:root_home)}/.mylogin.cnf"
-        mysql_raw([system_database, '-e', text_of_sql].flatten.compact)
+        mysql_raw([system_database, '-e', text_of_sql].flatten.compact).scrub
       else
-        mysql_raw([defaults_file, system_database, '-e', text_of_sql].flatten.compact)
+        mysql_raw([defaults_file, system_database, '-e', text_of_sql].flatten.compact).scrub
       end
     elsif type.eql? 'regular'
       if File.file?("#{Facter.value(:root_home)}/.mylogin.cnf")
         ENV['MYSQL_TEST_LOGIN_FILE'] = "#{Facter.value(:root_home)}/.mylogin.cnf"
-        mysql_raw(['-NBe', text_of_sql].flatten.compact)
+        mysql_raw(['-NBe', text_of_sql].flatten.compact).scrub
       else
-        mysql_raw([defaults_file, '-NBe', text_of_sql].flatten.compact)
+        mysql_raw([defaults_file, '-NBe', text_of_sql].flatten.compact).scrub
       end
     else
       raise Puppet::Error, _("#mysql_caller: Unrecognised type '%{type}'" % { type: type })


### PR DESCRIPTION
In the rare event MySQL spits out something non printable this should cleanse it see the error below:

```
Error: Could not prefetch mysql_user provider 'mysql': invalid byte sequence in UTF-8
Error: Failed to apply catalog: invalid byte sequence in UTF-8
```