### PR TITLE
Almalinux-support for V 9 and 10

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -476,7 +476,7 @@ class mysql::params {
   }
 
   ## Additional graceful failures
-  if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] < '7' and $facts['os']['name'] != 'Amazon' {
+  if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '7') < 0 and $facts['os']['name'] != 'Amazon' {
     fail("Unsupported platform: puppetlabs-${module_name} only supports RedHat 7.0 and beyond.")
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -73,7 +73,9 @@
     {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9",
+        "10"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
ups compatibility for AlmaLinux in metadata,json for 9 and 10

## Additional Context
Based on PR 

## Related Issues (if any)
Mention any related issues or pull requests.

Includes PR #1696 by Geramotte, which I can confirm as correct

Would probably work for RedHat as well, but I have no way to test that, so I left it unchanged.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (deployed to VM of Alma 10.1)