### PR TITLE
Add support for Mariadb 11.x

### DIFF
--- a/lib/facter/mysql_version.rb
+++ b/lib/facter/mysql_version.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 Facter.add('mysql_version') do
-  confine { Facter::Core::Execution.which('mysql') }
   setcode do
-    mysql_ver = Facter::Core::Execution.execute('mysql --version')
+    mysql_ver = if Facter::Core::Execution.which('mysql')
+                  Facter::Core::Execution.execute('mysql --version')
+                elsif Facter::Core::Execution.which('mariadb')
+                  Facter::Core::Execution.execute('mariadb --version')
+                end
     mysql_ver.match(%r{\d+\.\d+\.\d+})[0] if mysql_ver
   end
 end

--- a/lib/facter/mysqld_version.rb
+++ b/lib/facter/mysqld_version.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 Facter.add('mysqld_version') do
-  confine { Facter::Core::Execution.which('mysqld') || Facter::Core::Execution.which('/usr/libexec/mysqld') }
   setcode do
-    # Add /usr/libexec to PATH to find mysqld command
-    Facter::Core::Execution.execute('env PATH=$PATH:/usr/libexec mysqld --no-defaults -V 2>/dev/null')
+    if Facter::Core::Execution.which('mysqld') || Facter::Core::Execution.which('/usr/libexec/mysqld')
+      Facter::Core::Execution.execute('env PATH=$PATH:/usr/libexec mysqld --no-defaults -V 2>/dev/null')
+    elsif Facter::Core::Execution.which('mariadbd')
+      Facter::Core::Execution.execute('mariadbd --no-defaults -V 2>/dev/null')
+    end
   end
 end

--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -38,10 +38,28 @@ class Puppet::Provider::Mysql < Puppet::Provider
   ].join(':')
 
   # rubocop:disable Style/HashSyntax
-  commands :mysql_raw  => 'mysql'
-  commands :mysqld     => 'mysqld'
-  commands :mysqladmin => 'mysqladmin'
+  commands :mysql_client     => 'mysql'
+  commands :mariadb_client   => 'mariadb'
+  commands :mysqld_service   => 'mysqld'
+  commands :mariadbd_service => 'mariadbd'
+  commands :mysql_admin      => 'mysqladmin'
+  commands :mariadb_admin    => 'mariadb-admin'
   # rubocop:enable Style/HashSyntax
+
+  def self.mysql_raw(*args)
+    mysqld_version_string.scan(%r{mariadb}i) { return mariadb_client(*args) }
+    mysql_client(*args)
+  end
+
+  def self.mysqld(*args)
+    mysqld_version_string.scan(%r{mariadb}i) { return mariadbd_service(*args) }
+    mysqld_service(*args)
+  end
+
+  def self.mysqladmin(*args)
+    mysqld_version_string.scan(%r{mariadb}i) { return mariadb_admin(*args) }
+    mysql_admin(*args)
+  end
 
   # Optional defaults file
   def self.defaults_file

--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -47,17 +47,23 @@ class Puppet::Provider::Mysql < Puppet::Provider
   # rubocop:enable Style/HashSyntax
 
   def self.mysql_raw(*args)
-    mysqld_version_string.scan(%r{mariadb}i) { return mariadb_client(*args) }
+    if newer_than('mariadb' => '11.0.0') && mysqld_version_string.scan(%r{mariadb}i)
+      return mariadb_client(*args)
+    end
     mysql_client(*args)
   end
 
   def self.mysqld(*args)
-    mysqld_version_string.scan(%r{mariadb}i) { return mariadbd_service(*args) }
+    if newer_than('mariadb' => '11.0.0') && mysqld_version_string.scan(%r{mariadb}i)
+      return mariadb_client(*args)
+    end
     mysqld_service(*args)
   end
 
   def self.mysqladmin(*args)
-    mysqld_version_string.scan(%r{mariadb}i) { return mariadb_admin(*args) }
+    if newer_than('mariadb' => '11.0.0') && mysqld_version_string.scan(%r{mariadb}i)
+      return mariadb_client(*args)
+    end
     mysql_admin(*args)
   end
 
@@ -80,8 +86,8 @@ class Puppet::Provider::Mysql < Puppet::Provider
   def self.mysqld_version_string
     # As the possibility of the mysqld being remote we need to allow the version string to be overridden,
     # this can be done by facter.value as seen below. In the case that it has not been set and the facter
-    # value is nil we use the mysql -v command to ensure we report the correct version of mysql for later use cases.
-    @mysqld_version_string ||= Facter.value(:mysqld_version) || mysqld('-V')
+    # value is nil we use an empty string so that default client/service are used.
+    @mysqld_version_string ||= Facter.value(:mysqld_version) || ''
   end
 
   def mysqld_version_string

