### PR TITLE
(CAT-1428) Removal of redhat/scientific/oraclelinux 6 for mysql module

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -485,7 +485,7 @@ class mysql::params {
   }
 
   ## Additional graceful failures
-  if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '4' and $facts['os']['name'] != 'Amazon' {
-    fail("Unsupported platform: puppetlabs-${module_name} only supports RedHat 6.0 and beyond.")
+  if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] < '7' and $facts['os']['name'] != 'Amazon' {
+    fail("Unsupported platform: puppetlabs-${module_name} only supports RedHat 7.0 and beyond.")
   }
 }

--- a/spec/acceptance/05_mysql_xtrabackup_spec.rb
+++ b/spec/acceptance/05_mysql_xtrabackup_spec.rb
@@ -40,7 +40,7 @@ describe 'mysql::server::backup class with xtrabackup', if: Gem::Version.new(mys
           /RedHat/: {
             # RHEL/CentOS 5 is no longer supported by Percona, but older versions
             # of the repository are still available.
-            if versioncmp($facts['os']['release']['major'], '6') >= 0 {
+            if versioncmp($facts['os']['release']['major'], '7') >= 0 {
               $percona_url = 'http://repo.percona.com/yum/percona-release-latest.noarch.rpm'
               $epel_url = "https://download.fedoraproject.org/pub/epel/epel-release-latest-${facts['os']['release']['major']}.noarch.rpm"
             } else {

--- a/spec/acceptance/types/mysql_plugin_spec.rb
+++ b/spec/acceptance/types/mysql_plugin_spec.rb
@@ -9,11 +9,6 @@ require 'spec_helper_acceptance'
 case os[:family]
 when 'redhat'
   case os[:release].to_i
-  when 5
-    plugin = nil # Plugins not supported on mysql on RHEL 5
-  when 6
-    plugin     = 'example'
-    plugin_lib = 'ha_example.so'
   when 7
     plugin     = 'pam'
     plugin_lib = 'auth_pam.so'

--- a/spec/classes/mysql_backup_xtrabackup_spec.rb
+++ b/spec/classes/mysql_backup_xtrabackup_spec.rb
@@ -40,10 +40,8 @@ describe 'mysql::backup::xtrabackup' do
         package = if facts[:os]['family'] == 'RedHat'
                     if Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '8') >= 0
                       'percona-xtrabackup-24'
-                    elsif Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '7') >= 0
-                      'percona-xtrabackup'
                     else
-                      'percona-xtrabackup-20'
+                      'percona-xtrabackup'
                     end
                   elsif facts[:os]['name'] == 'Debian'
                     'percona-xtrabackup-24'
@@ -195,10 +193,8 @@ describe 'mysql::backup::xtrabackup' do
         package = if facts[:os]['family'] == 'RedHat'
                     if Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '8') >= 0
                       'percona-xtrabackup-24'
-                    elsif Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '7') >= 0
-                      'percona-xtrabackup'
                     else
-                      'percona-xtrabackup-20'
+                      'percona-xtrabackup'
                     end
                   elsif facts[:os]['name'] == 'Debian'
                     'percona-xtrabackup-24'


### PR DESCRIPTION
## Summary
With the removal of support for RHEL6 from our modules, work must be done to cleanup and remove any residual code.
This PR does the same for mysql repo module. More info can be found #1498 

## Additional Context

## Related Issues (if any)

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)