### PR TITLE
Use deferrable_epp for .my.cnf to ensure root password resolve correctly

### DIFF
--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -37,16 +37,16 @@ class mysql::server::root_password {
     }
   }
 
-  $parameters = {
-    'root_password_set' => $root_password_set,
-    'root_password' => $root_password,
-    'options' => $options,
-  }
-
   if $mysql::server::create_root_my_cnf and $root_password_set {
-    # TODO: use EPP instead of ERB, as EPP can handle Data of Type Sensitive without further ado
     file { "${facts['root_home']}/.my.cnf":
-      content => epp('mysql/my.cnf.pass.epp',$parameters),
+      content => Sensitive(stdlib::deferrable_epp(
+          'mysql/my.cnf.pass.epp',
+          {
+            'root_password_set' => $root_password_set,
+            'root_password'     => $root_password,
+            'options'           => $options,
+          }
+      )),
       owner   => 'root',
       mode    => '0600',
     }


### PR DESCRIPTION
## Summary
When the root password is type deferred, we have to defer the template rendering(.my.cnf) using the stdlib::deferrable_epp() function.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)