### PR TITLE
MODULES-8373 Fix mysql_grant resource to be idempodent on MySQL 8+

### DIFF
--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -46,8 +46,11 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, parent: Puppet::Provider::Mysql)
           end
         end
         sorted_privileges = stripped_privileges.sort
-        if self.newer_than('mysql' => '8.0.0')
-          sorted_privileges = (sorted_privileges == ['ALTER', 'ALTER ROUTINE', 'CREATE', 'CREATE ROLE', 'CREATE ROUTINE', 'CREATE TABLESPACE', 'CREATE TEMPORARY TABLES', 'CREATE USER', 'CREATE VIEW', 'DELETE', 'DROP', 'DROP ROLE', 'EVENT', 'EXECUTE', 'FILE', 'INDEX', 'INSERT', 'LOCK TABLES', 'PROCESS', 'REFERENCES', 'RELOAD', 'REPLICATION CLIENT', 'REPLICATION SLAVE', 'SELECT', 'SHOW DATABASES', 'SHOW VIEW', 'SHUTDOWN', 'SUPER', 'TRIGGER', 'UPDATE']) ? ['ALL'] : sorted_privileges
+        if newer_than('mysql' => '8.0.0') && sorted_privileges == ['ALTER', 'ALTER ROUTINE', 'CREATE', 'CREATE ROLE', 'CREATE ROUTINE', 'CREATE TABLESPACE', 'CREATE TEMPORARY TABLES', 'CREATE USER',
+                                                                   'CREATE VIEW', 'DELETE', 'DROP', 'DROP ROLE', 'EVENT', 'EXECUTE', 'FILE', 'INDEX', 'INSERT', 'LOCK TABLES', 'PROCESS', 'REFERENCES',
+                                                                   'RELOAD', 'REPLICATION CLIENT', 'REPLICATION SLAVE', 'SELECT', 'SHOW DATABASES', 'SHOW VIEW', 'SHUTDOWN', 'SUPER', 'TRIGGER',
+                                                                   'UPDATE']
+          sorted_privileges = ['ALL']
         end
         # Same here, but to remove OPTION leaving just GRANT.
         options = if %r{WITH\sGRANT\sOPTION}.match?(rest)

--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -45,6 +45,10 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, parent: Puppet::Provider::Mysql)
             (priv == 'ALL PRIVILEGES') ? 'ALL' : priv.strip
           end
         end
+        sorted_privileges = stripped_privileges.sort
+        if self.newer_than('mysql' => '8.0.0')
+          sorted_privileges = (sorted_privileges == ['ALTER', 'ALTER ROUTINE', 'CREATE', 'CREATE ROLE', 'CREATE ROUTINE', 'CREATE TABLESPACE', 'CREATE TEMPORARY TABLES', 'CREATE USER', 'CREATE VIEW', 'DELETE', 'DROP', 'DROP ROLE', 'EVENT', 'EXECUTE', 'FILE', 'INDEX', 'INSERT', 'LOCK TABLES', 'PROCESS', 'REFERENCES', 'RELOAD', 'REPLICATION CLIENT', 'REPLICATION SLAVE', 'SELECT', 'SHOW DATABASES', 'SHOW VIEW', 'SHUTDOWN', 'SUPER', 'TRIGGER', 'UPDATE']) ? ['ALL'] : sorted_privileges
+        end
         # Same here, but to remove OPTION leaving just GRANT.
         options = if %r{WITH\sGRANT\sOPTION}.match?(rest)
                     ['GRANT']
@@ -57,7 +61,7 @@ Puppet::Type.type(:mysql_grant).provide(:mysql, parent: Puppet::Provider::Mysql)
         instances << new(
           name: "#{user}@#{host}/#{table}",
           ensure: :present,
-          privileges: stripped_privileges.sort,
+          privileges: sorted_privileges,
           table: table,
           user: "#{user}@#{host}",
           options: options,

--- a/spec/acceptance/00_mysql_server_spec.rb
+++ b/spec/acceptance/00_mysql_server_spec.rb
@@ -39,7 +39,7 @@ describe 'mysql class' do
           databases => {
             'somedb' => {
               ensure  => 'present',
-              charset => #{$charset},
+              charset => #{fetch_charset},
             },
           }
         }

--- a/spec/acceptance/00_mysql_server_spec.rb
+++ b/spec/acceptance/00_mysql_server_spec.rb
@@ -39,7 +39,7 @@ describe 'mysql class' do
           databases => {
             'somedb' => {
               ensure  => 'present',
-              charset => 'utf8',
+              charset => #{$charset},
             },
           }
         }

