### PR TITLE
pdksync - (MAINT) Remove RHEL 5 family support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7",
         "8"
@@ -34,7 +33,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7",
         "8"
@@ -43,7 +41,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]


### PR DESCRIPTION
(MAINT) Remove RHEL 5 family support
pdk version: `1.18.1` 
