### PR TITLE
Repair check of logbindir

### DIFF
--- a/manifests/server/managed_dirs.pp
+++ b/manifests/server/managed_dirs.pp
@@ -23,6 +23,8 @@ class mysql::server::managed_dirs {
         }
       }
     }
+  } else {
+    $managed_dirs_path = []
   }
 
   $logbin = pick($options['mysqld']['log-bin'], $options['mysqld']['log_bin'], false)

--- a/manifests/server/managed_dirs.pp
+++ b/manifests/server/managed_dirs.pp
@@ -31,7 +31,7 @@ class mysql::server::managed_dirs {
     $logbindir = dirname($logbin)
 
     #Stop puppet from managing directory if just a filename/prefix is specified or is not already managed
-    if ($logbindir != '.' or !($logbindir in $managed_dirs_path)) {
+    if (!($logbindir == '.' or $logbindir in $managed_dirs_path)) {
       file { $logbindir:
         ensure => directory,
         mode   => '0700',


### PR DESCRIPTION
Presumably the intention was to check that it is *both* not relative
and not already managed.

After update to 10.8 the mysql module tries and fails to manage '.'
on nodes where i have log-bin set to a relative path.