### PR TITLE
(MAINT) Install curl package on Debian/Ubuntu

### DIFF
--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -27,6 +27,8 @@ RSpec.configure do |c|
     if os[:family] == 'debian' || os[:family] == 'ubuntu'
       # needed for the puppet fact
       LitmusHelper.instance.apply_manifest("package { 'lsb-release': ensure => installed, }", expect_failures: false)
+      # needed for percona xtra backup
+      LitmusHelper.instance.apply_manifest("package { 'curl': ensure => installed, }", expect_failures: false)
     end
     # needed for the grant tests, not installed on el7 docker images
     LitmusHelper.instance.apply_manifest("package { 'which': ensure => installed, }", expect_failures: false)


### PR DESCRIPTION
There are currently failures on Ubuntu/Debian images using Docker. This should resolve them.