### PR TITLE
Support compression command and extension

### DIFF
--- a/manifests/backup/mysqlbackup.pp
+++ b/manifests/backup/mysqlbackup.pp
@@ -29,6 +29,8 @@ class mysql::backup::mysqlbackup (
   $optional_args            = [],
   $incremental_backups      = false,
   $install_cron             = true,
+  $compression_command      = undef,
+  $compression_extension    = undef,
 ) inherits mysql::params {
   mysql_user { "${backupuser}@localhost":
     ensure        => $ensure,

--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -30,9 +30,11 @@ class mysql::backup::mysqldump (
   $mysqlbackupdir_target    = undef,
   $incremental_backups      = false,
   $install_cron             = true,
+  $compression_command      = 'bzcat -zc',
+  $compression_extension    = '.bz2'
 ) inherits mysql::params {
   unless $::osfamily == 'FreeBSD' {
-    if $backupcompress {
+    if $backupcompress and $compression_command == 'bzcat -zc' {
       ensure_packages(['bzip2'])
       Package['bzip2'] -> File['mysqlbackup.sh']
     }

--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -31,6 +31,8 @@ class mysql::backup::xtrabackup (
   $additional_cron_args     = '--backup',
   $incremental_backups      = true,
   $install_cron             = true,
+  $compression_command      = undef,
+  $compression_extension    = undef,
 ) inherits mysql::params {
   ensure_packages($xtrabackup_package_name)
 

--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -68,7 +68,8 @@
 # @param install_cron
 #   Manage installation of cron package
 # @param compression_command
-#   Configure the command used to compress the backup (when using the mysqldump provider)
+#   Configure the command used to compress the backup (when using the mysqldump provider). Make sure the command exists
+#   on the target system. Packages for it are NOT automatically installed.
 # @param compression_extension
 #   Configure the file extension for the compressed backup (when using the mysqldump provider)
 class mysql::server::backup (

--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -67,6 +67,10 @@
 #   Specifies an array of optional arguments which should be passed through to the backup tool. (Supported by the xtrabackup and mysqldump providers.)
 # @param install_cron
 #   Manage installation of cron package
+# @param compression_command
+#   Configure the command used to compress the backup (when using the mysqldump provider)
+# @param compression_extension
+#   Configure the file extension for the compressed backup (when using the mysqldump provider)
 class mysql::server::backup (
   $backupuser               = undef,
   $backuppassword           = undef,
@@ -94,6 +98,8 @@ class mysql::server::backup (
   $optional_args            = [],
   $incremental_backups      = true,
   $install_cron             = true,
+  $compression_command      = undef,
+  $compression_extension    = undef
 ) inherits mysql::params {
   if $prescript and $provider =~ /(mysqldump|mysqlbackup)/ {
     warning(translate("The 'prescript' option is not currently implemented for the %{provider} backup provider.",
@@ -127,6 +133,8 @@ class mysql::server::backup (
         'optional_args'            => $optional_args,
         'incremental_backups'      => $incremental_backups,
         'install_cron'             => $install_cron,
+        'compression_command'      => $compression_command,
+        'compression_extension'    => $compression_extension,
       }
   })
 }

--- a/spec/classes/mysql_backup_mysqldump_spec.rb
+++ b/spec/classes/mysql_backup_mysqldump_spec.rb
@@ -52,6 +52,24 @@ describe 'mysql::backup::mysqldump' do
           )
         }
       end
+
+      context 'with compression_command' do
+        let(:params) do
+          {
+            compression_command: "TEST -TEST",
+            compression_extension: ".TEST"
+          }.merge(default_params)
+        end
+        it {
+          is_expected.to contain_file('mysqlbackup.sh').with_content(
+            %r{(\| TEST -TEST)},
+          )
+          is_expected.to contain_file('mysqlbackup.sh').with_content(
+            %r{(\.TEST)},
+          )
+          is_expected.to_not contain_package('bzip2')
+        }
+      end
     end
   end
   # rubocop:enable RSpec/NestedGroups

--- a/spec/classes/mysql_backup_mysqldump_spec.rb
+++ b/spec/classes/mysql_backup_mysqldump_spec.rb
@@ -56,10 +56,11 @@ describe 'mysql::backup::mysqldump' do
       context 'with compression_command' do
         let(:params) do
           {
-            compression_command: "TEST -TEST",
-            compression_extension: ".TEST"
+            compression_command: 'TEST -TEST',
+            compression_extension: '.TEST'
           }.merge(default_params)
         end
+
         it {
           is_expected.to contain_file('mysqlbackup.sh').with_content(
             %r{(\| TEST -TEST)},
@@ -67,7 +68,7 @@ describe 'mysql::backup::mysqldump' do
           is_expected.to contain_file('mysqlbackup.sh').with_content(
             %r{(\.TEST)},
           )
-          is_expected.to_not contain_package('bzip2')
+          is_expected.not_to contain_package('bzip2')
         }
       end
     end

--- a/templates/mysqlbackup.sh.erb
+++ b/templates/mysqlbackup.sh.erb
@@ -93,18 +93,18 @@ mysql --defaults-extra-file=$TMPFILE -s -r -N -e 'SHOW DATABASES' | while read d
 do
   <%= @backupmethod -%> --defaults-extra-file=$TMPFILE --opt --flush-logs --single-transaction \
     ${ADDITIONAL_OPTIONS} \
-    ${dbname} <% if @backupcompress %>| bzcat -zc <% end %>> ${DIR}/${PREFIX}${dbname}_`date +%Y%m%d-%H%M%S`.sql<% if @backupcompress %>.bz2<% end  %>
+    ${dbname} <% if @backupcompress %>| <%= @compression_command %> <% end %>> ${DIR}/${PREFIX}${dbname}_`date +%Y%m%d-%H%M%S`.sql<% if @backupcompress %><%= @compression_extension %><% end  %>
 done
 <% else -%>
 <%= @backupmethod -%> --defaults-extra-file=$TMPFILE --opt --flush-logs --single-transaction \
  ${ADDITIONAL_OPTIONS} \
- --all-databases <% if @backupcompress %>| bzcat -zc <% end %>> ${DIR}/${PREFIX}`date +%Y%m%d-%H%M%S`.sql<% if @backupcompress %>.bz2<% end  %>
+ --all-databases <% if @backupcompress %>| <%= @compression_command %> <% end %>> ${DIR}/${PREFIX}`date +%Y%m%d-%H%M%S`.sql<% if @backupcompress %><%= @compression_extension %><% end  %>
 <% end -%>
 <% else -%>
 <% @backupdatabases.each do |db| -%>
 <%= @backupmethod -%> --defaults-extra-file=$TMPFILE --opt --flush-logs --single-transaction \
     ${ADDITIONAL_OPTIONS} \
- <%= db %><% if @backupcompress %>| bzcat -zc <% end %>> ${DIR}/${PREFIX}<%= db %>_`date +%Y%m%d-%H%M%S`.sql<% if @backupcompress %>.bz2<% end  %>
+ <%= db %><% if @backupcompress %>| <%= @compression_command %> <% end %>> ${DIR}/${PREFIX}<%= db %>_`date +%Y%m%d-%H%M%S`.sql<% if @backupcompress %><%= @compression_extension %><% end  %>
 <% end -%>
 <% end -%>
 


### PR DESCRIPTION
This makes it possible to configure the previously hardcoded bzip2 compression and use a faster or parallel compression. It doesn't support package installation for other compression commands.