### PR TITLE
Use MariaDB for Ubuntu 20.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -171,9 +171,10 @@ class mysql::params {
     }
 
     'Debian': {
-      if $::operatingsystem == 'Debian' {
+      if $::operatingsystem == 'Debian' or
+      ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) {
         $provider = 'mariadb'
-      } else { # Ubuntu
+      } else {
         $provider = 'mysql'
       }
       if $provider == 'mariadb' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -171,8 +171,8 @@ class mysql::params {
     }
 
     'Debian': {
-      if $::operatingsystem == 'Debian' or
-      ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) {
+      if $facts['os']['name'] == 'Debian' or
+      ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'], '20.04') >= 0) {
         $provider = 'mariadb'
       } else {
         $provider = 'mysql'

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -34,7 +34,7 @@ class mysql::server::config {
   }
 
   #Debian: Creating world readable directories before installing.
-  case $::osfamily {
+  case $facts['os']['family'] {
     'Debian': {
       if $managed_dirs {
         $managed_dirs.each | $entry | {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -34,7 +34,7 @@ class mysql::server::config {
   }
 
   #Debian: Creating world readable directories before installing.
-  case $::operatingsystem {
+  case $::osfamily {
     'Debian': {
       if $managed_dirs {
         $managed_dirs.each | $entry | {

--- a/spec/acceptance/00_mysql_server_spec.rb
+++ b/spec/acceptance/00_mysql_server_spec.rb
@@ -38,8 +38,7 @@ describe 'mysql class' do
           },
           databases => {
             'somedb' => {
-              ensure  => 'present',
-              charset => #{fetch_charset},
+              ensure => 'present',
             },
           }
         }

--- a/spec/acceptance/01_mysql_db_spec.rb
+++ b/spec/acceptance/01_mysql_db_spec.rb
@@ -14,7 +14,6 @@ describe 'mysql::db define' do
         mysql::db { 'spec1':
           user            => 'root1',
           password        => 'password',
-          charset         => #{fetch_charset},
         }
       MANIFEST
     end
@@ -43,7 +42,6 @@ describe 'mysql::db define' do
           user     => 'root1',
           password => 'password',
           sql      => '/tmp/spec.sql',
-          charset  => #{fetch_charset},
         }
       MANIFEST
     end
@@ -68,7 +66,6 @@ describe 'mysql::db define' do
           user     => 'root1',
           password => 'password',
           dbname   => 'realdb',
-          charset  => #{fetch_charset},
         }
       MANIFEST
     end

--- a/spec/acceptance/04_mysql_backup_spec.rb
+++ b/spec/acceptance/04_mysql_backup_spec.rb
@@ -12,7 +12,6 @@ describe 'mysql::server::backup class' do
         ]:
           user     => 'backup',
           password => 'secret',
-          charset  => #{fetch_charset},
         }
 
         class { 'mysql::server::backup':
@@ -73,7 +72,6 @@ describe 'mysql::server::backup class' do
           ]:
             user     => 'backup',
             password => 'secret',
-            charset  => #{fetch_charset},
           }
 
           class { 'mysql::server::backup':
@@ -138,7 +136,6 @@ describe 'mysql::server::backup class' do
           ]:
             user     => 'backup',
             password => 'secret',
-            charset  => #{fetch_charset},
           }
           case $facts['os']['family'] {
             /Debian/: {
@@ -259,7 +256,6 @@ describe 'mysql::server::backup class' do
           ]:
             user     => 'backup',
             password => 'secret',
-            charset  => #{fetch_charset},
           }
           case $facts['os']['family'] {
             /Debian/: {

--- a/spec/acceptance/types/mysql_database_spec.rb
+++ b/spec/acceptance/types/mysql_database_spec.rb
@@ -15,8 +15,7 @@ describe 'mysql_database' do
   describe 'creating database' do
     pp = <<-MANIFEST
         mysql_database { 'spec_db':
-          ensure  => present,
-          charset => #{fetch_charset},
+          ensure => present,
         }
     MANIFEST
     it 'works without errors' do
@@ -38,7 +37,7 @@ describe 'mysql_database' do
           collate => 'latin1_swedish_ci',
         }
         mysql_database { 'spec_utf8':
-          charset => #{fetch_charset},
+          charset => 'utf8',
           collate => 'utf8_general_ci',
         }
     MANIFEST

--- a/spec/acceptance/types/mysql_grant_spec.rb
+++ b/spec/acceptance/types/mysql_grant_spec.rb
@@ -273,8 +273,7 @@ describe 'mysql_grant' do
         $dbSubnet = '10.10.10.%'
 
         mysql_database { 'foo':
-          ensure  => present,
-          charset => '#{fetch_charset}',
+          ensure => present,
         }
 
         exec { 'mysql-create-table':
@@ -686,7 +685,6 @@ describe 'mysql_grant' do
           user     => 'root1',
           password => 'password',
           sql      => '/tmp/grant_spec_table.sql',
-          charset  => #{fetch_charset},
         }
     MANIFEST
     it 'creates table' do

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -32,14 +32,6 @@ def export_locales
   LitmusHelper.instance.run_shell('. ~/.bashrc')
 end
 
-def fetch_charset
-  @charset ||= if os[:family] == 'ubuntu' && os[:release] =~ %r{^20\.04}
-                 'utf8mb3'
-               else
-                 'utf8'
-               end
-end
-
 RSpec.configure do |c|
   c.before :suite do
     if os[:family] == 'debian' || os[:family] == 'ubuntu'


### PR DESCRIPTION
Ran into numerous issues when Puppet attempted to install MySQL 8.0. Not sure if maybe the repos on Azure Ubuntu 20.04 are the problem but using MariaDB solved the issues.