### PR TITLE
(CONT-173) - Updating deprecated facter instances

### DIFF
--- a/lib/facter/mysql_version.rb
+++ b/lib/facter/mysql_version.rb
@@ -3,7 +3,7 @@
 Facter.add('mysql_version') do
   confine { Facter::Core::Execution.which('mysql') }
   setcode do
-    mysql_ver = Facter::Util::Resolution.exec('mysql --version')
+    mysql_ver = Facter::Core::Execution.execute('mysql --version')
     mysql_ver.match(%r{\d+\.\d+\.\d+})[0] if mysql_ver
   end
 end

--- a/lib/facter/mysqld_version.rb
+++ b/lib/facter/mysqld_version.rb
@@ -3,6 +3,6 @@
 Facter.add('mysqld_version') do
   confine { Facter::Core::Execution.which('mysqld') }
   setcode do
-    Facter::Util::Resolution.exec('mysqld --no-defaults -V 2>/dev/null')
+    Facter::Core::Execution.execute('mysqld --no-defaults -V 2>/dev/null')
   end
 end

--- a/spec/unit/facter/mysql_version_spec.rb
+++ b/spec/unit/facter/mysql_version_spec.rb
@@ -11,7 +11,7 @@ describe Facter::Util::Fact.to_s do
     context 'with value' do
       before :each do
         allow(Facter::Core::Execution).to receive(:which).and_return('fake_mysql_path')
-        allow(Facter::Util::Resolution).to receive(:exec).with('mysql --version').and_return('mysql  Ver 14.12 Distrib 5.0.95, for redhat-linux-gnu (x86_64) using readline 5.1')
+        allow(Facter::Core::Execution).to receive(:execute).with('mysql --version').and_return('mysql  Ver 14.12 Distrib 5.0.95, for redhat-linux-gnu (x86_64) using readline 5.1')
       end
       it {
         expect(Facter.fact(:mysql_version).value).to eq('5.0.95')

--- a/spec/unit/facter/mysqld_version_spec.rb
+++ b/spec/unit/facter/mysqld_version_spec.rb
@@ -11,8 +11,8 @@ describe Facter::Util::Fact.to_s do
     context 'with value' do
       before :each do
         allow(Facter::Core::Execution).to receive(:which).with('mysqld').and_return('/usr/sbin/mysqld')
-        allow(Facter::Util::Resolution).to receive(:exec).with('mysqld --no-defaults -V 2>/dev/null')
-                                                         .and_return('mysqld  Ver 5.5.49-37.9 for Linux on x86_64 (Percona Server (GPL), Release 37.9, Revision efa0073)')
+        allow(Facter::Core::Execution).to receive(:execute).with('mysqld --no-defaults -V 2>/dev/null')
+                                                           .and_return('mysqld  Ver 5.5.49-37.9 for Linux on x86_64 (Percona Server (GPL), Release 37.9, Revision efa0073)')
       end
       it {
         expect(Facter.fact(:mysqld_version).value).to eq('mysqld  Ver 5.5.49-37.9 for Linux on x86_64 (Percona Server (GPL), Release 37.9, Revision efa0073)')


### PR DESCRIPTION
Prior to this PR, this module contained instances of Facter::Util::Resolution.exec and Facter::Util::Resolution.which, which are deprecated. This PR aims to replace these exec helpers with their supported Facter::Core::Execution counterparts.

This PR:

Replaces all Facter::Util::Resolution instances with corresponding Facter::Core::Execution exec helpers