### PR TITLE
(CAT-1696) - Skip pipeline for ARM based OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Setup Acceptance Test Matrix
       id: get-matrix
       run: |
-        bundle exec matrix_from_metadata_v2 
+        bundle exec matrix_from_metadata_v2 --exclude-platforms '["Ubuntu-22.04-arm", "RedHat-9-arm"]'
 
   Acceptance:
     name: "${{matrix.platforms.label}}, ${{matrix.collection}}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup Acceptance Test Matrix
       id: get-matrix
       run: |
-        bundle exec matrix_from_metadata_v2 
+        bundle exec matrix_from_metadata_v2 --exclude-platforms '["Ubuntu-22.04-arm", "RedHat-9-arm"]'
 
   Acceptance:
     name: "${{matrix.platforms.label}}, ${{matrix.collection}}"

--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ The MySQL module has an example task that allows a user to execute arbitary SQL 
 
 ## Limitations
 
-For an extensive list of supported operating systems, see [metadata.json](https://github.com/puppetlabs/puppetlabs-mysql/blob/main/metadata.json)
+This module lacks compatibility with the ARM architecture, for an extensive list of supported operating systems, see [metadata.json](https://github.com/puppetlabs/puppetlabs-mysql/blob/main/metadata.json)
 
 **Note:** The mysqlbackup.sh does not work and is not supported on MySQL 5.7 and greater.
 


### PR DESCRIPTION
## Summary
There are supporting binaries of MySQL which are not supported with ARM architecture which are : 
- my_print_defaults
- mysql_config_editor

Skip pipeline for **ARM** based OS, below is list of ARM supported OS : 
- Ubuntu 22.04 
- RHEL-9

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)