### PR TITLE
Fix typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ class { 'mysql::server::backup':
   backupuser              => 'mariabackup',
   backuppassword          => 'AVeryStrongPasswordUShouldEncrypt!',
   provider                => 'xtrabackup',
-  backupmethod            => 'mariabackup'
+  backupmethod            => 'mariabackup',
   backupmethod_package    => 'mariadb-backup',
   backupdir               => '/tmp/backups',
   backuprotate            => 15,


### PR DESCRIPTION
Fixing syntax error in my README example added in PR #1447   (forgot a comma)