### PR TITLE
Harden config class

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -39,14 +39,19 @@ class mysql::server::config {
       if $managed_dirs {
         $managed_dirs.each | $entry | {
           $dir = $options['mysqld']["${entry}"]
+
           if ( $dir and $dir != '/usr' and $dir != '/tmp' ) {
+            $clean_dir = shell_escape($dir)
+            $clean_package_name = shell_escape($mysql::server::package_name)
+
             exec { "${entry}-managed_dir-mkdir":
-              command => "/bin/mkdir -p ${dir}",
-              unless  => "/usr/bin/dpkg -s ${mysql::server::package_name}",
+              command => ['/bin/mkdir', '-p', $clean_dir],
+              unless  => [['/usr/bin/dpkg', '-s', $clean_package_name]],
               notify  => Exec["${entry}-managed_dir-chmod"],
             }
+
             exec { "${entry}-managed_dir-chmod":
-              command     => "/bin/chmod 777 ${dir}",
+              command     => ['/bin/chmod', '777', $clean_dir],
               refreshonly => true,
             }
           }


### PR DESCRIPTION
Prior to this commit the variables `dir` and `mysql::server::package_name` were passed to `exec` resources in such a way that could allow unsafe executions on the remote host.

This commit fixes the above by properly parameterizing the arguments passed to each `exec` resource.

Additionally the variables been sanitized with `shell_escape` for good measure.