### PR TITLE
(CONT-903) Use checkout@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Activate Ruby 2.7
       uses: ruby/setup-ruby@v1
@@ -58,7 +58,7 @@ jobs:
     
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Activate Ruby 2.7
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Activate Ruby 2.7
       uses: ruby/setup-ruby@v1
@@ -57,7 +57,7 @@ jobs:
     
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Activate Ruby 2.7
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Prior to this commit, deprecation warnings were present in the nightly and ci workflows due to checkout v2 being used rather than v3. This commit updates to v3.