### PR TITLE
logdir changed ensure 'directory' to 'present' for log dir

### DIFF
--- a/manifests/server/installdb.pp
+++ b/manifests/server/installdb.pp
@@ -32,7 +32,7 @@ class mysql::server::installdb {
     }
 
     file { $log_dir:
-      ensure => 'directory',
+      ensure => 'present',
       owner  => $mysqluser,
       group  => $mysql::server::mysql_group,
     }


### PR DESCRIPTION
this allows log dir path to be default while having the actual data somewhere else using symlinks

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
puppetlabs/puppetlabs-mysql#1662

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)