### PR TITLE
Fix backup/rotation with multiple excluded databases

### DIFF
--- a/spec/classes/mysql_backup_mysqldump_spec.rb
+++ b/spec/classes/mysql_backup_mysqldump_spec.rb
@@ -76,13 +76,13 @@ describe 'mysql::backup::mysqldump' do
         let(:params) do
           {
             'file_per_database' => true,
-            'excludedatabases' => ['information_schema']
+            'excludedatabases' => ['information_schema', 'performance_schema']
           }.merge(default_params)
         end
 
         it {
           expect(subject).to contain_file('mysqlbackup.sh').with_content(
-            %r{information_schema},
+            %r{information_schema\\\|performance_schema},
           )
         }
       end

--- a/templates/mysqlbackup.sh.epp
+++ b/templates/mysqlbackup.sh.epp
@@ -84,7 +84,7 @@ cleanup
 <% if $excludedatabases.empty { -%>
 mysql --defaults-extra-file=$TMPFILE -s -r -N -e 'SHOW DATABASES' | while read dbname
 <%} else {-%>
-mysql --defaults-extra-file=$TMPFILE -s -r -N -e 'SHOW DATABASES' | grep -v '^\(<%= $excludedatabases.join('|') %>\)$' | while read dbname
+mysql --defaults-extra-file=$TMPFILE -s -r -N -e 'SHOW DATABASES' | grep -v '^\(<%= $excludedatabases.join('\\|') %>\)$' | while read dbname
 <% } -%>
 do
   <%= $backupmethod %> --defaults-extra-file=$TMPFILE --opt --flush-logs --single-transaction \


### PR DESCRIPTION
## Summary

Right now, excluding multiple databases does not work.
This MR aims to fix excluding multiple databases, by revising the respective regular expression.

## Additional Context

* When using multiple excluded databases, the list of databases is filtered using `grep -v`. i.e. `grep -v '^\(information_schema|performance_schema\)$`
* When using Basic vs Extended Regular Expressions, the characters `(` and `|` lose their special meaning, the backslashed versions have to be used. For the group (`()`) the escaping has been done, however the alternation is unescaped.

Leading to:

* All the excluded databases will be backed up.
* In case a database is not backuppable (which is why it had been excluded), this leads to the cleanup not being run at all, as it depends on the backup having been successful.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.