### PR TITLE
Fix version comparison for RedHat 10+

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -476,7 +476,7 @@ class mysql::params {
   }
 
   ## Additional graceful failures
-  if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] < '7' and $facts['os']['name'] != 'Amazon' {
+  if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '7') < 0 and $facts['os']['name'] != 'Amazon' {
     fail("Unsupported platform: puppetlabs-${module_name} only supports RedHat 7.0 and beyond.")
   }
 }


### PR DESCRIPTION
## Summary

The version check for RedHat is wrong, using `<` instead of `versioncmp`.
This causes RedHat 10 to be considered below RedHat 7.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X] Manually verified. (For example `puppet apply`)