### PR TITLE
Add purge and recurse options to the include directory creation when …

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -86,8 +86,10 @@ class mysql::server::config {
       if $includedir == undef or $includedir == '' or
       ($configparentdir != $includedir and $configparentdir != dirname($includedir)) {
         file { $configparentdir:
-          ensure => directory,
-          mode   => '0755',
+          ensure  => directory,
+          mode    => '0755',
+          recurse => $mysql::server::purge_conf_dir,
+          purge   => $mysql::server::purge_conf_dir,
         }
       }
     }

--- a/spec/classes/mycnf_template_spec.rb
+++ b/spec/classes/mycnf_template_spec.rb
@@ -77,11 +77,27 @@ describe 'mysql::server' do
       end
 
       context 'with includedir' do
-        let(:params) { { includedir: '/etc/my.cnf.d' } }
+        let(:params) {{ includedir: '/etc/my.cnf.d' } }
 
-        it 'makes the directory' do
-          expect(subject).to contain_file('/etc/my.cnf.d').with(ensure: :directory,
-                                                                mode: '0755')
+        context 'when purge_conf_dir is false' do
+          let(:params) { super().merge({'purge_conf_dir' =>  false })}
+
+          it 'makes the directory without recursion' do
+            expect(subject).to contain_file('/etc/my.cnf.d').with(ensure: :directory,
+                                                                  mode: '0755',
+                                                                  recurse: false,
+                                                                  purge: false)
+          end
+        end
+
+        context 'when purge_conf_dir is true' do
+          let(:params) { super().merge({'purge_conf_dir' =>  true })}
+
+          it 'makes the directory with purge and recursion' do
+            expect(subject).to contain_file('/etc/my.cnf.d').with(ensure: :directory,
+                                                                  recurse: true,
+                                                                  purge: true )
+          end
         end
 
         it { is_expected.to contain_file('mysql-config-file').with_content(%r{!includedir}) }

--- a/spec/classes/mycnf_template_spec.rb
+++ b/spec/classes/mycnf_template_spec.rb
@@ -79,9 +79,25 @@ describe 'mysql::server' do
       context 'with includedir' do
         let(:params) { { includedir: '/etc/my.cnf.d' } }
 
-        it 'makes the directory' do
-          expect(subject).to contain_file('/etc/my.cnf.d').with(ensure: :directory,
-                                                                mode: '0755')
+        context 'when purge_conf_dir is false' do
+          let(:params) { super().merge({ 'purge_conf_dir' => false }) }
+
+          it 'makes the directory without recursion' do
+            expect(subject).to contain_file('/etc/my.cnf.d').with(ensure: :directory,
+                                                                  mode: '0755',
+                                                                  recurse: false,
+                                                                  purge: false)
+          end
+        end
+
+        context 'when purge_conf_dir is true' do
+          let(:params) { super().merge({ 'purge_conf_dir' => true }) }
+
+          it 'makes the directory with purge and recursion' do
+            expect(subject).to contain_file('/etc/my.cnf.d').with(ensure: :directory,
+                                                                  recurse: true,
+                                                                  purge: true)
+          end
         end
 
         it { is_expected.to contain_file('mysql-config-file').with_content(%r{!includedir}) }


### PR DESCRIPTION
…MariaDB package.

## Summary
On MariaDB package, the purge/recurse options weren't set for the include_dir directory.
