### PR TITLE
Solve issue with repeated restarts if ssl-disable is true

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -174,7 +174,7 @@ class mysql::server (
                 if you are forced to use a mysql version compiled without SSL support',
     }
   }
-  
+
   Anchor['mysql::server::start']
   -> Class['mysql::server::config']
   -> Class['mysql::server::install']

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -183,4 +183,5 @@ class mysql::server (
   -> Class['mysql::server::service']
   -> Class['mysql::server::root_password']
   -> Class['mysql::server::providers']
--> Anchor['mysql::server::end'] }
+  -> Anchor['mysql::server::end']
+}

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -167,6 +167,14 @@ class mysql::server (
     ~> Class['mysql::server::service']
   }
 
+
+  if $_options['mysqld']['ssl-disable'] {
+    notify { 'ssl-disable':
+      message => 'Disabling SSL is evil! You should never ever do this except
+                if you are forced to use a mysql version compiled without SSL support',
+    }
+  }
+  
   Anchor['mysql::server::start']
   -> Class['mysql::server::config']
   -> Class['mysql::server::install']

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -82,11 +82,4 @@ class mysql::server::config {
       }
     }
   }
-
-  if $options['mysqld']['ssl-disable'] {
-    notify { 'ssl-disable':
-      message => 'Disabling SSL is evil! You should never ever do this except
-                if you are forced to use a mysql version compiled without SSL support',
-    }
-  }
 }


### PR DESCRIPTION
With the current code, if ssl-disable is set to true and restart is set to true, the notify message in the server::config class warning about ssl being disabled causes the service to be restarted on each Puppet run.

I have therefore moved that warning message outside of the server::config class, so that server::config ~> server::service does not trigger a restart of the service on each Puppet run.