### PR TITLE
Set default MySQL version for FreeBSD

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -328,8 +328,8 @@ class mysql::params {
     }
 
     'FreeBSD': {
-      $client_package_name = 'databases/mysql56-client'
-      $server_package_name = 'databases/mysql56-server'
+      $client_package_name = 'databases/mysql57-client'
+      $server_package_name = 'databases/mysql57-server'
       $basedir             = '/usr/local'
       $config_file         = '/usr/local/etc/my.cnf'
       $includedir          = '/usr/local/etc/my.cnf.d'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -497,6 +497,9 @@ class mysql::params {
     'Alpine': {
       $server_service_provider = 'rc-service'
     }
+    'FreeBSD': {
+      $server_service_provider = 'freebsd'
+    }
     default: {
       $server_service_provider = undef
     }


### PR DESCRIPTION
FreeBSD uses MySQL 57 by default
Ref: https://svnweb.freebsd.org/ports/branches/2021Q1/Mk/bsd.default-versions.mk?revision=560000&view=markup#l83