### PR TITLE
Remove puppet5-specific resource_api module dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,10 +11,6 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 3.2.0 < 8.0.0"
-    },
-    {
-      "name": "puppetlabs/resource_api",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/types/mysql_login_path_spec.rb
+++ b/spec/acceptance/types/mysql_login_path_spec.rb
@@ -35,9 +35,6 @@ describe 'mysql_login_path', unless: ("#{os[:family]}-#{os[:release].to_i}" =~ %
 
   describe 'setup' do
     pp = <<-MANIFEST
-      if versioncmp($::puppetversion, '6.0.0') < 0 {
-        include resource_api
-      }
       user { 'loginpath_test':
         ensure => present,
         managehome => true,


### PR DESCRIPTION
The puppetlabs/resource_api module was used for puppet5 to install the
puppet-resource_api gem. With puppet6 and later this is not necessary
anymore.