### PR TITLE
(feat) allow to set and run backups using another user via cron

### DIFF
--- a/manifests/backup/mysqlbackup.pp
+++ b/manifests/backup/mysqlbackup.pp
@@ -6,6 +6,7 @@
 class mysql::backup::mysqlbackup (
   $backupuser               = '',
   Variant[String, Sensitive[String]] $backuppassword = '',
+  $backupcronuser           = $mysql::params::backupcronuser,
   $maxallowedpacket         = '1M',
   $backupdir                = '',
   $backupdirmode            = '0700',
@@ -85,7 +86,7 @@ class mysql::backup::mysqlbackup (
   cron { 'mysqlbackup-weekly':
     ensure  => $ensure,
     command => 'mysqlbackup backup',
-    user    => 'root',
+    user    => $backupcronuser,
     hour    => $time[0],
     minute  => $time[1],
     weekday => '0',
@@ -95,7 +96,7 @@ class mysql::backup::mysqlbackup (
   cron { 'mysqlbackup-daily':
     ensure  => $ensure,
     command => 'mysqlbackup --incremental backup',
-    user    => 'root',
+    user    => $backupcronuser,
     hour    => $time[0],
     minute  => $time[1],
     weekday => '1-6',

--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -4,6 +4,7 @@
 #
 class mysql::backup::mysqldump (
   $backupuser               = '',
+  $backupcronuser           = $mysql::params::backupcronuser,
   Variant[String, Sensitive[String]] $backuppassword = '',
   $backupdir                = '',
   $maxallowedpacket         = '1M',
@@ -79,7 +80,7 @@ class mysql::backup::mysqldump (
   cron { 'mysql-backup':
     ensure   => $ensure,
     command  => '/usr/local/sbin/mysqlbackup.sh',
-    user     => 'root',
+    user     => $backupcronuser,
     hour     => $time[0],
     minute   => $time[1],
     monthday => $time[2],
@@ -93,7 +94,7 @@ class mysql::backup::mysqldump (
     ensure  => $ensure,
     path    => '/usr/local/sbin/mysqlbackup.sh',
     mode    => '0700',
-    owner   => 'root',
+    owner   => $backupcronuser,
     group   => $mysql::params::root_group,
     content => template('mysql/mysqlbackup.sh.erb'),
   }

--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -6,6 +6,7 @@ class mysql::backup::xtrabackup (
   $xtrabackup_package_name  = $mysql::params::xtrabackup_package_name,
   $backupuser               = undef,
   Optional[Variant[String, Sensitive[String]]] $backuppassword = undef,
+  $backupcronuser           = $mysql::params::backupcronuser,
   $backupdir                = '',
   $maxallowedpacket         = '1M',
   $backupmethod             = 'xtrabackup',
@@ -81,7 +82,7 @@ class mysql::backup::xtrabackup (
     cron { 'xtrabackup-weekly':
       ensure  => $ensure,
       command => "/usr/local/sbin/xtrabackup.sh --target-dir=${backupdir}/$(date +\\%F)_full ${additional_cron_args}",
-      user    => 'root',
+      user    => $backupcronuser,
       hour    => $time[0],
       minute  => $time[1],
       weekday => '0',
@@ -113,7 +114,7 @@ class mysql::backup::xtrabackup (
   cron { 'xtrabackup-daily':
     ensure  => $ensure,
     command => "/usr/local/sbin/xtrabackup.sh ${daily_cron_data['directories']} ${additional_cron_args}",
-    user    => 'root',
+    user    => $backupcronuser,
     hour    => $time[0],
     minute  => $time[1],
     weekday => $daily_cron_data['weekday'],
@@ -132,7 +133,7 @@ class mysql::backup::xtrabackup (
     ensure  => $ensure,
     path    => '/usr/local/sbin/xtrabackup.sh',
     mode    => '0700',
-    owner   => 'root',
+    owner   => $backupcronuser,
     group   => $mysql::params::root_group,
     content => template($backupscript_template),
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@
 class mysql::params {
   $manage_config_file     = true
   $config_file_mode       = '0644'
+  $backupcronuser         = 'root'
   $purge_conf_dir         = false
   $restart                = false
   $root_password          = 'UNSET'

--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -112,7 +112,7 @@ class mysql::server::backup (
   create_resources('class', {
       "mysql::backup::${provider}" => {
         'backupuser'               => $backupuser,
-	'backupcronuser'           => $backupcronuser,
+        'backupcronuser'           => $backupcronuser,
         'backuppassword'           => $backuppassword,
         'backupdir'                => $backupdir,
         'backupdirmode'            => $backupdirmode,

--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -18,6 +18,8 @@
 #
 # @param backupuser
 #   MySQL user to create with backup administrator privileges.
+# @param backupcronuser
+#   User to use for backup cron jobs. Defaults to root.
 # @param backuppassword
 #   Password to create for `backupuser`.
 # @param backupdir
@@ -74,6 +76,7 @@
 #   Configure the file extension for the compressed backup (when using the mysqldump provider)
 class mysql::server::backup (
   $backupuser               = undef,
+  $backupcronuser           = $mysql::params::backupcronuser,
   Optional[Variant[String, Sensitive[String]]] $backuppassword = undef,
   $backupdir                = undef,
   $backupdirmode            = '0700',
@@ -109,10 +112,11 @@ class mysql::server::backup (
   create_resources('class', {
       "mysql::backup::${provider}" => {
         'backupuser'               => $backupuser,
+	'backupcronuser'           => $backupcronuser,
         'backuppassword'           => $backuppassword,
         'backupdir'                => $backupdir,
         'backupdirmode'            => $backupdirmode,
-        'backupdirowner'           => $backupdirowner,
+        'backupdirowner'           => $backupcronuser,
         'backupdirgroup'           => $backupdirgroup,
         'backupcompress'           => $backupcompress,
         'backuprotate'             => $backuprotate,


### PR DESCRIPTION
allow to set and run backups using another user via cron , default is set as root via params if no cronbackupuser is specified 