### PR TITLE
xtrabackup.sh only touch when backup_success_file_path is set

### DIFF
--- a/spec/classes/mysql_backup_xtrabackup_spec.rb
+++ b/spec/classes/mysql_backup_xtrabackup_spec.rb
@@ -24,7 +24,8 @@ describe 'mysql::backup::xtrabackup' do
         let(:params) do
           default_params
         end
-        it 'does not contain the touch /tmp/backup_success command' do
+
+        it 'does not contain the touch command' do
           is_expected.to contain_file('xtrabackup.sh').without_content(
             %r{(^\s+touch\s+$)},
           )

--- a/spec/classes/mysql_backup_xtrabackup_spec.rb
+++ b/spec/classes/mysql_backup_xtrabackup_spec.rb
@@ -24,6 +24,11 @@ describe 'mysql::backup::xtrabackup' do
         let(:params) do
           default_params
         end
+        it 'does not contain the touch /tmp/backup_success command' do
+          is_expected.to contain_file('xtrabackup.sh').without_content(
+            %r{(^\s+touch\s+$)},
+          )
+        end
 
         it 'contains the wrapper script' do
           is_expected.to contain_file('xtrabackup.sh').with_content(
@@ -301,6 +306,18 @@ describe 'mysql::backup::xtrabackup' do
         it 'contain the mariabackup executor' do
           is_expected.to contain_file('xtrabackup.sh').with_content(
             %r{(\n*^mariabackup\s+.*\$@)},
+          )
+        end
+      end
+
+      context 'with backup_success_file_path' do
+        let(:params) do
+          { backup_success_file_path: '/tmp/backup_success' }.merge(default_params)
+        end
+
+        it 'contain the touch /tmp/backup_success command' do
+          is_expected.to contain_file('xtrabackup.sh').with_content(
+            %r{(^\s+touch /tmp/backup_success$)},
           )
         end
       end

--- a/templates/xtrabackup.sh.erb
+++ b/templates/xtrabackup.sh.erb
@@ -59,7 +59,9 @@ cleanup
 <% unless @delete_before_dump -%>
 if [ $? -eq 0 ] ; then
     cleanup
+    <% if @backup_success_file_path -%>
     touch <%= @backup_success_file_path %>
+    <% end -%>
 fi
 <% end -%>
 


### PR DESCRIPTION
By default `backup_success_file_path` is `undef` what result in a `touch` command without argument that will produce an error like `touch: missing file operand`.

With this merge request we only add the `touch` command to the script when the value of `backup_success_file_path` is defined. 

Also added rspec test for both cases.