### PR TITLE
remove ssl-disable notify

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -183,13 +183,6 @@ class mysql::server (
     ~> Class['mysql::server::service']
   }
 
-  if $_options['mysqld']['ssl-disable'] {
-    notify { 'ssl-disable':
-      message => 'Disabling SSL is evil! You should never ever do this except
-                if you are forced to use a mysql version compiled without SSL support',
-    }
-  }
-
   Anchor['mysql::server::start']
   -> Class['mysql::server::config']
   -> Class['mysql::server::install']


### PR DESCRIPTION
This notify shows as a 'change' in puppet reports, so if you have ssl disabled, every puppet run indicates a resource is changing - which is not the case.  I also feel that it is not this puppet module's place to preach how to configure my systems - even if it is correct.  https://github.com/puppetlabs/puppetlabs-mysql/pull/1512#issuecomment-1326595628 suggests this as well and I agree.