### PR TITLE
mysql_grant: Output missmatching data during validation

### DIFF
--- a/lib/puppet/type/mysql_grant.rb
+++ b/lib/puppet/type/mysql_grant.rb
@@ -37,7 +37,9 @@ Puppet::Type.newtype(:mysql_grant) do
     raise(_('mysql_grant: `table` `parameter` is required.')) if self[:ensure] == :present && self[:table].nil?
     raise(_('mysql_grant: `user` `parameter` is required.')) if self[:ensure] == :present && self[:user].nil?
 
-    raise(_('mysql_grant: `name` `parameter` must match user@host/table format.')) if self[:user] && self[:table] && (self[:name] != "#{self[:user]}/#{self[:table]}")
+    if self[:user] && self[:table] && (self[:name] != "#{self[:user]}/#{self[:table]}")
+      raise(_("mysql_grant: `name` `parameter` must match user@host/table format. Got `name` #{self[:name]}, and user/table #{self[:user]}/#{self[:table]}"))
+    end
   end
 
   newparam(:name, namevar: true) do


### PR DESCRIPTION
The type does some validation for the title and user/table. It's helpful to output the data when the validation doesn't succeed.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)