### PR TITLE
Avoid env command in facter plugin

### DIFF
--- a/lib/facter/mysqld_version.rb
+++ b/lib/facter/mysqld_version.rb
@@ -2,8 +2,10 @@
 
 Facter.add('mysqld_version') do
   setcode do
-    if Facter::Core::Execution.which('mysqld') || Facter::Core::Execution.which('/usr/libexec/mysqld')
-      Facter::Core::Execution.execute('env PATH=$PATH:/usr/libexec mysqld --no-defaults -V 2>/dev/null')
+    if Facter::Core::Execution.which('mysqld')
+      Facter::Core::Execution.execute('mysqld --no-defaults -V 2>/dev/null')
+    elsif Facter::Core::Execution.which('/usr/libexec/mysqld')
+      Facter::Core::Execution.execute('/usr/libexec/mysqld --no-defaults -V 2>/dev/null')
     elsif Facter::Core::Execution.which('mariadbd')
       Facter::Core::Execution.execute('mariadbd --no-defaults -V 2>/dev/null')
     end

--- a/spec/unit/facter/mysqld_version_spec.rb
+++ b/spec/unit/facter/mysqld_version_spec.rb
@@ -11,8 +11,23 @@ describe Facter::Util::Fact.to_s do
     context 'with mysqld' do
       before :each do
         allow(Facter::Core::Execution).to receive(:which).with('mysqld').and_return('/usr/sbin/mysqld')
+        allow(Facter::Core::Execution).to receive(:which).with('/usr/libexec/mysqld').and_return(false)
         allow(Facter::Core::Execution).to receive(:which).with('mariadbd').and_return(false)
-        allow(Facter::Core::Execution).to receive(:execute).with('env PATH=$PATH:/usr/libexec mysqld --no-defaults -V 2>/dev/null')
+        allow(Facter::Core::Execution).to receive(:execute).with('mysqld --no-defaults -V 2>/dev/null')
+                                                           .and_return('mysqld  Ver 5.5.49-37.9 for Linux on x86_64 (Percona Server (GPL), Release 37.9, Revision efa0073)')
+      end
+
+      it {
+        expect(Facter.fact(:mysqld_version).value).to eq('mysqld  Ver 5.5.49-37.9 for Linux on x86_64 (Percona Server (GPL), Release 37.9, Revision efa0073)')
+      }
+    end
+
+    context 'with mysqld in /usr/libexec/mysqld' do
+      before :each do
+        allow(Facter::Core::Execution).to receive(:which).with('mysqld').and_return(false)
+        allow(Facter::Core::Execution).to receive(:which).with('/usr/libexec/mysqld').and_return('/usr/libexec/mysqld')
+        allow(Facter::Core::Execution).to receive(:which).with('mariadbd').and_return(false)
+        allow(Facter::Core::Execution).to receive(:execute).with('/usr/libexec/mysqld --no-defaults -V 2>/dev/null')
                                                            .and_return('mysqld  Ver 5.5.49-37.9 for Linux on x86_64 (Percona Server (GPL), Release 37.9, Revision efa0073)')
       end
 


### PR DESCRIPTION
## Additional Context

## Summary
Avoid env command in facter plugin because it interferes with the capability of core facter utility to translate command to its full path.

Also override of environment variables is not really necessary when 'mysqd' command is found in PATH.

## Related Issues (if any)
N/A

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)