### PR TITLE
fixtures.yml: Delete legacy symlink

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,5 +7,3 @@ fixtures:
     puppet_agent:
       repo: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
       ref: v4.12.1
-  symlinks:
-    "mysql": "#{source_dir}"


### PR DESCRIPTION
puppetlabs_spec_helper will create the symlink for us, we don't need it in .fixtures.yml.