### PR TITLE
fix: manage directory containing log

### DIFF
--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -13,7 +13,6 @@ class mysql::server::installdb {
     $basedir = $mysql::server::_options['mysqld']['basedir']
     $config_file = $mysql::server::config_file
     $log_error = $mysql::server::_options['mysqld']['log-error']
-    $log_dir = '/var/log/mysql'
 
     if $mysql::server::manage_config_file and $config_file != $mysql::params::config_file {
       $_config_file=$config_file
@@ -22,6 +21,11 @@ class mysql::server::installdb {
     }
 
     if $options['mysqld']['log-error'] {
+      file { dirname($options['mysqld']['log-error']):
+        ensure => 'directory',
+        owner  => $mysqluser,
+        group  => $mysql::server::mysql_group,
+      }
       file { $options['mysqld']['log-error']:
         ensure => file,
         owner  => $mysqluser,
@@ -29,12 +33,6 @@ class mysql::server::installdb {
         mode   => 'u+rw',
         before => Mysql_datadir[$datadir],
       }
-    }
-
-    file { $log_dir:
-      ensure => 'directory',
-      owner  => $mysqluser,
-      group  => $mysql::server::mysql_group,
     }
 
     mysql_datadir { $datadir:

--- a/manifests/server/managed_dirs.pp
+++ b/manifests/server/managed_dirs.pp
@@ -33,7 +33,7 @@ class mysql::server::managed_dirs {
     $logbindir = dirname($logbin)
 
     #Stop puppet from managing directory if just a filename/prefix is specified or is not already managed
-    if (!($logbindir == '.' or $logbindir in $managed_dirs_path)) {
+    if (!($logbindir == '.' or $logbindir in $managed_dirs_path or $logbindir == dirname($options['mysqld']['log-error']))) {
       file { $logbindir:
         ensure => directory,
         mode   => '0700',


### PR DESCRIPTION
Currently, /var/log/mysql is created on all mysql servers regardless if they are used or not
This change instead manages directory where configured log file is configured