### PR TITLE
(maint) Add missing entries for Debian in metadata.json

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -221,9 +221,15 @@ class mysql::params {
       } else {
         $php_package_name = 'php5-mysql'
       }
+      if $::operatingsystem == 'Debian' {
+        $xtrabackup_package_name_override = $::operatingsystemmajrelease ? {
+          '9'  => 'percona-xtrabackup-24',
+          '10' => 'percona-xtrabackup-24',
+          '11' => 'percona-xtrabackup-80',
+        }
+      }
       if  ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') < 0) or
-      ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) or
-      ($::operatingsystem == 'Debian') {
+      ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) {
         $xtrabackup_package_name_override = 'percona-xtrabackup-24'
       }
       if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) or

--- a/metadata.json
+++ b/metadata.json
@@ -52,6 +52,14 @@
       ]
     },
     {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "9",
+        "10",
+        "11"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "16.04",

--- a/spec/acceptance/04_mysql_backup_spec.rb
+++ b/spec/acceptance/04_mysql_backup_spec.rb
@@ -142,11 +142,7 @@ describe 'mysql::server::backup class' do
           }
           case $facts['os']['family'] {
             /Debian/: {
-              if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
-                $source_url = "http://repo.percona.com/apt/percona-release_1.0-22.generic_all.deb"
-              } else {
-                $source_url = "http://repo.percona.com/apt/percona-release_latest.${facts['os']['distro']['codename']}_all.deb"
-              }
+              $source_url = "http://repo.percona.com/apt/percona-release_latest.${facts['os']['distro']['codename']}_all.deb"
 
               file { '/tmp/percona-release_latest.deb':
                 ensure => present,
@@ -267,7 +263,7 @@ describe 'mysql::server::backup class' do
           }
           case $facts['os']['family'] {
             /Debian/: {
-              $source_url = "http://repo.percona.com/apt/percona-release_1.0-22.generic_all.deb"
+              $source_url = "http://repo.percona.com/apt/percona-release_latest.${facts['os']['distro']['codename']}_all.deb"
 
               file { '/tmp/percona-release_latest.deb':
                 ensure => present,


### PR DESCRIPTION
This module has support for all versions of Debian, but the
corresponding enty in metadata.json was missing.