### PR TITLE
add mysql_native_password plugin to authentication_string vs password

### DIFF
--- a/lib/puppet/provider/mysql_user/mysql.rb
+++ b/lib/puppet/provider/mysql_user/mysql.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) 
       @max_updates_per_hour, ssl_type, ssl_cipher, x509_issuer, x509_subject,
       @password, @plugin, @authentication_string = mysql_caller(query, 'regular').chomp.split(%r{\t})
       @tls_options = parse_tls_options(ssl_type, ssl_cipher, x509_issuer, x509_subject)
-      if newer_than('mariadb' => '10.1.21') && @plugin == 'ed25519'
+      if newer_than('mariadb' => '10.1.21') && (@plugin == 'ed25519' || @plugin == 'mysql_native_password')
         # Some auth plugins (e.g. ed25519) use authentication_string
         # to store password hash or auth information
         @password = @authentication_string


### PR DESCRIPTION
On a debian-11 server the plugin kept changing the password of a user. Turns out this user is using the plugin 'mysql_native_password', which does not use the PASSWORD field.