### PR TITLE
Update conditional logic xtrabackup.pp to properly...

### DIFF
--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -97,11 +97,17 @@ class mysql::backup::xtrabackup (
         }
       }
       else {
+        # RENAME CLIENT Renamed to BINLOG MONITOR in MariaDB 10.5.2 
+        if versioncmp($facts['mysql_version'], '10.5.2') >= 0 and (/(?i:mariadb)/ in $facts['mysqld_version']) {
+          $privs = ['BINLOG MONITOR', 'RELOAD', 'PROCESS', 'LOCK TABLES']
+        } else {
+          $privs = ['RELOAD', 'PROCESS', 'LOCK TABLES', 'REPLICATION CLIENT']
+        }
         mysql_grant { "${backupuser}@localhost/*.*":
           ensure     => $ensure,
           user       => "${backupuser}@localhost",
           table      => '*.*',
-          privileges => ['RELOAD', 'PROCESS', 'LOCK TABLES', 'REPLICATION CLIENT'],
+          privileges => $privs,
           require    => Mysql_user["${backupuser}@localhost"],
         }
       }


### PR DESCRIPTION
## Summary
Update conditional logic xtrabackup.pp to properly manage permissions of xtrabackup users for [MariaDB 10.5.2](https://mariadb.com/kb/en/mariadb-1052-release-notes/)

## Additional Context
Check [#1598](https://github.com/puppetlabs/puppetlabs-mysql/issues/1598)
## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)