### PR TITLE
fix: install mysql 8.4 without error

### DIFF
--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -86,8 +86,16 @@ class Puppet::Provider::Mysql < Puppet::Provider
   def self.mysqld_version_string
     # As the possibility of the mysqld being remote we need to allow the version string to be overridden,
     # this can be done by facter.value as seen below. In the case that it has not been set and the facter
-    # value is nil we use an empty string so that default client/service are used.
-    @mysqld_version_string ||= Facter.value(:mysqld_version) || ''
+    # value is nil we use the mariadbd or mysql command to ensure we report the correct version of engine
+    # for later use cases.
+    @mysqld_version_string ||= Facter.value(:mysqld_version) || version_raw
+  end
+
+  def self.version_raw
+    # get either version of mariadb or mysql
+    `mariadbd -V`
+  rescue
+    `mysqld -V`
   end
 
   def mysqld_version_string


### PR DESCRIPTION
mysqld_version_string use to report an empty version if not found in Facter. That causes installation failures for MySQL.

A new method gets the version of either MariaDB or MySQL, the first wins.

Nota: backticks (`) throws an Errno::ENOENT exception if the command is not found.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)