### PR TITLE
Fix package for python bindings on Ubuntu 20.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -244,8 +244,12 @@ class mysql::params {
       ($::operatingsystem == 'Debian') {
         $xtrabackup_package_name_override = 'percona-xtrabackup-24'
       }
+      if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) {
+        $python_package_name = 'python3-mysqldb'
+      } else {
+        $python_package_name = 'python-mysqldb'
+      }
 
-      $python_package_name = 'python-mysqldb'
       $ruby_package_name   = $::lsbdistcodename ? {
         'jessie'           => 'ruby-mysql',
         'stretch'          => 'ruby-mysql2',


### PR DESCRIPTION
The default python version on Ubuntu 20.04 is
python3 thus the current package is wrong.

This changes the package to use python3-mysqldb.