### PR TITLE
[Compatibility] Add Raspbian OS to provider configuration

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -170,7 +170,7 @@ class mysql::params {
     }
 
     'Debian': {
-      if $facts['os']['name'] == 'Debian' or
+      if $facts['os']['name'] == 'Debian' or $facts['os']['name'] == 'Raspbian' or
       ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'], '20.04') >= 0) {
         $provider = 'mariadb'
       } else {


### PR DESCRIPTION
On Raspbian OS must be defined as provider 'mariadb', otherwise can not install mysql-agent