### PR TITLE
mysqlbackup: Reenable tests

### DIFF
--- a/manifests/backup/mysqlbackup.pp
+++ b/manifests/backup/mysqlbackup.pp
@@ -32,6 +32,7 @@ class mysql::backup::mysqlbackup (
   Optional[String[1]]                           $compression_command      = undef,
   Optional[String[1]]                           $compression_extension    = undef,
   Optional[String[1]]                           $backupmethod_package     = undef,
+  Array                                         $excludedatabases         = [], # unused, compatibility variable for mysql::server::backup class
 ) inherits mysql::params {
   $backuppassword_unsensitive = if $backuppassword =~ Sensitive {
     $backuppassword.unwrap

--- a/manifests/server/backup.pp
+++ b/manifests/server/backup.pp
@@ -86,6 +86,7 @@
 #   The package which provides the binary specified by the backupmethod parameter.
 # @param excludedatabases
 #   Give a list of excluded databases when using file_per_database, e.g.: [ 'information_schema', 'performance_schema' ]
+#   Only used for the mysqldump and xtrabackup providers
 class mysql::server::backup (
   Optional[String[1]]                                                   $backupuser               = undef,
   Optional[Variant[String, Sensitive[String]]]                          $backuppassword           = undef,

--- a/spec/acceptance/04_mysql_backup_spec.rb
+++ b/spec/acceptance/04_mysql_backup_spec.rb
@@ -35,7 +35,7 @@ describe 'mysql::server::backup class' do
     end
   end
 
-  describe 'mysqlbackup.sh', if: Gem::Version.new(mysql_version) < Gem::Version.new('5.7.0') do
+  describe 'mysqlbackup.sh' do
     it 'runs mysqlbackup.sh with no errors' do
       run_shell('/usr/local/sbin/mysqlbackup.sh') do |r|
         expect(r.stderr).to eq('')
@@ -84,6 +84,7 @@ describe 'mysql::server::backup class' do
             backupdir         => '/tmp/backups',
             backupcompress    => true,
             file_per_database => true,
+            provider          => 'mysqlbackup',
             postscript        => [
               'rm -rf /var/tmp/mysqlbackups',
               'rm -f /var/tmp/mysqlbackups.done',
@@ -98,7 +99,7 @@ describe 'mysql::server::backup class' do
       end
     end
 
-    describe 'mysqlbackup.sh', if: Gem::Version.new(mysql_version) < Gem::Version.new('5.7.0') do
+    describe 'mysqlbackup.sh' do
       it 'runs mysqlbackup.sh with no errors without root credentials' do
         run_shell('HOME=/tmp/dontreadrootcredentials /usr/local/sbin/mysqlbackup.sh') do |r|
           expect(r.stderr).to eq('')


### PR DESCRIPTION
Previously the tests were only executed on mysql versions older than 5.7.0. This commit removes the contraint.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)