### PR TITLE
(IAC-1595) Return Debian to Metadata

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    
     - name: "Honeycomb: Start recording"
       uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
       with:
@@ -25,7 +26,6 @@ jobs:
       run: |
         echo STEP_ID="auto-release" >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
     - name: "Checkout Source"
       if: ${{ github.repository_owner == 'puppetlabs' }}
       uses: actions/checkout@v2
@@ -83,7 +83,7 @@ jobs:
       run: |
         echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
         echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
-
+ 
     - name: "Honeycomb: Record finish step"
       if: ${{ always() }}
       run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+
 env:
   HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
   HONEYCOMB_DATASET: litmus tests
@@ -16,6 +17,7 @@ jobs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
 
     steps:
+     
     - name: "Honeycomb: Start recording"
       uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
       with:
@@ -27,7 +29,6 @@ jobs:
       run: |
         echo STEP_ID=setup-environment >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
     - name: Checkout Source
       uses: actions/checkout@v2
       if: ${{ github.repository_owner == 'puppetlabs' }}
@@ -45,29 +46,27 @@ jobs:
         echo ::group::bundler environment
         buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
         echo ::endgroup::
-
+   
     - name: "Honeycomb: Record Setup Environment time"
       if: ${{ github.repository_owner == 'puppetlabs' }}
       run: |
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
         echo STEP_ID=Setup-Acceptance-Test-Matrix >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
     - name: Setup Acceptance Test Matrix
       id: get-matrix
       if: ${{ github.repository_owner == 'puppetlabs' }}
       run: |
         if [ '${{ github.repository_owner }}' == 'puppetlabs' ]; then
-          buildevents cmd $TRACE_ID $STEP_ID matrix_from_metadata -- bundle exec matrix_from_metadata_v2
+          buildevents cmd $TRACE_ID $STEP_ID matrix_from_metadata -- bundle exec matrix_from_metadata_v2 --exclude-platforms '["Debian-9", "Debian-10", "Debian-11"]'
         else
           echo  "::set-output name=matrix::{}"
         fi
-
+  
     - name: "Honeycomb: Record Setup Test Matrix time"
       if: ${{ always() }}
       run: |
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Test Matrix'
-
   Acceptance:
     name: "${{matrix.platforms.label}}, ${{matrix.collection}}"
     needs:

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -2,7 +2,9 @@ name: "PR Testing"
 
 on: [pull_request]
 
+
 env:
+ 
   HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
   HONEYCOMB_DATASET: litmus tests
 
@@ -14,6 +16,7 @@ jobs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
 
     steps:
+    
     - name: "Honeycomb: Start recording"
       uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
       with:
@@ -25,7 +28,6 @@ jobs:
       run: |
         echo STEP_ID=setup-environment >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
     - name: Checkout Source
       uses: actions/checkout@v2
       if: ${{ github.repository_owner == 'puppetlabs' }}
@@ -43,14 +45,13 @@ jobs:
         echo ::group::bundler environment
         buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
         echo ::endgroup::
-
+  
     - name: "Honeycomb: Record Setup Environment time"
       if: ${{ github.repository_owner == 'puppetlabs' }}
       run: |
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
         echo STEP_ID=Setup-Acceptance-Test-Matrix >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
     - name: Run validation steps
       run: |
         bundle exec rake validate
@@ -60,16 +61,15 @@ jobs:
       id: get-matrix
       run: |
         if [ '${{ github.repository_owner }}' == 'puppetlabs' ]; then
-          buildevents cmd $TRACE_ID $STEP_ID matrix_from_metadata -- bundle exec matrix_from_metadata_v2
+          buildevents cmd $TRACE_ID $STEP_ID matrix_from_metadata -- bundle exec matrix_from_metadata_v2 --exclude-platforms '["Debian-9", "Debian-10", "Debian-11"]'
         else
           echo  "::set-output name=matrix::{}"
         fi
-
+ 
     - name: "Honeycomb: Record Setup Test Matrix time"
       if: ${{ always() }}
       run: |
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Test Matrix'
-
   Acceptance:
     name: "${{matrix.platforms.label}}, ${{matrix.collection}}"
     needs:
@@ -89,7 +89,7 @@ jobs:
         echo 'platform=${{ matrix.platforms.image }}' >> $BUILDEVENT_FILE
         echo 'collection=${{ matrix.collection }}' >> $BUILDEVENT_FILE
         echo 'label=${{ matrix.platforms.label }}' >> $BUILDEVENT_FILE
-
+ 
     - name: "Honeycomb: Start recording"
       uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
       with:
@@ -102,7 +102,6 @@ jobs:
       run: |
         echo STEP_ID=${{ matrix.platforms.image }}-${{ matrix.collection }}-1 >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
     - name: Checkout Source
       uses: actions/checkout@v2
 
@@ -117,14 +116,13 @@ jobs:
         echo ::group::bundler environment
         buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
         echo ::endgroup::
