### PR TITLE
ci(MODULES-11557): add Twingate setup step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,11 @@ jobs:
       FACTER_GEM_VERSION: 'https://github.com/puppetlabs/facter#main'
     
     steps:
+    - name: "Install Twingate"
+      uses: "twingate/github-action@v1"
+      with:
+        service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
+
     - name: Checkout Source
       uses: actions/checkout@v3
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,6 +56,11 @@ jobs:
       FACTER_GEM_VERSION: 'https://github.com/puppetlabs/facter#main'
     
     steps:
+    - name: "Install Twingate"
+      uses: "twingate/github-action@v1"
+      with:
+        service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
+
     - name: Checkout Source
       uses: actions/checkout@v3
 


### PR DESCRIPTION
Adds the Twingate installation step in `.github/workflows/...` using `twingate/github-action@v1`. The action uses the `${{ secrets.TWINGATE_KEY }}` to establish secure access to internal resources.

This enables the workflow to access protected infrastructure during CI runs.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)