### PR TITLE
allow tls_options to be of String

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -49,7 +49,7 @@
 define mysql::db (
   String[1]                                      $user,
   Variant[String, Sensitive[String]]             $password,
-  Optional[Array[String[1]]]                     $tls_options     = undef,
+  Optional[Variant[String[1], Array[String[1]]]] $tls_options     = undef,
   String                                         $dbname          = $name,
   String[1]                                      $charset         = 'utf8',
   String[1]                                      $collate         = 'utf8_general_ci',


### PR DESCRIPTION
the type of $tls_options has recently been changed to Array in 5131e0f806 while the code in lib/puppet/type/mysql_user.rb is able to work with it as an Array or a String.

This change allows $tls_options to by a String in addition to Array, which re-establishes compatibility with other modules, like puppet-icinga

Fixes https://github.com/puppetlabs/puppetlabs-mysql/issues/1539