### PR TITLE
Update `client_dev_package_name` for Debian/Ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -162,7 +162,7 @@ class mysql::params {
         $client_package_name     = 'mariadb-client'
         $server_package_name     = 'mariadb-server'
         $server_service_name     = 'mariadb'
-        $client_dev_package_name = 'libmariadbclient-dev'
+        $client_dev_package_name = 'libmariadb-dev'
         $daemon_dev_package_name = 'libmariadbd-dev'
       } else {
         $client_package_name     = 'mysql-client'


### PR DESCRIPTION
The package `libmariadbclient-dev` was transitioned to `libmariadb-dev` several releases ago.

The old package isn't installable in the supported versions and beyond.