### PR TITLE
Fix #1580 Read symlinks for mysql commands that are deprecated in MariaDB 11

### DIFF
--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -39,13 +39,20 @@ class Puppet::Provider::Mysql < Puppet::Provider
 
   # rubocop:disable Style/HashSyntax
   if File.symlink?(Facter::Core::Execution.which('mysql'))
-    real_command = File.readlink(Facter::Core::Execution.which('mysql'))
+    commands :mysql_raw  => File.readlink(Facter::Core::Execution.which('mysql'))
   else
-    real_command = Facter::Core::Execution.which('mysql')
+    commands :mysql_raw  => Facter::Core::Execution.which('mysql')
   end
-  commands :mysql_raw  => real_command
-  commands :mysqld     => 'mysqld'
-  commands :mysqladmin => 'mysqladmin'
+  if File.symlink?(Facter::Core::Execution.which('mysqld'))
+    commands :mysqld     => File.readlink(Facter::Core::Execution.which('mysqld'))
+  else
+    commands :mysqld     => 'mysqld'
+  end
+  if File.symlink?(Facter::Core::Execution.which('mysqladmin'))
+    commands :mysqladmin => File.readlink(Facter::Core::Execution.which('mysqladmin'))
+  else
+    commands :mysqladmin => 'mysqladmin'
+  end
   # rubocop:enable Style/HashSyntax
 
   # Optional defaults file

--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -38,7 +38,12 @@ class Puppet::Provider::Mysql < Puppet::Provider
   ].join(':')
 
   # rubocop:disable Style/HashSyntax
-  commands :mysql_raw  => 'mysql'
+  if File.symlink?(Facter::Core::Execution.which('mysql'))
+    real_command = File.readlink(Facter::Core::Execution.which('mysql'))
+  else
+    real_command = Facter::Core::Execution.which('mysql')
+  end
+  commands :mysql_raw  => real_command
   commands :mysqld     => 'mysqld'
   commands :mysqladmin => 'mysqladmin'
   # rubocop:enable Style/HashSyntax

--- a/tasks/export.rb
+++ b/tasks/export.rb
@@ -6,7 +6,11 @@ require 'open3'
 require 'puppet'
 
 def get(file, database, user, password)
-  cmd_string = 'mysqldump'
+  if File.symlink?(Facter::Core::Execution.which('mysqldump'))
+    cmd_string = File.readlink(Facter::Core::Execution.which('mysqldump'))
+  else
+    cmd_string = 'mysqldump'
+  end
   cmd_string << " --databases #{database}" unless database.nil?
   cmd_string << " --user=#{user}" unless user.nil?
   cmd_string << " --password=#{password}" unless password.nil?


### PR DESCRIPTION
## Summary
Provide a detailed description of all the changes present in this pull request.
MariaDB 11 is deprecating compatibility with MySQL commands. The deprecation message get in between the output while running this commands breaking providers. See more details in Issue #1580 
As one of my first attempts to Ruby (sorry if the code is not up to standards), I added some test to check if the commands are actually symlinks and in that case read them and use the target.

Probably the code shouldn't take the stderr merge with stdout, and that would solve the issue. Also a version check could help indicate the specific command to run. But I thought that it was cleaner and covering future possible cases by just reading the symlink and running the target command.

## Additional Context
Add any additional context about the problem here. 
- [x] Root cause and the steps to reproduce. (If applicable)
- [x] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.
#1580 
## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)