### PR TITLE
(CAT-2100) Add Debian 12 support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,4 +6,4 @@ fixtures:
     "provision": "https://github.com/puppetlabs/provision.git"
     puppet_agent:
       repo: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-      ref: v4.13.0
+      ref: v4.21.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Setup Acceptance Test Matrix
       id: get-matrix
       run: |
-        bundle exec matrix_from_metadata_v2 --exclude-platforms '["Ubuntu-22.04-arm", "RedHat-9-arm"]'
+        bundle exec matrix_from_metadata_v2 --exclude-platforms '["Debian-12-arm", "Ubuntu-22.04-arm", "RedHat-9-arm"]'
 
   Acceptance:
     name: "${{matrix.platforms.label}}, ${{matrix.collection}}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup Acceptance Test Matrix
       id: get-matrix
       run: |
-        bundle exec matrix_from_metadata_v2 --exclude-platforms '["Ubuntu-22.04-arm", "RedHat-9-arm"]'
+        bundle exec matrix_from_metadata_v2 --exclude-platforms '["Debian-12-arm", "Ubuntu-22.04-arm", "RedHat-9-arm"]'
 
   Acceptance:
     name: "${{matrix.platforms.label}}, ${{matrix.collection}}"

--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -86,7 +86,7 @@ class mysql::backup::xtrabackup (
       }
     }
     else {
-      if $facts['os']['family'] == 'debian' and $facts['os']['release']['major'] == '11' or
+      if ($facts['os']['name'] == 'debian' and versioncmp($facts['os']['release']['major'], '11') >= 0) or
       ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'], '22.04') >= 0) {
         mysql_grant { "${backupuser}@localhost/*.*":
           ensure     => $ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -217,6 +217,7 @@ class mysql::params {
         '9'     => 'ruby-mysql2', # stretch
         '10'    => 'ruby-mysql2', # buster
         '11'    => 'ruby-mysql2', # bullseye
+        '12'    => 'ruby-mysql2', # bookworm
         '16.04' => 'ruby-mysql', # xenial
         '18.04' => 'ruby-mysql2', # bionic
         '20.04' => 'ruby-mysql2', # focal

--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -13,6 +13,7 @@ class mysql::server::installdb {
     $basedir = $mysql::server::_options['mysqld']['basedir']
     $config_file = $mysql::server::config_file
     $log_error = $mysql::server::_options['mysqld']['log-error']
+    $log_dir = '/var/log/mysql'
 
     if $mysql::server::manage_config_file and $config_file != $mysql::params::config_file {
       $_config_file=$config_file
@@ -28,6 +29,12 @@ class mysql::server::installdb {
         mode   => 'u+rw',
         before => Mysql_datadir[$datadir],
       }
+    }
+
+    file { $log_dir:
+      ensure => 'directory',
+      owner  => $mysqluser,
+      group  => $mysql::server::mysql_group,
     }
 
     mysql_datadir { $datadir:

--- a/metadata.json
+++ b/metadata.json
@@ -39,7 +39,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "10",
-        "11"
+        "11",
+        "12"
       ]
     },
     {

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -36,8 +36,12 @@ def sles_15?
   os[:family] == 'sles' && os[:release].to_i == 15
 end
 
+def debian_12?
+  os[:family] == 'debian' && os[:release].to_i == 12
+end
+
 def charset
-  @charset ||= (ubuntu_2204? || sles_15?) ? 'utf8mb3' : 'utf8'
+  @charset ||= (debian_12? || ubuntu_2204? || sles_15?) ? 'utf8mb3' : 'utf8'
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
## Summary
Add support for Debian 12

## Additional Context
 - Add all Debian 11 and above platforms to have expected privileges.
 - Add ruby package for Debian 12
 - When downloading the mariadb-server package '/var/log/mysql' is automatically created for other platforms, but that is not the case with Debian 12. So, make sure the directory is present.
 - Debian 12 uses utf8mb3 encoding since utf8 is not supported on it.
 - Skip Debian-12-arm platform from tests since the mysql binaries, 'my_print_defaults' and 'mysql_config_editor', are not supported for ARM architecture.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)