### PR TITLE
Update xtrabackup package name for Ubuntu 20.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -248,6 +248,7 @@ class mysql::params {
         $php_package_name = 'php5-mysql'
       }
       if  ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') < 0) or
+      ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) or
       ($::operatingsystem == 'Debian') {
         $xtrabackup_package_name_override = 'percona-xtrabackup-24'
       }

--- a/spec/classes/mysql_backup_xtrabackup_spec.rb
+++ b/spec/classes/mysql_backup_xtrabackup_spec.rb
@@ -40,7 +40,9 @@ describe 'mysql::backup::xtrabackup' do
                   elsif facts[:operatingsystem] == 'Debian'
                     'percona-xtrabackup-24'
                   elsif facts[:operatingsystem] == 'Ubuntu'
-                    if Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '16') >= 0
+                    if Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '20') >= 0
+                      'percona-xtrabackup-24'
+                    elsif Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '16') >= 0
                       'percona-xtrabackup'
                     else
                       'percona-xtrabackup-24'
@@ -125,7 +127,9 @@ describe 'mysql::backup::xtrabackup' do
                   elsif facts[:operatingsystem] == 'Debian'
                     'percona-xtrabackup-24'
                   elsif facts[:operatingsystem] == 'Ubuntu'
-                    if Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '16') >= 0
+                    if Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '20') >= 0
+                      'percona-xtrabackup-24'
+                    elsif Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '16') >= 0
                       'percona-xtrabackup'
                     else
                       'percona-xtrabackup-24'


### PR DESCRIPTION
Percona no longer includes the generic package name 'percona-xtrabackup' in their Ubuntu 20.04 focal fossa release of percona-xtrabackup. The package name 'percona-xtrabackup-24' must be used instead. This can be verified in the package names included by percona-release, listed at https://repo.percona.com/apt/dists/focal/main/binary-amd64/Packages