### PR TITLE
xtrabackup: handle missing facts gracefully

### DIFF
--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -50,7 +50,7 @@ class mysql::backup::xtrabackup (
       require       => Class['mysql::server::root_password'],
     }
     # Percona XtraBackup needs additional grants/privileges to work with MySQL 8
-    if versioncmp($facts['mysql_version'], '8') >= 0 and !(/(?i:mariadb)/ in $facts['mysqld_version']) {
+    if ('mysql_version' in $facts) and ('mysqld_version' in $facts) and versioncmp($facts['mysql_version'], '8') >= 0 and !(/(?i:mariadb)/ in $facts['mysqld_version']) {
       if ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'], '11') >= 0) or
       ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'], '22.04') >= 0) {
         mysql_grant { "${backupuser}@localhost/*.*":


### PR DESCRIPTION
## Summary
When setting up a new server (or when reinstalling an existing server) with xtrabackup enabled, the Puppet Run may fail:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error:
Error while evaluating a Function Call, 'versioncmp' parameter 'a' expects a String value, got Undef
(file: /etc/puppetlabs/code/environments/development/modules/mysql/manifests/backup/xtrabackup.pp, line: 53, column: 8) on node
```

This patch adds a check to verify that the facts are available, before accessing them.

## Additional Context
none

## Related Issues (if any)
none

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)