### PR TITLE
Harden service class

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -52,10 +52,11 @@ class mysql::server::service {
       $mysqlsocket = $options['mysqld']['socket']
     }
 
+    $test_command = ['test', '-S', shell_escape($mysqlsocket)]
     if $service_ensure != 'stopped' {
       exec { 'wait_for_mysql_socket_to_open':
-        command   => "test -S ${mysqlsocket}",
-        unless    => "test -S ${mysqlsocket}",
+        command   => $test_command,
+        unless    => [$test_command],
         tries     => '3',
         try_sleep => '10',
         require   => Service['mysqld'],


### PR DESCRIPTION
Prior to this PR the variable `mysqlsocket` was passed to the `exec` resource in such a way that could allow unsafe executions on the remote host.

This commit fixes the above by properly parameterizing the arguments passed to the `command` and `unless` parameters of the `exec` resource.

The variable is also wrapped with a `shell_escape` for good measure.