### PR TITLE
Inhertis params to avoid Puppet Unknown variable: 'mysql::params::exe…

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -54,7 +54,7 @@ define mysql::db (
   $import_timeout                             = 300,
   $import_cat_cmd                             = 'cat',
   $mysql_exec_path                            = $mysql::params::exec_path,
-) {
+) inherits mysql::params {
   $table = "${dbname}.*"
 
   $sql_inputs = join([$sql], ' ')


### PR DESCRIPTION
…c_path'