### PR TITLE
allow metacharacters * and ? in sql file path

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -78,7 +78,7 @@ define mysql::db (
   # Ensure that the sql files passed are valid file paths.
   if $sql {
     $sql.each | $sqlfile | {
-      if $sqlfile !~ /^\/(?:.[.A-Za-z0-9_-]+\/?+)+(?:\.[.A-Za-z0-9]+)+$/ {
+      if $sqlfile !~ /^\/(?:.[.A-Za-z0-9_\-\?*]+\/?+)+(?:\.[.A-Za-z0-9]+)+$/ {
         $message = "The file '${sqlfile}' is invalid. A valid file path is expected."
         fail($message)
       }


### PR DESCRIPTION
Hi,

I had a problem with another module (sensson/puppet-powerdns)
which has given `/usr/share/doc/pdns-backend-mysql-*.*.*/schema.mysql.sql` as sql to mysql::db
this failed with `file … is invalid. A valid file path is expected.`

Are the metacharacters ? and * problematic in these paths and should I fix it else where or would it be okay to use these?