### PR TITLE
Add CentOS 9 to supported operating systems

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,8 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
This adds CentOS 9 to supported operating systems.