--- a/spec/acceptance/01_mysql_db_spec.rb
+++ b/spec/acceptance/01_mysql_db_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper_acceptance'
 
 describe 'mysql::db define' do
   describe 'creating a database' do
+
     let(:pp) do
       <<-MANIFEST
         class { 'mysql::server':
@@ -14,6 +15,7 @@ describe 'mysql::db define' do
         mysql::db { 'spec1':
           user            => 'root1',
           password        => 'password',
+          charset         => #{$charset},
         }
       MANIFEST
     end
@@ -42,6 +44,7 @@ describe 'mysql::db define' do
           user     => 'root1',
           password => 'password',
           sql      => '/tmp/spec.sql',
+          charset  => #{$charset},
         }
       MANIFEST
     end
@@ -66,6 +69,7 @@ describe 'mysql::db define' do
           user     => 'root1',
           password => 'password',
           dbname   => 'realdb',
+          charset  => #{$charset},
         }
       MANIFEST
     end

--- a/spec/acceptance/01_mysql_db_spec.rb
+++ b/spec/acceptance/01_mysql_db_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper_acceptance'
 
 describe 'mysql::db define' do
   describe 'creating a database' do
-
     let(:pp) do
       <<-MANIFEST
         class { 'mysql::server':
@@ -15,7 +14,7 @@ describe 'mysql::db define' do
         mysql::db { 'spec1':
           user            => 'root1',
           password        => 'password',
-          charset         => #{$charset},
+          charset         => #{fetch_charset},
         }
       MANIFEST
     end
@@ -44,7 +43,7 @@ describe 'mysql::db define' do
           user     => 'root1',
           password => 'password',
           sql      => '/tmp/spec.sql',
-          charset  => #{$charset},
+          charset  => #{fetch_charset},
         }
       MANIFEST
     end
@@ -69,7 +68,7 @@ describe 'mysql::db define' do
           user     => 'root1',
           password => 'password',
           dbname   => 'realdb',
-          charset  => #{$charset},
+          charset  => #{fetch_charset},
         }
       MANIFEST
     end

--- a/spec/acceptance/04_mysql_backup_spec.rb
+++ b/spec/acceptance/04_mysql_backup_spec.rb
@@ -12,6 +12,7 @@ describe 'mysql::server::backup class' do
         ]:
           user     => 'backup',
           password => 'secret',
+          charset  => #{$charset},
         }
 
         class { 'mysql::server::backup':
@@ -72,6 +73,7 @@ describe 'mysql::server::backup class' do
           ]:
             user     => 'backup',
             password => 'secret',
+            charset  => #{$charset},
           }
 
           class { 'mysql::server::backup':
@@ -136,6 +138,7 @@ describe 'mysql::server::backup class' do
           ]:
             user     => 'backup',
             password => 'secret',
+            charset  => #{$charset},
           }
           case $facts['os']['family'] {
             /Debian/: {
@@ -260,6 +263,7 @@ describe 'mysql::server::backup class' do
           ]:
             user     => 'backup',
             password => 'secret',
+            charset  => #{$charset},
           }
           case $facts['os']['family'] {
             /Debian/: {

--- a/spec/acceptance/04_mysql_backup_spec.rb
+++ b/spec/acceptance/04_mysql_backup_spec.rb
@@ -12,7 +12,7 @@ describe 'mysql::server::backup class' do
         ]:
           user     => 'backup',
           password => 'secret',
-          charset  => #{$charset},
+          charset  => #{fetch_charset},
         }
 
         class { 'mysql::server::backup':
@@ -73,7 +73,7 @@ describe 'mysql::server::backup class' do
           ]:
             user     => 'backup',
             password => 'secret',
-            charset  => #{$charset},
+            charset  => #{fetch_charset},
           }
 
           class { 'mysql::server::backup':
@@ -138,7 +138,7 @@ describe 'mysql::server::backup class' do
           ]:
             user     => 'backup',
             password => 'secret',
