### PR TITLE
Also set passwords for the additional root users.

### DIFF
--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -35,6 +35,16 @@ class mysql::server::root_password {
       password_hash => Deferred('mysql::password', [$mysql::server::root_password]),
       require       => Exec['remove install pass'],
     }
+    mysql_user { 'root@127.0.0.1':
+      ensure        => present,
+      password_hash => mysql::password($mysql::server::root_password),
+      require       => Exec['remove install pass'],
+    }
+    mysql_user { 'root@::1':
+      ensure        => present,
+      password_hash => mysql::password($mysql::server::root_password),
+      require       => Exec['remove install pass'],
+    }
   }
 
   if $mysql::server::create_root_my_cnf and $root_password_set {


### PR DESCRIPTION
MySQL/MariaDB also have root@127.0.0.1 and root@::1 users. If the password is not set for them then any user can log in as root without a password by specifying `-h 127.0.0.1` or `-h ::1`.