### PR TITLE
Use params::provider instead of "mysql" to import sql

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -124,7 +124,7 @@ define mysql::db (
 
     if $sql {
       exec { "${dbname}-import":
-        command     => "${import_cat_cmd} ${shell_join($sql)} | mysql ${dbname}",
+        command     => "${import_cat_cmd} ${shell_join($sql)} | ${mysql::params::provider} ${dbname}",
         logoutput   => true,
         environment => "HOME=${facts['root_home']}",
         refreshonly => ! $enforce_sql,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -129,6 +129,7 @@ class mysql::params {
           fail("Unsupported platform: puppetlabs-${module_name} currently doesn\'t support ${facts['os']['name']}.")
         }
       }
+      $provider            = 'mariadb'
       $config_file         = '/etc/my.cnf'
       $includedir          = '/etc/my.cnf.d'
       $datadir             = '/var/lib/mysql'
@@ -227,6 +228,7 @@ class mysql::params {
     }
 
     'Archlinux': {
+      $provider                = 'mariadb'
       $daemon_dev_package_name = undef
       $client_dev_package_name = undef
       $includedir              = undef
@@ -255,6 +257,7 @@ class mysql::params {
     }
 
     'Gentoo': {
+      $provider            = 'mysql'
       $client_package_name = 'virtual/mysql'
       $includedir          = undef
       $server_package_name = 'virtual/mysql'
@@ -281,6 +284,7 @@ class mysql::params {
     }
 
     'FreeBSD': {
+      $provider            = 'mysql'
       $client_package_name = 'databases/mysql57-client'
       $server_package_name = 'databases/mysql57-server'
       $basedir             = '/usr/local'
@@ -310,6 +314,7 @@ class mysql::params {
     }
 
     'OpenBSD': {
+      $provider            = 'mariadb'
       $client_package_name = 'mariadb-client'
       $server_package_name = 'mariadb-server'
       $basedir             = '/usr/local'
@@ -341,6 +346,7 @@ class mysql::params {
     default: {
       case $facts['os']['name'] {
         'Alpine': {
+          $provider            = 'mariadb'
           $client_package_name = 'mariadb-client'
           $server_package_name = 'mariadb'
           $basedir             = '/usr'
@@ -366,6 +372,7 @@ class mysql::params {
           $daemon_dev_package_name     = undef
         }
         'Amazon': {
+          $provider            = 'mysql'
           $client_package_name = 'mysql'
           $server_package_name = 'mysql-server'
           $basedir             = '/usr'

--- a/spec/defines/mysql_db_spec.rb
+++ b/spec/defines/mysql_db_spec.rb
@@ -5,6 +5,21 @@ require 'spec_helper'
 describe 'mysql::db', type: :define do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
+      provider = if facts[:os]['family'] == 'RedHat'
+                   'mariadb'
+                 elsif facts[:os]['family'] == 'Suse'
+                   'mariadb'
+                 elsif facts[:os]['name'] == 'Debian'
+                   'mariadb'
+                 elsif facts[:os]['name'] == 'Ubuntu'
+                   if Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '20') < 0 &&
+                      Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '16') >= 0
+                     'mysql'
+                   else
+                     'mariadb'
+                   end
+                 end
+
       let(:facts) do
         facts.merge(root_home: '/root')
       end
@@ -39,7 +54,7 @@ describe 'mysql::db', type: :define do
         # ' if enforcing #refreshonly'
         expect(subject).to contain_exec('test_db-import').with_refreshonly(false)
         # 'if enforcing #command'
-        expect(subject).to contain_exec('test_db-import').with_command('cat /tmp/test.sql | mysql test_db')
+        expect(subject).to contain_exec('test_db-import').with_command("cat /tmp/test.sql | #{provider} test_db")
       end
 
       it 'imports sql script with custom command on creation' do
@@ -47,12 +62,12 @@ describe 'mysql::db', type: :define do
         # if enforcing #refreshonly
         expect(subject).to contain_exec('test_db-import').with_refreshonly(false)
         # if enforcing #command
-        expect(subject).to contain_exec('test_db-import').with_command('zcat /tmp/test.sql | mysql test_db')
+        expect(subject).to contain_exec('test_db-import').with_command("zcat /tmp/test.sql | #{provider} test_db")
       end
 
       it 'imports sql scripts when more than one is specified' do
         params['sql'] = ['/tmp/test.sql', '/tmp/test_2.sql']
-        expect(subject).to contain_exec('test_db-import').with_command('cat /tmp/test.sql /tmp/test_2.sql | mysql test_db')
+        expect(subject).to contain_exec('test_db-import').with_command("cat /tmp/test.sql /tmp/test_2.sql | #{provider} test_db")
       end
 
       it 'does not create database' do
@@ -111,7 +126,7 @@ describe 'mysql::db', type: :define do
       ].each do |path|
         it "succeeds when provided '#{path}' as a value to the 'sql' parameter" do
           params['sql'] = [path]
-          expect(subject).to contain_exec('test_db-import').with_command("cat #{path} | mysql test_db")
+          expect(subject).to contain_exec('test_db-import').with_command("cat #{path} | #{provider} test_db")
         end
       end
 


### PR DESCRIPTION
## Summary

Use `$mysql::params::provider` instead of `mysql` to import a database in `mysql::db`.

As this parameter is already configured for some OS, I decided to define this variable for every OS, and use it.

## Additional Context
See #1693

## Related Issues (if any)
#1693

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)