### PR TITLE
mysql::db sql parameter support filenames with multiple dots

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -76,8 +76,8 @@ define mysql::db (
   # Ensure that the sql files passed are valid file paths.
   if $sql {
     $sql.each | $sqlfile | {
-      if $sqlfile !~ /^\/(?:[A-Za-z0-9_-]+\/?+)+(?:.[A-Za-z0-9]+)$/ {
-        $message = "The file '${sqlfile}' is invalid. A a valid file path is expected."
+      if $sqlfile !~ /^\/(?:[A-Za-z0-9_-]+\/?+)+(?:\.[A-Za-z0-9]+)+$/ {
+        $message = "The file '${sqlfile}' is invalid. A valid file path is expected."
         fail($message)
       }
     }

--- a/spec/defines/mysql_db_spec.rb
+++ b/spec/defines/mysql_db_spec.rb
@@ -94,7 +94,7 @@ describe 'mysql::db', type: :define do
       ].each do |path|
         it "fails when provided '#{path}' as a value to the 'sql' parameter" do
           params['sql'] = [path]
-          is_expected.to raise_error(Puppet::PreformattedError, %r{The file '#{Regexp.escape(path)}' is invalid. A a valid file path is expected.})
+          is_expected.to raise_error(Puppet::PreformattedError, %r{The file '#{Regexp.escape(path)}' is invalid. A valid file path is expected.})
         end
       end
 
@@ -103,6 +103,7 @@ describe 'mysql::db', type: :define do
         '/tmp/test.txt',
         '/tmp/.test',
         '/foo.test',
+        '/foo.test.txt',
       ].each do |path|
         it "succeeds when provided '#{path}' as a value to the 'sql' parameter" do
           params['sql'] = [path]


### PR DESCRIPTION
This fixes mysql::db sql parameter to support filenames with multiple dots. #1499 