### PR TITLE
Drop legacy facts

### DIFF
--- a/manifests/backup/mysqlbackup.pp
+++ b/manifests/backup/mysqlbackup.pp
@@ -74,9 +74,9 @@ class mysql::backup::mysqlbackup (
   }
 
   if $install_cron {
-    if $::osfamily == 'RedHat' {
+    if $facts['os']['family'] == 'RedHat' {
       ensure_packages('cronie')
-    } elsif $::osfamily != 'FreeBSD' {
+    } elsif $facts['os']['family'] != 'FreeBSD' {
       ensure_packages('cron')
     }
   }

--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -41,7 +41,7 @@ class mysql::backup::mysqldump (
     $backuppassword
   }
 
-  unless $::osfamily == 'FreeBSD' {
+  unless $facts['os']['family'] == 'FreeBSD' {
     if $backupcompress and $compression_command == 'bzcat -zc' {
       ensure_packages(['bzip2'])
       Package['bzip2'] -> File['mysqlbackup.sh']
@@ -69,9 +69,9 @@ class mysql::backup::mysqldump (
   }
 
   if $install_cron {
-    if $::osfamily == 'RedHat' {
+    if $facts['os']['family'] == 'RedHat' {
       ensure_packages('cronie')
-    } elsif $::osfamily != 'FreeBSD' {
+    } elsif $facts['os']['family'] != 'FreeBSD' {
       ensure_packages('cron')
     }
   }

--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -109,9 +109,9 @@ class mysql::backup::xtrabackup (
   }
 
   if $install_cron {
-    if $::osfamily == 'RedHat' {
+    if $facts['os']['family'] == 'RedHat' {
       ensure_packages('cronie')
-    } elsif $::osfamily != 'FreeBSD' {
+    } elsif $facts['os']['family'] != 'FreeBSD' {
       ensure_packages('cron')
     }
   }
@@ -138,7 +138,7 @@ class mysql::backup::xtrabackup (
   }
 
   # Wether to use GNU or BSD date format.
-  case $::osfamily {
+  case $facts['os']['family'] {
     'FreeBSD','OpenBSD': {
       $dateformat = '$(date -v-sun +\\%F)_full'
     }

--- a/manifests/bindings.pp
+++ b/manifests/bindings.pp
@@ -100,7 +100,7 @@ class mysql::bindings (
   $daemon_dev_package_name     = $mysql::params::daemon_dev_package_name,
   $daemon_dev_package_provider = $mysql::params::daemon_dev_package_provider
 ) inherits mysql::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     'Archlinux': {
       if $java_enable { fail("::mysql::bindings::java cannot be managed by puppet on ${::facts['os']['family']} as it is not in official repositories. Please disable java mysql binding.") }
       if $perl_enable { include 'mysql::bindings::perl' }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,7 +37,7 @@ class mysql::params {
   $daemon_dev_package_ensure   = 'present'
   $daemon_dev_package_provider = undef
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     'RedHat': {
       case $::operatingsystem {
         'Fedora': {
@@ -425,7 +425,7 @@ class mysql::params {
         }
 
         default: {
-          fail("Unsupported platform: puppetlabs-${module_name} currently doesn\'t support ${::osfamily} or ${::operatingsystem}.")
+          fail("Unsupported platform: puppetlabs-${module_name} currently doesn\'t support ${facts['os']['family']} or ${::operatingsystem}.")
         }
       }
     }
@@ -516,7 +516,7 @@ class mysql::params {
   }
 
   ## Additional graceful failures
-  if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '4' and $::operatingsystem != 'Amazon' {
+  if $facts['os']['family'] == 'RedHat' and $::operatingsystemmajrelease == '4' and $::operatingsystem != 'Amazon' {
     fail("Unsupported platform: puppetlabs-${module_name} only supports RedHat 6.0 and beyond.")
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -340,7 +340,7 @@ class mysql::params {
       $config_file         = '/etc/my.cnf'
       $includedir          = undef
       $datadir             = '/var/mysql'
-      $log_error           = "/var/mysql/${::hostname}.err"
+      $log_error           = "/var/mysql/${facts['networking']['hostname']}.err"
       $pidfile             = '/var/mysql/mysql.pid'
       $root_group          = 'wheel'
       $mysql_group         = '_mysql'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,16 +56,16 @@ class mysql::params {
           }
         }
         /^(RedHat|Rocky|CentOS|Scientific|OracleLinux|AlmaLinux)$/: {
-          if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
+          if versioncmp($facts['os']['release']['major'], '7') >= 0 {
             $provider = 'mariadb'
-            if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
+            if versioncmp($facts['os']['release']['major'], '8') >= 0 {
               $xtrabackup_package_name = 'percona-xtrabackup-24'
             }
           } else {
             $provider = 'mysql'
             $xtrabackup_package_name = 'percona-xtrabackup-20'
           }
-          if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
+          if versioncmp($facts['os']['release']['major'], '8') >= 0 {
             $java_package_name   = 'mariadb-java-client'
             $python_package_name = 'python3-PyMySQL'
           } else {
@@ -516,7 +516,7 @@ class mysql::params {
   }
 
   ## Additional graceful failures
-  if $facts['os']['family'] == 'RedHat' and $::operatingsystemmajrelease == '4' and $facts['os']['name'] != 'Amazon' {
+  if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '4' and $facts['os']['name'] != 'Amazon' {
     fail("Unsupported platform: puppetlabs-${module_name} only supports RedHat 6.0 and beyond.")
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,7 +41,7 @@ class mysql::params {
     'RedHat': {
       case $facts['os']['name'] {
         'Fedora': {
-          if versioncmp($::operatingsystemrelease, '19') >= 0 or $::operatingsystemrelease == 'Rawhide' {
+          if versioncmp($facts['os']['release']['full'], '19') >= 0 or $facts['os']['release']['full'] == 'Rawhide' {
             $provider = 'mariadb'
           } else {
             $provider = 'mysql'
@@ -49,7 +49,7 @@ class mysql::params {
           $python_package_name = 'MySQL-python'
         }
         'Amazon': {
-          if versioncmp($::operatingsystemrelease, '2') >= 0 {
+          if versioncmp($facts['os']['release']['full'], '2') >= 0 {
             $provider = 'mariadb'
           } else {
             $provider = 'mysql'
@@ -207,26 +207,26 @@ class mysql::params {
       $managed_dirs            = ['tmpdir','basedir','datadir','innodb_data_home_dir','innodb_log_group_home_dir','innodb_undo_directory','innodb_tmpdir']
 
       # mysql::bindings
-      if ($facts['os']['name'] == 'Debian' and versioncmp($::operatingsystemrelease, '10') >= 0) or
-      ($facts['os']['name'] == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) {
+      if ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['full'], '10') >= 0) or
+      ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['full'], '20.04') >= 0) {
         $java_package_name   = 'libmariadb-java'
       } else {
         $java_package_name   = 'libmysql-java'
       }
       $perl_package_name   = 'libdbd-mysql-perl'
-      if  ($facts['os']['name'] == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0) or
+      if  ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['full'], '16.04') >= 0) or
       ($facts['os']['name'] == 'Debian') {
         $php_package_name = 'php-mysql'
       } else {
         $php_package_name = 'php5-mysql'
       }
-      if  ($facts['os']['name'] == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') < 0) or
-      ($facts['os']['name'] == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) or
+      if  ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['full'], '16.04') < 0) or
+      ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['full'], '20.04') >= 0) or
       ($facts['os']['name'] == 'Debian') {
         $xtrabackup_package_name = 'percona-xtrabackup-24'
       }
-      if ($facts['os']['name'] == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) or
-      ($facts['os']['name'] == 'Debian' and versioncmp($::operatingsystemrelease, '11') >= 0) {
+      if ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['full'], '20.04') >= 0) or
+      ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['full'], '11') >= 0) {
         $python_package_name = 'python3-mysqldb'
       } else {
         $python_package_name = 'python-mysqldb'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,7 +39,7 @@ class mysql::params {
 
   case $facts['os']['family'] {
     'RedHat': {
-      case $::operatingsystem {
+      case $facts['os']['name'] {
         'Fedora': {
           if versioncmp($::operatingsystemrelease, '19') >= 0 or $::operatingsystemrelease == 'Rawhide' {
             $provider = 'mariadb'
@@ -119,7 +119,7 @@ class mysql::params {
     }
 
     'Suse': {
-      case $::operatingsystem {
+      case $facts['os']['name'] {
         'OpenSuSE': {
           $socket = '/var/run/mysql/mysql.sock'
           $log_error = '/var/log/mysql/mysqld.log'
@@ -141,7 +141,7 @@ class mysql::params {
           $basedir             = undef
         }
         default: {
-          fail("Unsupported platform: puppetlabs-${module_name} currently doesn\'t support ${::operatingsystem}.")
+          fail("Unsupported platform: puppetlabs-${module_name} currently doesn\'t support ${facts['os']['name']}.")
         }
       }
       $config_file         = '/etc/my.cnf'
@@ -207,26 +207,26 @@ class mysql::params {
       $managed_dirs            = ['tmpdir','basedir','datadir','innodb_data_home_dir','innodb_log_group_home_dir','innodb_undo_directory','innodb_tmpdir']
 
       # mysql::bindings
-      if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '10') >= 0) or
-      ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) {
+      if ($facts['os']['name'] == 'Debian' and versioncmp($::operatingsystemrelease, '10') >= 0) or
+      ($facts['os']['name'] == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) {
         $java_package_name   = 'libmariadb-java'
       } else {
         $java_package_name   = 'libmysql-java'
       }
       $perl_package_name   = 'libdbd-mysql-perl'
-      if  ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0) or
-      ($::operatingsystem == 'Debian') {
+      if  ($facts['os']['name'] == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0) or
+      ($facts['os']['name'] == 'Debian') {
         $php_package_name = 'php-mysql'
       } else {
         $php_package_name = 'php5-mysql'
       }
-      if  ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') < 0) or
-      ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) or
-      ($::operatingsystem == 'Debian') {
+      if  ($facts['os']['name'] == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') < 0) or
+      ($facts['os']['name'] == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) or
+      ($facts['os']['name'] == 'Debian') {
         $xtrabackup_package_name = 'percona-xtrabackup-24'
       }
-      if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) or
-      ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '11') >= 0) {
+      if ($facts['os']['name'] == 'Ubuntu' and versioncmp($::operatingsystemrelease, '20.04') >= 0) or
+      ($facts['os']['name'] == 'Debian' and versioncmp($::operatingsystemrelease, '11') >= 0) {
         $python_package_name = 'python3-mysqldb'
       } else {
         $python_package_name = 'python-mysqldb'
@@ -365,7 +365,7 @@ class mysql::params {
     }
 
     default: {
-      case $::operatingsystem {
+      case $facts['os']['name'] {
         'Alpine': {
           $client_package_name = 'mariadb-client'
           $server_package_name = 'mariadb'
@@ -425,13 +425,13 @@ class mysql::params {
         }
 
         default: {
-          fail("Unsupported platform: puppetlabs-${module_name} currently doesn\'t support ${facts['os']['family']} or ${::operatingsystem}.")
+          fail("Unsupported platform: puppetlabs-${module_name} currently doesn\'t support ${facts['os']['family']} or ${facts['os']['name']}.")
         }
       }
     }
   }
 
-  case $::operatingsystem {
+  case $facts['os']['name'] {
     'Ubuntu': {
       $server_service_provider = 'systemd'
     }
@@ -516,7 +516,7 @@ class mysql::params {
   }
 
   ## Additional graceful failures
-  if $facts['os']['family'] == 'RedHat' and $::operatingsystemmajrelease == '4' and $::operatingsystem != 'Amazon' {
+  if $facts['os']['family'] == 'RedHat' and $::operatingsystemmajrelease == '4' and $facts['os']['name'] != 'Amazon' {
     fail("Unsupported platform: puppetlabs-${module_name} only supports RedHat 6.0 and beyond.")
   }
 }

--- a/manifests/server/account_security.pp
+++ b/manifests/server/account_security.pp
@@ -28,9 +28,9 @@ class mysql::server::account_security {
         require => Anchor['mysql::server::end'],
     }
   }
-  if ($::fqdn != $::hostname) {
-    if ($::hostname != 'localhost') {
-      mysql_user { ["root@${::hostname}", "@${::hostname}"]:
+  if ($::fqdn != $facts['networking']['hostname']) {
+    if ($facts['networking']['hostname'] != 'localhost') {
+      mysql_user { ["root@${facts['networking']['hostname']}", "@${facts['networking']['hostname']}"]:
         ensure  => 'absent',
         require => Anchor['mysql::server::end'],
       }

--- a/manifests/server/account_security.pp
+++ b/manifests/server/account_security.pp
@@ -12,7 +12,7 @@ class mysql::server::account_security {
       ensure  => 'absent',
       require => Anchor['mysql::server::end'],
   }
-  if ($::fqdn != 'localhost.localdomain') {
+  if ($facts['networking']['fqdn'] != 'localhost.localdomain') {
     mysql_user {
       ['root@localhost.localdomain',
       '@localhost.localdomain']:
@@ -20,15 +20,15 @@ class mysql::server::account_security {
         require => Anchor['mysql::server::end'],
     }
   }
-  if ($::fqdn and $::fqdn != 'localhost') {
+  if ($facts['networking']['fqdn'] and $facts['networking']['fqdn'] != 'localhost') {
     mysql_user {
-      ["root@${::fqdn}",
-      "@${::fqdn}"]:
+      ["root@${facts['networking']['fqdn']}",
+      "@${facts['networking']['fqdn']}"]:
         ensure  => 'absent',
         require => Anchor['mysql::server::end'],
     }
   }
-  if ($::fqdn != $facts['networking']['hostname']) {
+  if ($facts['networking']['fqdn'] != $facts['networking']['hostname']) {
     if ($facts['networking']['hostname'] != 'localhost') {
       mysql_user { ["root@${facts['networking']['hostname']}", "@${facts['networking']['hostname']}"]:
         ensure  => 'absent',

--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -46,7 +46,7 @@ class mysql::server::root_password {
     }
 
     # show_diff was added with puppet 3.0
-    if versioncmp($::puppetversion, '3.0') >= 0 {
+    if versioncmp($facts['puppetversion'], '3.0') >= 0 {
       File["${::root_home}/.my.cnf"] { show_diff => false }
     }
     if $mysql::server::create_root_user {

--- a/spec/acceptance/05_mysql_xtrabackup_spec.rb
+++ b/spec/acceptance/05_mysql_xtrabackup_spec.rb
@@ -40,7 +40,7 @@ describe 'mysql::server::backup class with xtrabackup', if: Gem::Version.new(mys
           /RedHat/: {
             # RHEL/CentOS 5 is no longer supported by Percona, but older versions
             # of the repository are still available.
-            if versioncmp($::operatingsystemmajrelease, '6') >= 0 {
+            if versioncmp($facts['os']['release']['major'], '6') >= 0 {
               $percona_url = 'http://repo.percona.com/yum/percona-release-latest.noarch.rpm'
               $epel_url = "https://download.fedoraproject.org/pub/epel/epel-release-latest-${facts['os']['release']['major']}.noarch.rpm"
             } else {

--- a/spec/classes/graceful_failures_spec.rb
+++ b/spec/classes/graceful_failures_spec.rb
@@ -6,7 +6,9 @@ describe 'mysql::server' do
   context 'on an unsupported OS' do
     let(:facts) do
       {
-        osfamily: 'UNSUPPORTED',
+        os: {
+          family: 'UNSUPPORTED',
+        },
         operatingsystem: 'UNSUPPORTED',
       }
     end

--- a/spec/classes/graceful_failures_spec.rb
+++ b/spec/classes/graceful_failures_spec.rb
@@ -8,8 +8,8 @@ describe 'mysql::server' do
       {
         os: {
           family: 'UNSUPPORTED',
+          name: 'UNSUPPORTED',
         },
-        operatingsystem: 'UNSUPPORTED',
       }
     end
 

--- a/spec/classes/mysql_backup_xtrabackup_spec.rb
+++ b/spec/classes/mysql_backup_xtrabackup_spec.rb
@@ -45,9 +45,9 @@ describe 'mysql::backup::xtrabackup' do
                     else
                       'percona-xtrabackup-20'
                     end
-                  elsif facts[:operatingsystem] == 'Debian'
+                  elsif facts[:os]['name'] == 'Debian'
                     'percona-xtrabackup-24'
-                  elsif facts[:operatingsystem] == 'Ubuntu'
+                  elsif facts[:os]['name'] == 'Ubuntu'
                     if Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '20') >= 0
                       'percona-xtrabackup-24'
                     elsif Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '16') >= 0
@@ -114,8 +114,8 @@ describe 'mysql::backup::xtrabackup' do
               user: 'backupuser@localhost',
               table: '*.*',
               privileges:
-              if (facts[:operatingsystem] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '11') >= 0) ||
-                (facts[:operatingsystem] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '22') >= 0)
+              if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '11') >= 0) ||
+                (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '22') >= 0)
                 ['BINLOG MONITOR', 'RELOAD', 'PROCESS', 'LOCK TABLES']
               else
                 ['RELOAD', 'PROCESS', 'LOCK TABLES', 'REPLICATION CLIENT']
@@ -157,8 +157,8 @@ describe 'mysql::backup::xtrabackup' do
                 user: 'backupuser@localhost',
                 table: '*.*',
                 privileges:
-                if (facts[:operatingsystem] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '11') >= 0) ||
-                  (facts[:operatingsystem] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '22') >= 0)
+                if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '11') >= 0) ||
+                  (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '22') >= 0)
                   ['BINLOG MONITOR', 'RELOAD', 'PROCESS', 'LOCK TABLES', 'BACKUP_ADMIN']
                 else
                   ['RELOAD', 'PROCESS', 'LOCK TABLES', 'REPLICATION CLIENT', 'BACKUP_ADMIN']
@@ -201,9 +201,9 @@ describe 'mysql::backup::xtrabackup' do
                     else
                       'percona-xtrabackup-20'
                     end
-                  elsif facts[:operatingsystem] == 'Debian'
+                  elsif facts[:os]['name'] == 'Debian'
                     'percona-xtrabackup-24'
-                  elsif facts[:operatingsystem] == 'Ubuntu'
+                  elsif facts[:os]['name'] == 'Ubuntu'
                     if Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '20') >= 0
                       'percona-xtrabackup-24'
                     elsif Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '16') >= 0

--- a/spec/classes/mysql_backup_xtrabackup_spec.rb
+++ b/spec/classes/mysql_backup_xtrabackup_spec.rb
@@ -37,7 +37,7 @@ describe 'mysql::backup::xtrabackup' do
           )
         end
 
-        package = if facts[:osfamily] == 'RedHat'
+        package = if facts[:os]['family'] == 'RedHat'
                     if Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '8') >= 0
                       'percona-xtrabackup-24'
                     elsif Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '7') >= 0
@@ -55,7 +55,7 @@ describe 'mysql::backup::xtrabackup' do
                     else
                       'percona-xtrabackup-24'
                     end
-                  elsif facts[:osfamily] == 'Suse'
+                  elsif facts[:os]['family'] == 'Suse'
                     'xtrabackup'
                   else
                     'percona-xtrabackup'
@@ -75,7 +75,7 @@ describe 'mysql::backup::xtrabackup' do
         end
 
         it 'contains the daily cronjob for weekdays 1-6' do
-          dateformat = case facts[:osfamily]
+          dateformat = case facts[:os]['family']
                        when 'FreeBSD', 'OpenBSD'
                          '$(date -v-sun +\%F)_full'
                        else
@@ -193,7 +193,7 @@ describe 'mysql::backup::xtrabackup' do
           { additional_cron_args: '--backup --skip-ssl' }.merge(default_params)
         end
 
-        package = if facts[:osfamily] == 'RedHat'
+        package = if facts[:os]['family'] == 'RedHat'
                     if Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '8') >= 0
                       'percona-xtrabackup-24'
                     elsif Puppet::Util::Package.versioncmp(facts[:operatingsystemmajrelease], '7') >= 0
@@ -211,13 +211,13 @@ describe 'mysql::backup::xtrabackup' do
                     else
                       'percona-xtrabackup-24'
                     end
-                  elsif facts[:osfamily] == 'Suse'
+                  elsif facts[:os]['family'] == 'Suse'
                     'xtrabackup'
                   else
                     'percona-xtrabackup'
                   end
 
-        dateformat = case facts[:osfamily]
+        dateformat = case facts[:os]['family']
                      when 'FreeBSD', 'OpenBSD'
                        '$(date -v-sun +\%F)_full'
                      else

--- a/spec/classes/mysql_bindings_spec.rb
+++ b/spec/classes/mysql_bindings_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'mysql::bindings' do
   on_supported_os.each do |os, facts|
-    next if facts[:osfamily] == 'Archlinux'
+    next if facts[:os]['family'] == 'Archlinux'
     context "on #{os}" do
       let(:facts) do
         facts.merge(root_home: '/root')

--- a/spec/classes/mysql_server_account_security_spec.rb
+++ b/spec/classes/mysql_server_account_security_spec.rb
@@ -14,8 +14,8 @@ describe 'mysql::server::account_security' do
       context 'with fqdn==myhost.mydomain' do
         let(:facts) do
           facts.merge(root_home: '/root',
-                      fqdn: 'myhost.mydomain',
                       networking: {
+                        fqdn: 'myhost.mydomain',
                         hostname: 'myhost'
                       })
         end
@@ -48,8 +48,8 @@ describe 'mysql::server::account_security' do
       context 'with fqdn==localhost' do
         let(:facts) do
           facts.merge(root_home: '/root',
-                      fqdn: 'localhost',
                       networking: {
+                        fqdn: 'localhost',
                         hostname: 'localhost'
                       })
         end
@@ -69,8 +69,8 @@ describe 'mysql::server::account_security' do
       context 'with fqdn==localhost.localdomain' do
         let(:facts) do
           facts.merge(root_home: '/root',
-                      fqdn: 'localhost.localdomain',
                       networking: {
+                        fqdn: 'localhost.localdomain',
                         hostname: 'localhost'
                       })
         end

--- a/spec/classes/mysql_server_account_security_spec.rb
+++ b/spec/classes/mysql_server_account_security_spec.rb
@@ -15,7 +15,9 @@ describe 'mysql::server::account_security' do
         let(:facts) do
           facts.merge(root_home: '/root',
                       fqdn: 'myhost.mydomain',
-                      hostname: 'myhost')
+                      networking: {
+                        hostname: 'myhost'
+                      })
         end
 
         ['root@myhost.mydomain',
@@ -47,7 +49,9 @@ describe 'mysql::server::account_security' do
         let(:facts) do
           facts.merge(root_home: '/root',
                       fqdn: 'localhost',
-                      hostname: 'localhost')
+                      networking: {
+                        hostname: 'localhost'
+                      })
         end
 
         ['root@127.0.0.1',
@@ -66,7 +70,9 @@ describe 'mysql::server::account_security' do
         let(:facts) do
           facts.merge(root_home: '/root',
                       fqdn: 'localhost.localdomain',
-                      hostname: 'localhost')
+                      networking: {
+                        hostname: 'localhost'
+                      })
         end
 
         ['root@127.0.0.1',


### PR DESCRIPTION
Puppet 8 will default to not send legacy facts. Update the module so that it uses the facts that superseded these legacy facts.
