### PR TITLE
(maint) Putting Debian back into the metadata.json

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -155,6 +155,13 @@ jobs:
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
         echo ::endgroup::
 
+    - name: Start SSH session
+      if: ${{ matrix.collection == 'puppet6-nightly' && matrix.platforms.image == 'litmusimage/debian:9' }}
+      uses: luchihoratiu/debug-via-ssh@main
+      with:
+        NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
+        SSH_PASS: ${{ secrets.SSH_PASS }}
+
     - name: Run acceptance tests
       run: |
         buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:acceptance:parallel' -- bundle exec rake 'litmus:acceptance:parallel'

--- a/metadata.json
+++ b/metadata.json
@@ -52,6 +52,14 @@
       ]
     },
     {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "8",
+        "9",
+        "10"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -37,10 +37,11 @@ end
 
 RSpec.configure do |c|
   c.before :suite do
-    if os[:family] == 'debian' || os[:family] == 'ubuntu'
+    if os[:family] == 'debian'
       # needed for the puppet fact
       LitmusHelper.instance.apply_manifest("package { 'lsb-release': ensure => installed, }", expect_failures: false)
       LitmusHelper.instance.apply_manifest("package { 'ap': ensure => installed, }", expect_failures: false)
+      LitmusHelper.instance.apply_manifest('sudo chmod -R 755 /var/run/mysqld/') if [9, 10].include?(os[:release].to_i)
     end
     # needed for the grant tests, not installed on el7 docker images
     LitmusHelper.instance.apply_manifest("package { 'which': ensure => installed, }", expect_failures: false)


### PR DESCRIPTION
Currently we have raised an issue to track Debian failures https://tickets.puppetlabs.com/browse/IAC-1595
In order to stop blocking us we planned on stopping to test on these OSs temporarily and the obvious move was to remove from the metadata.json

However the problem with this is, when we cut a release the Forge will use this to show the supported OSs and we do support Debian, just we wanted to disable testing. We will have to come up with a 'better' was to disable tests on specific OSs.