### PR TITLE
Remove deprecated option expire_logs_days from default config

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -435,7 +435,6 @@ class mysql::params {
       'basedir'               => $mysql::params::basedir,
       'bind-address'          => '127.0.0.1',
       'datadir'               => $mysql::params::datadir,
-      'expire_logs_days'      => '10',
       'key_buffer_size'       => '16M',
       'log-error'             => $mysql::params::log_error,
       'max_allowed_packet'    => '16M',


### PR DESCRIPTION
## Summary
The option `expire_logs_days` is deprecated and should no longer be used. This PR removes it from the default configuration.

## Additional Context
This change should only have a minor effect on existing installations. Old versions of MySQL (5.7) will fallback to their internal default value of `expire_logs_days`. Newer versions (MySQL 8.0) will probably already use the new option `binlog_expire_logs_seconds`.

This removes the following warning from MySQL's log:
```
[Server] The syntax 'expire-logs-days' is deprecated and will be removed in a future release. Please use binlog_expire_logs_seconds instead.
```

## Related Issues (if any)
none

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)