### PR TITLE
1509: Fix ssl params issue for EL7 and newer mariadb versions

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -106,9 +106,9 @@ class mysql::params {
       $mycnf_owner             = undef
       $mycnf_group             = undef
       $socket                  = '/var/lib/mysql/mysql.sock'
-      $ssl_ca                  = '/etc/mysql/cacert.pem'
-      $ssl_cert                = '/etc/mysql/server-cert.pem'
-      $ssl_key                 = '/etc/mysql/server-key.pem'
+      $ssl_ca                  = undef
+      $ssl_cert                = undef
+      $ssl_key                 = undef
       $tmpdir                  = '/tmp'
       $managed_dirs            = undef
       # mysql::bindings


### PR DESCRIPTION
#1509 ssl params should be undefined for RedHat family systems.