### PR TITLE
Correctly set provider for all versions of AmazonLinux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,7 +36,7 @@ class mysql::params {
           $python_package_name = 'MySQL-python'
         }
         'Amazon': {
-          if versioncmp($facts['os']['release']['full'], '2') >= 0 {
+          if versioncmp($facts['os']['release']['full'], '2022') >= 0 or $facts['os']['release']['full'] == '2' {
             $provider = 'mariadb'
           } else {
             $provider = 'mysql'


### PR DESCRIPTION
… set provider on Amazon Linux

## Summary
Updated conditional for $provider in params.pp to account for all versions of Amazon Linux.

## Additional Context
See https://github.com/puppetlabs/puppetlabs-mysql/issues/1584

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)