### PR TITLE
fix naming in documentation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1598,7 +1598,7 @@ Plain text password.
 
 Data type: `Optional[Boolean]`
 
-If the Postgresql-Passwordhash should be of Datatype Sensitive[String]
+If the mysql password hash should be of datatype Sensitive[String]
 
 ### <a name="mysql--strip_hash"></a>`mysql::strip_hash`
 

--- a/lib/puppet/functions/mysql/password.rb
+++ b/lib/puppet/functions/mysql/password.rb
@@ -8,7 +8,7 @@ Puppet::Functions.create_function(:'mysql::password') do
   # @param password
   #   Plain text password.
   # @param sensitive
-  #   If the Postgresql-Passwordhash should be of Datatype Sensitive[String]
+  #   If the mysql password hash should be of datatype Sensitive[String]
   #
   # @return hash
   #   The mysql password hash from the clear text password.


### PR DESCRIPTION
This module configures no potgres, so we should describe the params with mysql instead of postgres.