--- a/spec/unit/facter/mysql_version_spec.rb
+++ b/spec/unit/facter/mysql_version_spec.rb
@@ -8,14 +8,27 @@ describe Facter::Util::Fact.to_s do
   end
 
   describe 'mysql_version' do
-    context 'with value' do
+    context 'with mysql' do
       before :each do
-        allow(Facter::Core::Execution).to receive(:which).and_return('fake_mysql_path')
+        allow(Facter::Core::Execution).to receive(:which).with('mysql').and_return('fake_mysql_path')
+        allow(Facter::Core::Execution).to receive(:which).with('mariadb').and_return(false)
         allow(Facter::Core::Execution).to receive(:execute).with('mysql --version').and_return('mysql  Ver 14.12 Distrib 5.0.95, for redhat-linux-gnu (x86_64) using readline 5.1')
       end
 
       it {
         expect(Facter.fact(:mysql_version).value).to eq('5.0.95')
+      }
+    end
+
+    context 'with mariadb' do
+      before :each do
+        allow(Facter::Core::Execution).to receive(:which).with('mysql').and_return(false)
+        allow(Facter::Core::Execution).to receive(:which).with('mariadb').and_return('/usr/bin/mariadb')
+        allow(Facter::Core::Execution).to receive(:execute).with('mariadb --version').and_return('mariadb from 11.4.2-MariaDB, client 15.2 for debian-linux-gnu (x86_64) using  EditLine wrapper')
+      end
+
+      it {
+        expect(Facter.fact(:mysql_version).value).to eq('11.4.2')
       }
     end
   end

--- a/spec/unit/facter/mysqld_version_spec.rb
+++ b/spec/unit/facter/mysqld_version_spec.rb
@@ -8,15 +8,30 @@ describe Facter::Util::Fact.to_s do
   end
 
   describe 'mysqld_version' do
-    context 'with value' do
+    context 'with mysqld' do
       before :each do
         allow(Facter::Core::Execution).to receive(:which).with('mysqld').and_return('/usr/sbin/mysqld')
+        allow(Facter::Core::Execution).to receive(:which).with('mariadbd').and_return(false)
         allow(Facter::Core::Execution).to receive(:execute).with('env PATH=$PATH:/usr/libexec mysqld --no-defaults -V 2>/dev/null')
                                                            .and_return('mysqld  Ver 5.5.49-37.9 for Linux on x86_64 (Percona Server (GPL), Release 37.9, Revision efa0073)')
       end
 
       it {
         expect(Facter.fact(:mysqld_version).value).to eq('mysqld  Ver 5.5.49-37.9 for Linux on x86_64 (Percona Server (GPL), Release 37.9, Revision efa0073)')
+      }
+    end
+
+    context 'with mariadb' do
+      before :each do
+        allow(Facter::Core::Execution).to receive(:which).with('mysqld').and_return(false)
+        allow(Facter::Core::Execution).to receive(:which).with('/usr/libexec/mysqld').and_return(false)
+        allow(Facter::Core::Execution).to receive(:which).with('mariadbd').and_return('/usr/sbin/mariadbd')
+        allow(Facter::Core::Execution).to receive(:execute).with('mariadbd --no-defaults -V 2>/dev/null')
+                                                           .and_return('mariadbd  Ver 11.4.2-MariaDB-ubu2404 for debian-linux-gnu on x86_64 (mariadb.org binary distribution)')
+      end
+
+      it {
+        expect(Facter.fact(:mysqld_version).value).to eq('mariadbd  Ver 11.4.2-MariaDB-ubu2404 for debian-linux-gnu on x86_64 (mariadb.org binary distribution)')
       }
     end
   end


### PR DESCRIPTION
## Summary
Add support for Mariadb 11.x and use its mariadb and mariadbd binaries.

## Additional Context
From Mariadb 11.0, mysql* names are deprecated in favor of mariadb* (cf. https://jira.mariadb.org/browse/MDEV-29582).
This pull request is:
- including commits from @OxCom, determining which binaries to use, depending on the mysqld_version facter
- fixing facters for mysql_version and mysqld_version whithin the MariaDB>11 context
- updating/adding tests for this new context

The initial PR #1626 causes [an infinite loop](https://github.com/puppetlabs/puppetlabs-mysql/pull/1626#issuecomment-2236002878) in our case of fresh deployment, because facter is not properly initialized.

## Related Issues
This pull request manages to fix #1580 .