### PR TITLE
added helper method in mysql provider to pick mysql or mariadb binary…

### DIFF
--- a/lib/puppet/provider/mysql_database/mysql.rb
+++ b/lib/puppet/provider/mysql_database/mysql.rb
@@ -4,7 +4,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'mysql'))
 Puppet::Type.type(:mysql_database).provide(:mysql, parent: Puppet::Provider::Mysql) do
   desc 'Manages MySQL databases.'
 
-  commands mysql_raw: 'mysql'
+  commands mysql_raw: pick_correct_binary('mysql', 'mariadb')
 
   def self.instances
     mysql_caller('show databases', 'regular').split("\n").map do |name|

--- a/lib/puppet/provider/mysql_datadir/mysql.rb
+++ b/lib/puppet/provider/mysql_datadir/mysql.rb
@@ -34,8 +34,8 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, parent: Puppet::Provider::Mysq
     '/usr/mysql/5.7/bin',
   ].join(':')
 
-  commands mysqld: 'mysqld'
-  optional_commands mysql_install_db: 'mysql_install_db'
+  commands mysqld: pick_correct_binary('mysqld', 'mariadbd')
+  optional_commands mysql_install_db: pick_correct_binary('mysql_install_db', 'mariadb-install-db')
   # rubocop:disable Lint/UselessAssignment
   def create
     name                     = @resource[:name]

--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -4,7 +4,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'mysql'))
 Puppet::Type.type(:mysql_grant).provide(:mysql, parent: Puppet::Provider::Mysql) do
   desc 'Set grants for users in MySQL.'
 
-  commands mysql_raw: 'mysql'
+  commands mysql_raw: pick_correct_binary('mysql', 'mariadb')
 
   def self.instances
     instance_configs = {}

--- a/lib/puppet/provider/mysql_plugin/mysql.rb
+++ b/lib/puppet/provider/mysql_plugin/mysql.rb
@@ -4,7 +4,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'mysql'))
 Puppet::Type.type(:mysql_plugin).provide(:mysql, parent: Puppet::Provider::Mysql) do
   desc 'Manages MySQL plugins.'
 
-  commands mysql_raw: 'mysql'
+  commands mysql_raw: pick_correct_binary('mysql', 'mariadb')
 
   def self.instances
     mysql_caller('show plugins', 'regular').split("\n").map do |line|

--- a/lib/puppet/provider/mysql_user/mysql.rb
+++ b/lib/puppet/provider/mysql_user/mysql.rb
@@ -3,7 +3,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'mysql'))
 Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) do
   desc 'manage users for a mysql database.'
-  commands mysql_raw: 'mysql'
+  commands mysql_raw: pick_correct_binary('mysql', 'mariadb')
 
   # Build a property_hash containing all the discovered information about MySQL
   # users.


### PR DESCRIPTION
added helper method in mysql provider to pick mysql or mariadb binary variant based on version

changed commands to use the new helper method

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.
puppetlabs/puppetlabs-mysql#1685
puppetlabs/puppetlabs-mysql#1676
puppetlabs/puppetlabs-mysql#1672

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)