-
+ 
     - name: "Honeycomb: Record Setup Environment time"
       if: ${{ always() }}
       run: |
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
         echo STEP_ID=${{ matrix.platforms.image }}-${{ matrix.collection }}-2 >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
     - name: Provision test environment
       run: |
         buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:provision ${{ matrix.platforms.image }}' -- bundle exec rake 'litmus:provision[${{matrix.platforms.provider}},${{ matrix.platforms.image }}]'
@@ -150,7 +148,7 @@ jobs:
     - name: Install module
       run: |
         buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:install_module' -- bundle exec rake 'litmus:install_module'
-
+ 
     - name: "Honeycomb: Record deployment times"
       if: ${{ always() }}
       run: |
@@ -159,18 +157,16 @@ jobs:
         echo STEP_ID=${{ matrix.platforms.image }}-${{ matrix.collection }}-3 >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
         echo ::endgroup::
-
     - name: Run acceptance tests
       run: |
         buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:acceptance:parallel' -- bundle exec rake 'litmus:acceptance:parallel'
-
+ 
     - name: "Honeycomb: Record acceptance testing times"
       if: ${{ always() }}
       run: |
         buildevents step $TRACE_ID $STEP_ID $STEP_START 'Run acceptance tests'
         echo STEP_ID=${{ matrix.platforms.image }}-${{ matrix.collection }}-4 >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
     - name: Remove test environment
       if: ${{ always() }}
       continue-on-error: true
@@ -182,7 +178,7 @@ jobs:
           echo
           echo ::endgroup::
         fi
-
+ 
     - name: "Honeycomb: Record removal times"
       if: ${{ always() }}
       run: |

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
   pull_request:
 
+
 env:
   HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
   HONEYCOMB_DATASET: litmus tests
@@ -18,6 +19,7 @@ jobs:
       spec_matrix: ${{ steps.get-matrix.outputs.spec_matrix }}
 
     steps:
+    
       - name: "Honeycomb: Start recording"
         uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
         with:
@@ -29,7 +31,6 @@ jobs:
         run: |
           echo STEP_ID=setup-environment >> $GITHUB_ENV
           echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
       - name: Checkout Source
         uses: actions/checkout@v2
         if: ${{ github.repository_owner == 'puppetlabs' }}
@@ -47,14 +48,12 @@ jobs:
           echo ::group::bundler environment
           buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
           echo ::endgroup::
-
       - name: "Honeycomb: Record Setup Environment time"
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
           buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
           echo STEP_ID=Setup-Acceptance-Test-Matrix >> $GITHUB_ENV
           echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
       - name: Run Static & Syntax Tests
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
@@ -68,12 +67,10 @@ jobs:
           else
             echo  "::set-output name=spec_matrix::{}"
           fi
-
       - name: "Honeycomb: Record Setup Test Matrix time"
         if: ${{ always() }}
         run: |
           buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Test Matrix'
-
   Spec:
     name: "Spec Tests (Puppet: ${{matrix.puppet_version}}, Ruby Ver: ${{matrix.ruby_version}})"
     needs:
@@ -96,7 +93,6 @@ jobs:
 
       - run: |
           echo 'puppet_version=${{ env.SANITIZED_PUPPET_VERSION }}' >> $BUILDEVENT_FILE
-
       - name: "Honeycomb: Start first step"
         run: |
           echo "STEP_ID=${{ env.SANITIZED_PUPPET_VERSION }}-spec" >> $GITHUB_ENV
@@ -109,7 +105,6 @@ jobs:
           dataset: ${{ env.HONEYCOMB_DATASET }}
           job-status: ${{ job.status }}
           matrix-key: ${{ env.SANITIZED_PUPPET_VERSION }}
-
       - name: Checkout Source
         uses: actions/checkout@v2
 

--- a/.sync.yml
+++ b/.sync.yml
@@ -21,8 +21,16 @@ Rakefile:
   unmanaged: false
 .github/workflows/nightly.yml:
   unmanaged: false
+  exclude_platforms:
+    - Debian-9
+    - Debian-10
+    - Debian-11
 .github/workflows/pr_test.yml:
   unmanaged: false
+  exclude_platforms:
+    - Debian-9
+    - Debian-10
+    - Debian-11
 .github/workflows/auto_release.yml:
   unmanaged: false
 .github/workflows/spec.yml:

--- a/Rakefile
+++ b/Rakefile
@@ -43,6 +43,7 @@ end
 
 PuppetLint.configuration.send('disable_relative')
 
+
 if Bundler.rubygems.find_name('github_changelog_generator').any?
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?

--- a/metadata.json
+++ b/metadata.json
@@ -38,6 +38,14 @@
       ]
     },
     {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "9",
+        "10",
+        "11"
+      ]
+    },
+    {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
         "6",
@@ -68,6 +76,6 @@
   ],
   "description": "MySQL module",
   "template-url": "https://github.com/puppetlabs/pdk-templates#main",
-  "template-ref": "heads/main-0-g51828b4",
+  "template-ref": "heads/main-0-gbd3742c",
   "pdk-version": "2.2.0"
 }


### PR DESCRIPTION
Debian had previously been removed in order to cancel the tests, however this can now be accomplished with the `exclude_platforms` parameter within the sync.yml