### PR TITLE
Use consistent values for ssl-ca, ssl-cert and ssl-key

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -106,9 +106,6 @@ class mysql::params {
       $mycnf_owner             = undef
       $mycnf_group             = undef
       $socket                  = '/var/lib/mysql/mysql.sock'
-      $ssl_ca                  = '/etc/mysql/cacert.pem'
-      $ssl_cert                = '/etc/mysql/server-cert.pem'
-      $ssl_key                 = '/etc/mysql/server-key.pem'
       $tmpdir                  = '/tmp'
       $managed_dirs            = undef
       # mysql::bindings
@@ -154,9 +151,6 @@ class mysql::params {
       $server_service_name = 'mysql'
       $xtrabackup_package_name = 'xtrabackup'
 
-      $ssl_ca              = '/etc/mysql/cacert.pem'
-      $ssl_cert            = '/etc/mysql/server-cert.pem'
-      $ssl_key             = '/etc/mysql/server-key.pem'
       $tmpdir              = '/tmp'
       $managed_dirs        = undef
       # mysql::bindings
@@ -200,9 +194,6 @@ class mysql::params {
       $mycnf_owner             = undef
       $mycnf_group             = undef
       $socket                  = '/var/run/mysqld/mysqld.sock'
-      $ssl_ca                  = '/etc/mysql/cacert.pem'
-      $ssl_cert                = '/etc/mysql/server-cert.pem'
-      $ssl_key                 = '/etc/mysql/server-key.pem'
       $tmpdir                  = '/tmp'
       $managed_dirs            = ['tmpdir','basedir','datadir','innodb_data_home_dir','innodb_log_group_home_dir','innodb_undo_directory','innodb_tmpdir']
 
@@ -261,9 +252,6 @@ class mysql::params {
       $mycnf_group             = undef
       $server_service_name     = 'mysqld'
       $socket                  = '/var/lib/mysql/mysql.sock'
-      $ssl_ca                  = '/etc/mysql/cacert.pem'
-      $ssl_cert                = '/etc/mysql/server-cert.pem'
-      $ssl_key                 = '/etc/mysql/server-key.pem'
       $tmpdir                  = '/tmp'
       $managed_dirs            = undef
       # mysql::bindings
@@ -289,9 +277,6 @@ class mysql::params {
       $mycnf_group         = undef
       $server_service_name = 'mysql'
       $socket              = '/run/mysqld/mysqld.sock'
-      $ssl_ca              = '/etc/mysql/cacert.pem'
-      $ssl_cert            = '/etc/mysql/server-cert.pem'
-      $ssl_key             = '/etc/mysql/server-key.pem'
       $tmpdir              = '/tmp'
       $managed_dirs        = undef
       # mysql::bindings
@@ -317,9 +302,6 @@ class mysql::params {
       $mycnf_group         = undef
       $server_service_name = 'mysql-server'
       $socket              = '/var/db/mysql/mysql.sock'
-      $ssl_ca              = undef
-      $ssl_cert            = undef
-      $ssl_key             = undef
       $tmpdir              = '/tmp'
       $managed_dirs        = undef
       # mysql::bindings
@@ -348,9 +330,6 @@ class mysql::params {
       $mycnf_group         = undef
       $server_service_name = 'mysqld'
       $socket              = '/var/run/mysql/mysql.sock'
-      $ssl_ca              = undef
-      $ssl_cert            = undef
-      $ssl_key             = undef
       $tmpdir              = '/tmp'
       $managed_dirs        = undef
       # mysql::bindings
@@ -380,9 +359,6 @@ class mysql::params {
           $mycnf_group         = undef
           $server_service_name = 'mariadb'
           $socket              = '/run/mysqld/mysqld.sock'
-          $ssl_ca              = '/etc/mysql/cacert.pem'
-          $ssl_cert            = '/etc/mysql/server-cert.pem'
-          $ssl_key             = '/etc/mysql/server-key.pem'
           $tmpdir              = '/tmp'
           $managed_dirs        = undef
           $java_package_name   = undef
@@ -408,9 +384,6 @@ class mysql::params {
           $mycnf_group         = undef
           $server_service_name = 'mysqld'
           $socket              = '/var/lib/mysql/mysql.sock'
-          $ssl_ca              = '/etc/mysql/cacert.pem'
-          $ssl_cert            = '/etc/mysql/server-cert.pem'
-          $ssl_key             = '/etc/mysql/server-key.pem'
           $tmpdir              = '/tmp'
           $managed_dirs        = undef
           # mysql::bindings
@@ -492,9 +465,9 @@ class mysql::params {
       'skip-external-locking' => true,
       'socket'                => $mysql::params::socket,
       'ssl'                   => false,
-      'ssl-ca'                => $mysql::params::ssl_ca,
-      'ssl-cert'              => $mysql::params::ssl_cert,
-      'ssl-key'               => $mysql::params::ssl_key,
+      'ssl-ca'                => undef,
+      'ssl-cert'              => undef,
+      'ssl-key'               => undef,
       'ssl-disable'           => false,
       'thread_cache_size'     => '8',
       'thread_stack'          => '256K',


### PR DESCRIPTION
The default value of the server's ssl-ca, ssl-cert and ssl-key
parameters are system-dependent:
  * Some systems set these parameters to `undef`;
  * Some systems set these parameters to a filename which is not managed
    by the module.

Recent versions of MariaDB insist on being able to read the files these
parameters point to even if TLS is not in use.  As a consequence,
MariaDB is broken and cannot start successfully.

Always use `undef` as the default version of these parameters so that
users have the same experience regardless of the Operating System they
are running.

Existing PR #1511 and #1512 propose a partial fix focused on the
current breakage of MariaDB on RedHat and Debian OS families.  This PR
is proposed as an alternative to bring consistent configuration across
all systems.

Fixes #1509