### PR TITLE
(GH-1516) Update sql example to use array

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ mysql::db { 'mydb':
   password        => 'mypass',
   host            => 'localhost',
   grant           => ['SELECT', 'UPDATE'],
-  sql             => '/path/to/sqlfile.gz',
+  sql             => ['/path/to/sqlfile.gz'],
   import_cat_cmd  => 'zcat',
   import_timeout  => 900,
   mysql_exec_path => '/opt/rh/rh-myql57/root/bin',


### PR DESCRIPTION
Prior to this commit the db example shows a String however it is an optional array. 

This commit updates the example from a String to an array.