### PR TITLE
MySQL 8.0: Grant required privileges to xtrabackup user

### DIFF
--- a/lib/facter/mysqld_version.rb
+++ b/lib/facter/mysqld_version.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 Facter.add('mysqld_version') do
-  confine { Facter::Core::Execution.which('mysqld') }
+  confine { Facter::Core::Execution.which('mysqld') || Facter::Core::Execution.which('/usr/libexec/mysqld') }
   setcode do
-    Facter::Core::Execution.execute('mysqld --no-defaults -V 2>/dev/null')
+    # Add /usr/libexec to PATH to find mysqld command
+    Facter::Core::Execution.execute('env PATH=$PATH:/usr/libexec mysqld --no-defaults -V 2>/dev/null')
   end
 end

--- a/spec/classes/mysql_backup_xtrabackup_spec.rb
+++ b/spec/classes/mysql_backup_xtrabackup_spec.rb
@@ -11,7 +11,9 @@ describe 'mysql::backup::xtrabackup' do
         EOF
       end
       let(:facts) do
-        facts.merge(root_home: '/root')
+        facts.merge(root_home: '/root',
+                    mysql_version: '5.7',
+                    mysld_version: 'mysqld  Ver 5.7.38 for Linux on x86_64 (MySQL Community Server - (GPL)')
       end
 
       let(:default_params) do
@@ -114,6 +116,69 @@ describe 'mysql::backup::xtrabackup' do
               end,
             )
             .that_requires('Mysql_user[backupuser@localhost]')
+        end
+
+        context 'with MySQL version 5.7' do
+          let(:facts) do
+            facts.merge(mysql_version: '5.7')
+          end
+
+          it {
+            is_expected.not_to contain_mysql_grant('backupuser@localhost/performance_schema.keyring_component_status')
+            is_expected.not_to contain_mysql_grant('backupuser@localhost/performance_schema.log_status')
+            is_expected.not_to contain_mysql_grant('backupuser@localhost/*.*')
+              .with(
+                ensure: 'present',
+                user: 'backupuser@localhost',
+                table: '*.*',
+                privileges:
+                  ['BACKUP_ADMIN'],
+              )
+              .that_requires('Mysql_user[backupuser@localhost]')
+          }
+        end
+
+        context 'with MySQL version 8.0' do
+          let(:facts) do
+            facts.merge(mysql_version: '8.0',
+                        mysld_version: 'mysqld  Ver 8.0.28 for Linux on x86_64 (MySQL Community Server - GPL)')
+          end
+
+          it {
+            is_expected.to contain_mysql_grant('backupuser@localhost/*.*')
+              .with(
+                ensure: 'present',
+                user: 'backupuser@localhost',
+                table: '*.*',
+                privileges:
+                if (facts[:operatingsystem] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '11') >= 0) ||
+                  (facts[:operatingsystem] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '22') >= 0)
+                  ['BINLOG MONITOR', 'RELOAD', 'PROCESS', 'LOCK TABLES', 'BACKUP_ADMIN']
+                else
+                  ['RELOAD', 'PROCESS', 'LOCK TABLES', 'REPLICATION CLIENT', 'BACKUP_ADMIN']
+                end,
+              )
+              .that_requires('Mysql_user[backupuser@localhost]')
+            is_expected.to contain_mysql_grant('backupuser@localhost/performance_schema.keyring_component_status')
+              .with(
+                ensure: 'present',
+                user: 'backupuser@localhost',
+                table: 'performance_schema.keyring_component_status',
+                privileges:
+                  ['SELECT'],
+              )
+              .that_requires('Mysql_user[backupuser@localhost]')
+
+            is_expected.to contain_mysql_grant('backupuser@localhost/performance_schema.log_status')
+              .with(
+                ensure: 'present',
+                user: 'backupuser@localhost',
+                table: 'performance_schema.log_status',
+                privileges:
+                  ['SELECT'],
+              )
+              .that_requires('Mysql_user[backupuser@localhost]')
+          }
         end
       end
 

--- a/spec/unit/facter/mysqld_version_spec.rb
+++ b/spec/unit/facter/mysqld_version_spec.rb
@@ -11,7 +11,7 @@ describe Facter::Util::Fact.to_s do
     context 'with value' do
       before :each do
         allow(Facter::Core::Execution).to receive(:which).with('mysqld').and_return('/usr/sbin/mysqld')
-        allow(Facter::Core::Execution).to receive(:execute).with('mysqld --no-defaults -V 2>/dev/null')
+        allow(Facter::Core::Execution).to receive(:execute).with('env PATH=$PATH:/usr/libexec mysqld --no-defaults -V 2>/dev/null')
                                                            .and_return('mysqld  Ver 5.5.49-37.9 for Linux on x86_64 (Percona Server (GPL), Release 37.9, Revision efa0073)')
       end
       it {


### PR DESCRIPTION
Since MySQL version 8.0 the backup user needs the following additional privileges:
- SELECT privilege on the _performance_schema.log_status_ table
- SELECT privilege on the _keyring_component_status_ table
- BACKUP_ADMIN privilege on all tables \*.\*

https://docs.percona.com/percona-xtrabackup/latest/using_xtrabackup/privileges.html