-            charset  => #{$charset},
+            charset  => #{fetch_charset},
           }
           case $facts['os']['family'] {
             /Debian/: {
@@ -263,7 +263,7 @@ describe 'mysql::server::backup class' do
           ]:
             user     => 'backup',
             password => 'secret',
-            charset  => #{$charset},
+            charset  => #{fetch_charset},
           }
           case $facts['os']['family'] {
             /Debian/: {

--- a/spec/acceptance/types/mysql_database_spec.rb
+++ b/spec/acceptance/types/mysql_database_spec.rb
@@ -16,7 +16,7 @@ describe 'mysql_database' do
     pp = <<-MANIFEST
         mysql_database { 'spec_db':
           ensure  => present,
-          charset => #{$charset},
+          charset => #{fetch_charset},
         }
     MANIFEST
     it 'works without errors' do
@@ -38,7 +38,7 @@ describe 'mysql_database' do
           collate => 'latin1_swedish_ci',
         }
         mysql_database { 'spec_utf8':
-          charset => #{$charset},
+          charset => #{fetch_charset},
           collate => 'utf8_general_ci',
         }
     MANIFEST

--- a/spec/acceptance/types/mysql_database_spec.rb
+++ b/spec/acceptance/types/mysql_database_spec.rb
@@ -15,7 +15,8 @@ describe 'mysql_database' do
   describe 'creating database' do
     pp = <<-MANIFEST
         mysql_database { 'spec_db':
-          ensure => present,
+          ensure  => present,
+          charset => #{$charset},
         }
     MANIFEST
     it 'works without errors' do
@@ -37,7 +38,7 @@ describe 'mysql_database' do
           collate => 'latin1_swedish_ci',
         }
         mysql_database { 'spec_utf8':
-          charset => 'utf8',
+          charset => #{$charset},
           collate => 'utf8_general_ci',
         }
     MANIFEST
@@ -54,7 +55,7 @@ describe 'mysql_database' do
 
     it 'finds utf8 db #stdout' do
       run_shell("mysql -NBe \"SHOW VARIABLES LIKE '%_database'\" spec_utf8") do |r|
-        expect(r.stdout).to match(%r{^character_set_database\tutf8\ncollation_database\tutf8_general_ci$})
+        expect(r.stdout).to match(%r{^character_set_database\tutf8(mb3)?\ncollation_database\tutf8_general_ci$})
         expect(r.stderr).to be_empty
       end
     end

--- a/spec/acceptance/types/mysql_grant_spec.rb
+++ b/spec/acceptance/types/mysql_grant_spec.rb
@@ -274,7 +274,7 @@ describe 'mysql_grant' do
 
         mysql_database { 'foo':
           ensure  => present,
-          charset => '#{$charset}',
+          charset => '#{fetch_charset}',
         }
 
         exec { 'mysql-create-table':
@@ -686,7 +686,7 @@ describe 'mysql_grant' do
           user     => 'root1',
           password => 'password',
           sql      => '/tmp/grant_spec_table.sql',
-          charset  => #{$charset},
+          charset  => #{fetch_charset},
         }
     MANIFEST
     it 'creates table' do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -4,3 +4,10 @@ require 'puppet_litmus'
 require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))
 
 PuppetLitmus.configure!
+
+# On Ubuntu 20.04 'utf8' charset now sets 'utf8mb3' internally and breaks idempotence
+$charset = if os[:family] == 'ubuntu' && os[:release] =~ %r{^20\.04}
+                "utf8mb3"
+             else
+               "utf8"
+             end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -4,10 +4,3 @@ require 'puppet_litmus'
 require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))
 
 PuppetLitmus.configure!
-
-# On Ubuntu 20.04 'utf8' charset now sets 'utf8mb3' internally and breaks idempotence
-$charset = if os[:family] == 'ubuntu' && os[:release] =~ %r{^20\.04}
-                "utf8mb3"
-             else
-               "utf8"
-             end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -32,6 +32,14 @@ def export_locales
   LitmusHelper.instance.run_shell('source ~/.bashrc')
 end
 
+def fetch_charset
+  @charset ||= if os[:family] == 'ubuntu' && os[:release] =~ %r{^20\.04}
+                 'utf8mb3'
+               else
+                 'utf8'
+               end
+end
+
 RSpec.configure do |c|
   c.before :suite do
     if os[:family] == 'debian' || os[:family] == 'ubuntu'


### PR DESCRIPTION
When the MySQL module is used against MySQL8, mysql_grant is no more idempodent.
This is because MySQL 8+ no more returns "ALL" for SHOW GRANTS, when all privileges
are granted. Instead, the separate privileges are shown.
Unfortunately, the tests were just adapted to not error in this situation.
This commit aims to fix the issue and also fixes the tests.