### PR TITLE
Fix version check for RHEL/CentOS Stream 10

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -476,7 +476,7 @@ class mysql::params {
   }
 
   ## Additional graceful failures
-  if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] < '7' and $facts['os']['name'] != 'Amazon' {
+  if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '7') < 0 and $facts['os']['name'] != 'Amazon' {
     fail("Unsupported platform: puppetlabs-${module_name} only supports RedHat 7.0 and beyond.")
   }
 }


### PR DESCRIPTION
## Summary
Use versioncmp to make sure 10 is considered newer than 7.

## Additional Context
n/a

## Related Issues (if any)
#1673

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)