### PR TITLE
Add support for mariabackup 

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,30 @@ class { 'mysql::server::backup':
 }
 ```
 
+The next example shows how to use mariabackup (a fork of xtrabackup) as a backup provider.
+Note that on most Linux/BSD distributions, this will require setting `backupmethod_package => 'mariadb-backup'` in the `mysql::server::backup` declaration in order to override the default xtrabackup package (`percona-xtrabackup`).
+
+```puppet
+class { 'mysql::server':
+  package_name            => 'mariadb-server',
+  package_ensure          => '1:10.3.21+maria~xenial',
+  service_name            => 'mysqld',
+  root_password           => 'AVeryStrongPasswordUShouldEncrypt!',
+}
+
+class { 'mysql::server::backup':
+  backupuser              => 'mariabackup',
+  backuppassword          => 'AVeryStrongPasswordUShouldEncrypt!',
+  provider                => 'xtrabackup',
+  backupmethod            => 'mariabackup'
+  backupmethod_package    => 'mariadb-backup',
+  backupdir               => '/tmp/backups',
+  backuprotate            => 15,
+  execpath                => '/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin',
+  time                    => ['23', '15'],
+}
+```
+
 ## Reference
 
 ### Classes

--- a/manifests/backup/mysqlbackup.pp
+++ b/manifests/backup/mysqlbackup.pp
@@ -31,6 +31,7 @@ class mysql::backup::mysqlbackup (
   $install_cron             = true,
   $compression_command      = undef,
   $compression_extension    = undef,
+  $backupmethod_package     = undef,
 ) inherits mysql::params {
   $backuppassword_unsensitive = if $backuppassword =~ Sensitive {
     $backuppassword.unwrap

--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -31,7 +31,8 @@ class mysql::backup::mysqldump (
   $incremental_backups      = false,
   $install_cron             = true,
   $compression_command      = 'bzcat -zc',
-  $compression_extension    = '.bz2'
+  $compression_extension    = '.bz2',
+  $backupmethod_package     = undef,
 ) inherits mysql::params {
   $backuppassword_unsensitive = if $backuppassword =~ Sensitive {
     $backuppassword.unwrap

--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -3,7 +3,6 @@
 # @api private
 #
 class mysql::backup::xtrabackup (
-  $xtrabackup_package_name  = $mysql::params::xtrabackup_package_name,
   $backupuser               = undef,
   Optional[Variant[String, Sensitive[String]]] $backuppassword = undef,
   $backupdir                = '',
@@ -33,8 +32,9 @@ class mysql::backup::xtrabackup (
   $install_cron             = true,
   $compression_command      = undef,
   $compression_extension    = undef,
+  $backupmethod_package     = $mysql::params::xtrabackup_package_name,
 ) inherits mysql::params {
-  ensure_packages($xtrabackup_package_name)
+  ensure_packages($backupmethod_package)
 
   $backuppassword_unsensitive = if $backuppassword =~ Sensitive {
     $backuppassword.unwrap
@@ -94,7 +94,7 @@ class mysql::backup::xtrabackup (
       hour    => $time[0],
       minute  => $time[1],
       weekday => '0',
-      require => Package[$xtrabackup_package_name],
+      require => Package[$backupmethod_package],
     }
   }
 
@@ -126,7 +126,7 @@ class mysql::backup::xtrabackup (
     hour    => $time[0],
     minute  => $time[1],
     weekday => $daily_cron_data['weekday'],
-    require => Package[$xtrabackup_package_name],
+    require => Package[$backupmethod_package],
   }
 
   file { $backupdir:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,7 +37,6 @@ class mysql::params {
   $client_dev_package_provider = undef
   $daemon_dev_package_ensure   = 'present'
   $daemon_dev_package_provider = undef
-  $xtrabackup_package_name_default = 'percona-xtrabackup'
 
   case $::osfamily {
     'RedHat': {
@@ -61,11 +60,11 @@ class mysql::params {
           if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
             $provider = 'mariadb'
             if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
-              $xtrabackup_package_name_override = 'percona-xtrabackup-24'
+              $xtrabackup_package_name = 'percona-xtrabackup-24'
             }
           } else {
             $provider = 'mysql'
-            $xtrabackup_package_name_override = 'percona-xtrabackup-20'
+            $xtrabackup_package_name = 'percona-xtrabackup-20'
           }
           if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
             $java_package_name   = 'mariadb-java-client'
@@ -154,7 +153,7 @@ class mysql::params {
       $mycnf_owner         = undef
       $mycnf_group         = undef
       $server_service_name = 'mysql'
-      $xtrabackup_package_name_override = 'xtrabackup'
+      $xtrabackup_package_name = 'xtrabackup'
 
       $ssl_ca              = '/etc/mysql/cacert.pem'
       $ssl_cert            = '/etc/mysql/server-cert.pem'
@@ -224,7 +223,7 @@ class mysql::params {
       if  ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') < 0) or
       ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) or
       ($::operatingsystem == 'Debian') {
-        $xtrabackup_package_name_override = 'percona-xtrabackup-24'
+        $xtrabackup_package_name = 'percona-xtrabackup-24'
       }
       if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) or
       ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '11') >= 0) {
@@ -511,10 +510,8 @@ class mysql::params {
     },
   }
 
-  if defined('$xtrabackup_package_name_override') {
-    $xtrabackup_package_name = pick($xtrabackup_package_name_override, $xtrabackup_package_name_default)
-  } else {
-    $xtrabackup_package_name = $xtrabackup_package_name_default
+  if !defined('$xtrabackup_package_name') {
+    $xtrabackup_package_name = 'percona-xtrabackup'
   }
 
   ## Additional graceful failures

--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -3,17 +3,23 @@
 #
 # @example Create a basic MySQL backup:
 #   class { 'mysql::server':
-#     root_password => 'password'
+#     root_password           => 'password'
 #   }
 #   class { 'mysql::server::backup':
-#     backupuser     => 'myuser',
-#     backuppassword => 'mypassword',
-#     backupdir      => '/tmp/backups',
+#     backupuser              => 'myuser',
+#     backuppassword          => 'mypassword',
+#     backupdir               => '/tmp/backups',
+#   }
+#
+# @example Create a basic MySQL backup using mariabackup:
+#   class { 'mysql::server':
+#     root_password           => 'password'
 #   }
 #   class { 'mysql::server::backup':
-#     backupmethod => 'mariabackup',
-#     provider     => 'xtrabackup',
-#     backupdir    => '/tmp/backups',
+#     backupmethod            => 'mariabackup',
+#     backupmethod_package    => 'mariadb-backup'
+#     provider                => 'xtrabackup',
+#     backupdir               => '/tmp/backups',
 #   }
 #
 # @param backupuser
@@ -60,7 +66,7 @@
 # @param execpath
 #   Allows you to set a custom PATH should your MySQL installation be non-standard places. Defaults to `/usr/bin:/usr/sbin:/bin:/sbin`.
 # @param provider
-#   Sets the server backup implementation. Valid values are:
+#   Sets the server backup implementation. Valid values are: xtrabackup, mysqldump, mysqlbackup
 # @param maxallowedpacket
 #   Defines the maximum SQL statement size for the backup dump script. The default value is 1MB, as this is the default MySQL Server value.
 # @param optional_args
@@ -72,6 +78,8 @@
 #   on the target system. Packages for it are NOT automatically installed.
 # @param compression_extension
 #   Configure the file extension for the compressed backup (when using the mysqldump provider)
+# @param backupmethod_package
+#   The package which provides the binary specified by the backupmethod parameter.
 class mysql::server::backup (
   $backupuser               = undef,
   Optional[Variant[String, Sensitive[String]]] $backuppassword = undef,
@@ -100,7 +108,8 @@ class mysql::server::backup (
   $incremental_backups      = true,
   $install_cron             = true,
   $compression_command      = undef,
-  $compression_extension    = undef
+  $compression_extension    = undef,
+  $backupmethod_package     = $mysql::params::xtrabackup_package_name,
 ) inherits mysql::params {
   if $prescript and $provider =~ /(mysqldump|mysqlbackup)/ {
     warning("The 'prescript' option is not currently implemented for the ${provider} backup provider.")
@@ -135,6 +144,7 @@ class mysql::server::backup (
         'install_cron'             => $install_cron,
         'compression_command'      => $compression_command,
         'compression_extension'    => $compression_extension,
+        'backupmethod_package'     => $backupmethod_package,
       }
   })
 }

--- a/spec/classes/mysql_backup_xtrabackup_spec.rb
+++ b/spec/classes/mysql_backup_xtrabackup_spec.rb
@@ -228,7 +228,8 @@ describe 'mysql::backup::xtrabackup' do
 
       context 'with mariabackup' do
         let(:params) do
-          { backupmethod: 'mariabackup' }.merge(default_params)
+          { backupmethod: 'mariabackup',
+            backupmethod_package: 'mariadb-backup' }.merge(default_params)
         end
 
         it 'contain the mariabackup executor' do


### PR DESCRIPTION
This is a fix for https://tickets.puppetlabs.com/browse/MODULES-11079

The current behavior of this module is to install the `percona-xtrabackup` package, even if we specify `mariabackup` as a backupmethod. This PR adds the `backupmethod_package` param, which allows users to specify the package needed for the backup binary (e.g. for mariabackup, you would specify the `mariadb-backup` package). An example is also provided in the README in this PR. 