### PR TITLE
Harden db defined type

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -9,6 +9,12 @@
 #     grant    => ['SELECT', 'UPDATE'],
 #   }
 #
+# @param name
+#   The name of the database to create. Database names must:
+#     * be longer than 64 characters.
+#     * not contain / \ or . characters.
+#     * not contain characters that are not permitted in file names.
+#     * not end with space characters.
 # @param user
 #   The user for the database you're creating.
 # @param password
@@ -28,7 +34,7 @@
 # @param grant_options
 #   The grant_options for the grant for user@host on the database.
 # @param sql
-#   The path to the sqlfile you want to execute. This can be single file specified as string, or it can be an array of strings.
+#   The path to the sqlfile you want to execute. This can be a an array containing one or more file paths.
 # @param enforce_sql
 #   Specifies whether executing the sqlfiles should happen on every run. If set to false, sqlfiles only run once.
 # @param ensure
@@ -41,25 +47,41 @@
 define mysql::db (
   $user,
   Variant[String, Sensitive[String]] $password,
-  $tls_options                                = undef,
-  $dbname                                     = $name,
-  $charset                                    = 'utf8',
-  $collate                                    = 'utf8_general_ci',
-  $host                                       = 'localhost',
-  $grant                                      = 'ALL',
-  $grant_options                              = undef,
-  Optional[Variant[Array, Hash, String]] $sql = undef,
-  $enforce_sql                                = false,
-  Enum['absent', 'present'] $ensure           = 'present',
-  $import_timeout                             = 300,
-  $import_cat_cmd                             = 'cat',
-  $mysql_exec_path                            = undef,
+  $tls_options                                  = undef,
+  String $dbname                                = $name,
+  $charset                                      = 'utf8',
+  $collate                                      = 'utf8_general_ci',
+  $host                                         = 'localhost',
+  $grant                                        = 'ALL',
+  $grant_options                                = undef,
+  Optional[Array] $sql                          = undef,
+  $enforce_sql                                  = false,
+  Enum['absent', 'present'] $ensure             = 'present',
+  $import_timeout                               = 300,
+  Enum['cat', 'zcat'] $import_cat_cmd           = 'cat',
+  $mysql_exec_path                              = undef,
 ) {
-  $table = "${dbname}.*"
-
-  $sql_inputs = join([$sql], ' ')
-
   include 'mysql::client'
+
+  # Ensure that the database name is valid.
+  if $dbname !~ /^[^\/?%*:|\""<>.\s;]{1,64}$/ {
+    $message = "The database name '${dbname}' is invalid. Values must:
+      * be longer than 64 characters.
+      * not contain // \\ or . characters.
+      * not contain characters that are not permitted in file names.
+      * not end with space characters."
+    fail($message)
+  }
+
+  # Ensure that the sql files passed are valid file paths.
+  if $sql {
+    $sql.each | $sqlfile | {
+      if $sqlfile !~ /^\/(?:[A-Za-z0-9_-]+\/?+)+(?:.[A-Za-z0-9]+)$/ {
+        $message = "The file '${sqlfile}' is invalid. A a valid file path is expected."
+        fail($message)
+      }
+    }
+  }
 
   if ($mysql_exec_path) {
     $_mysql_exec_path = $mysql_exec_path
@@ -84,6 +106,8 @@ define mysql::db (
   ensure_resource('mysql_user', "${user}@${host}", $user_resource)
 
   if $ensure == 'present' {
+    $table = "${dbname}.*"
+
     mysql_grant { "${user}@${host}/${table}":
       privileges => $grant,
       provider   => 'mysql',
@@ -96,14 +120,12 @@ define mysql::db (
       ],
     }
 
-    $refresh = ! $enforce_sql
-
     if $sql {
       exec { "${dbname}-import":
-        command     => "${import_cat_cmd} ${sql_inputs} | mysql ${dbname}",
+        command     => "${import_cat_cmd} ${shell_join($sql)} | mysql ${dbname}",
         logoutput   => true,
         environment => "HOME=${::root_home}",
-        refreshonly => $refresh,
+        refreshonly => ! $enforce_sql,
         path        => "/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:${_mysql_exec_path}",
         require     => Mysql_grant["${user}@${host}/${table}"],
         subscribe   => Mysql_database[$dbname],

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -58,7 +58,7 @@ define mysql::db (
   $enforce_sql                                  = false,
   Enum['absent', 'present'] $ensure             = 'present',
   $import_timeout                               = 300,
-  Enum['cat', 'zcat'] $import_cat_cmd           = 'cat',
+  Enum['cat', 'zcat', 'bzcat'] $import_cat_cmd  = 'cat',
   $mysql_exec_path                              = undef,
 ) {
   include 'mysql::client'

--- a/spec/acceptance/01_mysql_db_spec.rb
+++ b/spec/acceptance/01_mysql_db_spec.rb
@@ -43,9 +43,9 @@ describe 'mysql::db define' do
         mysql::db { 'spec2':
           user     => 'root1',
           password => 'password',
-          sql      => '/tmp/spec.sql',
           charset  => '#{fetch_charset}',
           collate  => '#{fetch_charset}_general_ci',
+          sql      => ['/tmp/spec.sql'],
         }
       MANIFEST
     end

--- a/spec/acceptance/types/mysql_grant_spec.rb
+++ b/spec/acceptance/types/mysql_grant_spec.rb
@@ -686,8 +686,8 @@ describe 'mysql_grant' do
         mysql::db { 'grant_spec_db':
           user     => 'root1',
           password => 'password',
-          sql      => '/tmp/grant_spec_table.sql',
           charset  => '#{fetch_charset}',
+          sql      => ['/tmp/grant_spec_table.sql'],
         }
     MANIFEST
     it 'creates table' do

--- a/spec/defines/mysql_db_spec.rb
+++ b/spec/defines/mysql_db_spec.rb
@@ -17,40 +17,42 @@ describe 'mysql::db', type: :define do
           'mysql_exec_path' => '' }
       end
 
+      let(:sql) { [ '/tmp/test.sql' ] }
+
       it 'does not notify the import sql exec if no sql script was provided' do
         is_expected.to contain_mysql_database('test_db').without_notify
       end
 
       it 'subscribes to database if sql script is given' do
-        params['sql'] = 'test_sql'
+        params['sql'] = sql
         is_expected.to contain_mysql_database('test_db')
         is_expected.to contain_exec('test_db-import').with_subscribe('Mysql_database[test_db]')
       end
 
       it 'onlies import sql script on creation if not enforcing' do
-        params.merge!('sql' => 'test_sql', 'enforce_sql' => false)
+        params.merge!('sql' => sql, 'enforce_sql' => false)
         is_expected.to contain_exec('test_db-import').with_refreshonly(true)
       end
 
       it 'imports sql script on creation' do
-        params.merge!('sql' => 'test_sql', 'enforce_sql' => true)
+        params.merge!('sql' => sql, 'enforce_sql' => true)
         # ' if enforcing #refreshonly'
         is_expected.to contain_exec('test_db-import').with_refreshonly(false)
         # 'if enforcing #command'
-        is_expected.to contain_exec('test_db-import').with_command('cat test_sql | mysql test_db')
+        is_expected.to contain_exec('test_db-import').with_command('cat /tmp/test.sql | mysql test_db')
       end
 
-      it 'imports sql script with custom command on creation ' do
-        params.merge!('sql' => 'test_sql', 'enforce_sql' => true, 'import_cat_cmd' => 'zcat')
+      it 'imports sql script with custom command on creation' do
+        params.merge!('sql' => sql, 'enforce_sql' => true, 'import_cat_cmd' => 'zcat')
         # if enforcing #refreshonly
         is_expected.to contain_exec('test_db-import').with_refreshonly(false)
         # if enforcing #command
-        is_expected.to contain_exec('test_db-import').with_command('zcat test_sql | mysql test_db')
+        is_expected.to contain_exec('test_db-import').with_command('zcat /tmp/test.sql | mysql test_db')
       end
 
       it 'imports sql scripts when more than one is specified' do
-        params['sql'] = ['test_sql', 'test_2_sql']
-        is_expected.to contain_exec('test_db-import').with_command('cat test_sql test_2_sql | mysql test_db')
+        params['sql'] = ['/tmp/test.sql', '/tmp/test_2.sql']
+        is_expected.to contain_exec('test_db-import').with_command('cat /tmp/test.sql /tmp/test_2.sql | mysql test_db')
       end
 
       it 'does not create database' do
@@ -78,6 +80,61 @@ describe 'mysql::db', type: :define do
       it 'uses grant_options for grant when set' do
         params['grant_options'] = ['GRANT']
         is_expected.to contain_mysql_grant('testuser@localhost/test_db.*').with_options(['GRANT'])
+      end
+
+      # Invalid file paths
+      [
+        '|| ls -la ||',
+        '|| touch /tmp/foo.txt ||',
+        '/tmp/foo.txt;echo',
+        'myPath;',
+        '\\myPath\\',
+        '//myPath has spaces//',
+        '/',
+      ].each do |path|
+        it "fails when provided '#{path}' as a value to the 'sql' parameter" do
+          params['sql'] = [path]
+          is_expected.to raise_error(Puppet::PreformattedError, %r{The file '#{Regexp.escape(path)}' is invalid. A a valid file path is expected.})
+        end
+      end
+
+      # Valid file paths
+      [
+        '/tmp/test.txt',
+        '/tmp/.test',
+        '/foo.test',
+      ].each do |path|
+        it "succeeds when provided '#{path}' as a value to the 'sql' parameter" do
+          params['sql'] = [path]
+          is_expected.to contain_exec('test_db-import').with_command("cat #{path} | mysql test_db")
+        end
+      end
+
+      # Invalid database names
+      [
+        'test db',
+        'test_db;',
+        'test/db',
+        '|| ls -la ||',
+        '|| touch /tmp/foo.txt ||',
+      ].each do |name|
+        it "fails when provided '#{name}' as a value to the 'name' parameter" do
+          params['name'] = name
+          is_expected.to raise_error(Puppet::PreformattedError, %r{The database name '#{name}' is invalid.})
+        end
+      end
+
+      # Valid database names
+      [
+        'test_db',
+        'testdb',
+        'test-db',
+        'TESTDB',
+      ].each do |name|
+        it "succeeds when the provided '#{name}' as a value to the 'dbname' parameter" do
+          params['dbname'] = name
+          is_expected.to contain_mysql_database(name)
+        end
       end
     end
   end


### PR DESCRIPTION
Prior to this commit there was a possibility that malformed strings could be passed in to the resource. 
This could lead to unsafe executions on a remote system.

The parameters that are susceptible are `dbname`, `sql` and `import_cat_cmd`.

In addition, commands were not properly broken out in to arrays of arguments when passed to the exec resource.

This commit fixes the above by adding validation to parameters (where possible) to ensure that the given values conform to expectation.

`dbname` is validated with a regular expression that ensures that it matches expectations set by mysql.

`sql` now only accepts values as an `Array[String]`. 
This can be one or more value. 
Values are also validated with a regular expression that ensures that the given paths are valid.

`import_cat_cmd` has been removed in favour of a boolean parameter called `use_zcat`.
Setting this parameter to `true` will set the value of the private `import_cat_cmd` to `zcat`.

This commit also contains some minor refactoring.