### PR TITLE
1663: Fix backup optional_args

### DIFF
--- a/templates/mysqlbackup.sh.epp
+++ b/templates/mysqlbackup.sh.epp
@@ -56,7 +56,7 @@ ADDITIONAL_OPTIONS="$ADDITIONAL_OPTIONS --skip-routines"
 <% } -%>
 <% } -%>
 
-<%- if $optional_args and type($optional_args) =~ Type(Array) { -%>
+<%- if $optional_args and type($optional_args) =~ Type[Array] { -%>
 <% $optional_args.each |$arg| { -%>
 ADDITIONAL_OPTIONS="$ADDITIONAL_OPTIONS <%= $arg %>"
 <%- } -%>


### PR DESCRIPTION
## Summary
Fix array check for the `optional_args` parameter in backup script template.

## Additional Context
Please see #1663 

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests. - Sorry, not sure how to run these.
- [x] Manually verified. (For example `puppet apply`)