### PR TITLE
Do not set empty password as policy don't allow that

### DIFF
--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -13,8 +13,8 @@ class mysql::server::root_password {
   # below exec will remove this default password. If the user has supplied a root
   # password it will be set further down with the mysql_user resource.
   $rm_pass_cmd = join([
-      "mysqladmin -u root --password=\$(grep -o '[^ ]\\+\$' ${secret_file}) password ''",
-      "rm -f ${secret_file}",
+      "mysqladmin -u root --password=\$(grep -o '[^ ]\\+\$' ${secret_file}) password \"${mysql::server::root_password}\"",
+      "rm -f ${secret_file}"
   ], ' && ')
   exec { 'remove install pass':
     command => $rm_pass_cmd,

--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -43,7 +43,7 @@ class mysql::server::root_password {
       File["${::root_home}/.my.cnf"] { show_diff => false }
     }
     if $mysql::server::create_root_user == true {
-      Mysql_user['root@localhost'] -> File["${::root_home}/.my.cnf"]
+      File["${::root_home}/.my.cnf"] -> Mysql_user['root@localhost']
     }
   }
 


### PR DESCRIPTION
Mysql server doesn't allow setting an empty password. With this PR the root password would be directly set by mysqladmin. Also /root/.my.cnf is first set before the root user is managed. Without this ordering, mysql_user() cannot be used as the root password has a password set, which isn't set in the client config.