### PR TITLE
(CAT-2665) Roll out safe fork CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,33 @@ on:
   pull_request:
     branches:
       - "main"
+  pull_request_target:
+    types: [labeled, reopened]
+    branches:
+      - "main"
   workflow_dispatch:
-    
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Spec:
+    if: github.event_name != 'pull_request_target'
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
     secrets: "inherit"
 
   Acceptance:
-    needs: Spec
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.fork == false) ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.pull_request.head.repo.fork == true &&
+       contains(github.event.pull_request.labels.*.name, 'allowed-for-ci'))
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
       flags: "--nightly --platform-exclude centos-7 --platform-exclude scientific-7 --platform-exclude oraclelinux-7 --platform-exclude almalinux-8 --arch-exclude arm"

--- a/.github/workflows/fork_ci_label_guard.yml
+++ b/.github/workflows/fork_ci_label_guard.yml
@@ -1,0 +1,12 @@
+name: "Fork CI Label Guard"
+
+on:
+  pull_request_target:
+    types: [synchronize, closed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  strip:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/fork_ci_label_guard.yml@main"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,12 @@
 ---
 inherit_from: .rubocop_todo.yml
-
-require:
+plugins:
 - rubocop-performance
+- rubocop-hash_inspect
 - rubocop-rspec
+- rubocop-rspec_rails
+- rubocop-factory_bot
+- rubocop-capybara
 AllCops:
   NewCops: enable
   DisplayCopNames: true
@@ -108,6 +111,8 @@ Performance/StringInclude:
   Enabled: true
 Performance/Sum:
   Enabled: true
+Security/IoMethods:
+  Enabled: true
 Style/CollectionMethods:
   Enabled: true
 Style/MethodCalledOnDoEndBlock:
@@ -121,6 +126,12 @@ Bundler/InsecureProtocolSource:
 Capybara/CurrentPathExpectation:
   Enabled: false
 Capybara/VisibilityMatcher:
+  Enabled: false
+FactoryBot/AttributeDefinedStatically:
+  Enabled: false
+FactoryBot/CreateList:
+  Enabled: false
+FactoryBot/FactoryClassName:
   Enabled: false
 Gemspec/DuplicatedAssignment:
   Enabled: false
@@ -296,8 +307,6 @@ Performance/UriDefaultParser:
   Enabled: false
 RSpec/Be:
   Enabled: false
-RSpec/Capybara/FeatureMethods:
-  Enabled: false
 RSpec/ContainExactly:
   Enabled: false
 RSpec/ContextMethod:
@@ -305,6 +314,8 @@ RSpec/ContextMethod:
 RSpec/ContextWording:
   Enabled: false
 RSpec/DescribeClass:
+  Enabled: false
+RSpec/Dialect:
   Enabled: false
 RSpec/EmptyHook:
   Enabled: false
@@ -321,12 +332,6 @@ RSpec/ExampleWithoutDescription:
 RSpec/ExpectChange:
   Enabled: false
 RSpec/ExpectInHook:
-  Enabled: false
-RSpec/FactoryBot/AttributeDefinedStatically:
-  Enabled: false
-RSpec/FactoryBot/CreateList:
-  Enabled: false
-RSpec/FactoryBot/FactoryClassName:
   Enabled: false
 RSpec/HooksBeforeExamples:
   Enabled: false
@@ -375,8 +380,6 @@ RSpec/VariableDefinition:
 RSpec/VoidExpect:
   Enabled: false
 RSpec/Yield:
-  Enabled: false
-Security/Open:
   Enabled: false
 Style/AccessModifierDeclarations:
   Enabled: false
@@ -502,6 +505,12 @@ Capybara/SpecificFinders:
   Enabled: false
 Capybara/SpecificMatcher:
   Enabled: false
+FactoryBot/ConsistentParenthesesStyle:
+  Enabled: false
+FactoryBot/FactoryNameStyle:
+  Enabled: false
+FactoryBot/SyntaxMethods:
+  Enabled: false
 Gemspec/DeprecatedAttributeAssignment:
   Enabled: false
 Gemspec/DevelopmentDependencies:
@@ -602,27 +611,11 @@ RSpec/DuplicatedMetadata:
   Enabled: false
 RSpec/ExcessiveDocstringSpacing:
   Enabled: false
-RSpec/FactoryBot/ConsistentParenthesesStyle:
-  Enabled: false
-RSpec/FactoryBot/FactoryNameStyle:
-  Enabled: false
-RSpec/FactoryBot/SyntaxMethods:
-  Enabled: false
 RSpec/IdenticalEqualityAssertion:
   Enabled: false
 RSpec/NoExpectationExample:
   Enabled: false
 RSpec/PendingWithoutReason:
-  Enabled: false
-RSpec/Rails/AvoidSetupHook:
-  Enabled: false
-RSpec/Rails/HaveHttpStatus:
-  Enabled: false
-RSpec/Rails/InferredSpecType:
-  Enabled: false
-RSpec/Rails/MinitestAssertions:
-  Enabled: false
-RSpec/Rails/TravelAround:
   Enabled: false
 RSpec/RedundantAround:
   Enabled: false
@@ -634,9 +627,17 @@ RSpec/SubjectDeclaration:
   Enabled: false
 RSpec/VerifiedDoubleReference:
   Enabled: false
-Security/CompoundHash:
+RSpecRails/AvoidSetupHook:
   Enabled: false
-Security/IoMethods:
+RSpecRails/HaveHttpStatus:
+  Enabled: false
+RSpecRails/InferredSpecType:
+  Enabled: false
+RSpecRails/MinitestAssertions:
+  Enabled: false
+RSpecRails/TravelAround:
+  Enabled: false
+Security/CompoundHash:
   Enabled: false
 Style/ArgumentsForwarding:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ end
 group :development do
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.18.0',                        require: false if Gem::Requirement.create(['>= 4.0.0', '< 5.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "deep_merge", '~> 1.2.2',                  require: false
   gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
@@ -52,29 +53,35 @@ group :development do
   gem "pry", '~> 0.10',                          require: false
   gem "simplecov-console", '~> 0.9',             require: false
   gem "puppet-debugger", '~> 1.6',               require: false
-  gem "rubocop", '~> 1.50.0',                    require: false
-  gem "rubocop-performance", '= 1.16.0',         require: false
-  gem "rubocop-rspec", '= 2.19.0',               require: false
-  gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "bigdecimal", '< 3.2.2',                   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "rubocop", '~> 1.73.0',                    require: false
+  gem "rubocop-performance", '~> 1.24.0',        require: false
+  gem "rubocop-hash_inspect", '~> 0.2',          require: false
+  gem "rubocop-rspec", '~> 3.5.0',               require: false
+  gem "rubocop-rspec_rails", '~> 2.31.0',        require: false
+  gem "rubocop-factory_bot", '~> 2.27.0',        require: false
+  gem "rubocop-capybara", '~> 2.22.0',           require: false
+  gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:windows]
+  gem "bigdecimal", '< 3.2.2',                   require: false, platforms: [:windows]
 end
 group :development, :release_prep do
-  gem "puppet-strings", '~> 4.0',         require: false
-  gem "puppetlabs_spec_helper", '~> 8.0', require: false
-  gem "puppet-blacksmith", '~> 7.0',      require: false
+  gem "puppet-strings", '~> 4.0',              require: false
+  gem "puppetlabs_spec_helper", '~> 8.0',      require: false
+  gem "puppet-blacksmith", '>= 7.0', '< 10.0', require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 2.0',   require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw] if ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet_litmus", '~> 2.5',   require: false
+  gem "faraday", '~> 2.5',         require: false
+  gem "CFPropertyList", '< 3.0.7', require: false if RUBY_PLATFORM.include?('darwin')
   gem "serverspec", '~> 2.41',     require: false
 end
 
 gems = {}
+bolt_version = ENV.fetch('BOLT_GEM_VERSION', nil)
 puppet_version = ENV.fetch('PUPPET_GEM_VERSION', nil)
 facter_version = ENV.fetch('FACTER_GEM_VERSION', nil)
 hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 
+gems['bolt'] = location_for(bolt_version, nil, { source: gemsource_puppetcore })
 gems['puppet'] = location_for(puppet_version, nil, { source: gemsource_puppetcore })
 gems['facter'] = location_for(facter_version, nil, { source: gemsource_puppetcore })
 gems['hiera'] = location_for(hiera_version, nil, {}) if hiera_version

--- a/lib/puppet/functions/mysql/strip_hash.rb
+++ b/lib/puppet/functions/mysql/strip_hash.rb
@@ -17,7 +17,7 @@ Puppet::Functions.create_function(:'mysql::strip_hash') do
 
   def strip_hash(hash)
     # Filter out all the top level blanks.
-    hash.reject { |_k, v| v == '' }.each do |_k, v|
+    hash.reject { |_k, v| v == '' }.each_value do |v|
       v.reject! { |_ki, vi| vi == '' } if v.is_a?(Hash)
     end
   end

--- a/lib/puppet/provider/mysql_login_path/sensitive.rb
+++ b/lib/puppet/provider/mysql_login_path/sensitive.rb
@@ -4,7 +4,7 @@
 #
 class Puppet::Provider::MysqlLoginPath::Sensitive < Puppet::Pops::Types::PSensitiveType::Sensitive
   def ==(other)
-    return true if other.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive) && unwrap == other.unwrap
+    true if other.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive) && unwrap == other.unwrap
   end
 
   def encode_with(coder)

--- a/metadata.json
+++ b/metadata.json
@@ -85,6 +85,6 @@
   ],
   "description": "MySQL module",
   "template-url": "https://github.com/puppetlabs/pdk-templates#main",
-  "template-ref": "heads/main-0-g19976cd",
-  "pdk-version": "3.5.0"
+  "template-ref": "heads/main-0-gc391e21",
+  "pdk-version": "3.7.0"
 }

--- a/spec/acceptance/02_mysql_mariadb_spec.rb
+++ b/spec/acceptance/02_mysql_mariadb_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper_acceptance'
 
-describe 'mysql server class', if: ((os[:family] == 'debian') || (os[:family] == 'redhat' && os[:release].to_i > 6)) do
+describe 'mysql server class', if: (os[:family] == 'debian') || (os[:family] == 'redhat' && os[:release].to_i > 6) do
   describe 'mariadb' do
     let(:pp) do
       <<-MANIFEST

--- a/spec/acceptance/types/mysql_user_spec.rb
+++ b/spec/acceptance/types/mysql_user_spec.rb
@@ -46,8 +46,8 @@ describe 'mysql_user' do
       end
     end
 
-    describe 'changing authentication plugin', if: (Gem::Version.new(mysql_version) > Gem::Version.new('5.5.0') && os[:release] !~ %r{^16\.04}) do
-      it 'works without errors', if: (os[:family] != 'sles' && os[:release].to_i == 15) do
+    describe 'changing authentication plugin', if: Gem::Version.new(mysql_version) > Gem::Version.new('5.5.0') && os[:release] !~ %r{^16\.04} do
+      it 'works without errors', if: os[:family] != 'sles' && os[:release].to_i == 15 do
         pp = <<-MANIFEST
           mysql_user { 'ashp@localhost':
             plugin => 'auth_socket',
@@ -57,14 +57,14 @@ describe 'mysql_user' do
         idempotent_apply(pp)
       end
 
-      it 'has the correct plugin', if: (os[:family] != 'sles' && os[:release].to_i == 15) do
+      it 'has the correct plugin', if: os[:family] != 'sles' && os[:release].to_i == 15 do
         run_shell("#{mysql_cmd} -NBe \"select plugin from mysql.user where CONCAT(user, '@', host) = 'ashp@localhost'\"") do |r|
           expect(r.stdout.rstrip).to eq('auth_socket')
           expect(r.stderr).to be_empty
         end
       end
 
-      it 'does not have a password', if: (os[:family] != 'sles' && os[:release].to_i == 15) do
+      it 'does not have a password', if: os[:family] != 'sles' && os[:release].to_i == 15 do
         table = if Gem::Version.new(mysql_version) > Gem::Version.new('5.7.0')
                   'authentication_string'
                 else

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ default_fact_files.each do |f|
 
   begin
     require 'deep_merge'
-    default_facts.deep_merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
+    default_facts.deep_merge!(YAML.safe_load_file(f, permitted_classes: [], permitted_symbols: [], aliases: true))
   rescue StandardError => e
     RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
   end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -72,7 +72,7 @@ end
 
 RSpec.configure do |c|
   c.before :suite do
-    if os[:family] == 'debian' || os[:family] == 'ubuntu'
+    if ['debian', 'ubuntu'].include?(os[:family])
       # needed for the puppet fact
       LitmusHelper.instance.apply_manifest("package { 'lsb-release': ensure => installed, }", expect_failures: false)
       LitmusHelper.instance.apply_manifest("package { 'ap': ensure => installed, }", expect_failures: false)

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -171,7 +171,7 @@ describe Puppet::Type.type(:mysql_user).provider(:mysql) do
   end
 
   describe 'mysql version and type detection' do
-    mysql_version_string_hash.each do |_name, line|
+    mysql_version_string_hash.each_value do |line|
       version = line[:version]
       string = line[:string]
       mysql_type = line[:mysql_type]


### PR DESCRIPTION
## Summary

- Add `pull_request_target` trigger (`labeled`, `reopened`) with fork CI guard on `Acceptance`
- `Spec` skips on `pull_request_target`; `Acceptance` skips for fork `pull_request` events, requires `allowed-for-ci` label via `pull_request_target`
- Remove `needs: Spec` from `Acceptance`; add `permissions` and `concurrency` blocks
- Add `fork_ci_label_guard.yml` (via pdk update)
- pdk update to 3.7.0: `.rubocop.yml` namespace updates, `Gemfile`, `spec/spec_helper.rb`
- Restore `inherit_from: .rubocop_todo.yml` dropped by pdk template update
- Fix autocorrectable rubocop offenses: `Style/HashEachMethods`, `Style/RedundantReturn`, `Style/RedundantParentheses`

## Test plan

- [x] Spec and Acceptance pass on this PR
- [ ] Fork test PR: `Acceptance` skips on open, gate activates after `allowed-for-ci` label + `puppetcore-fork` approval
- [ ] New push to fork PR strips label

🤖 Generated with [Claude Code](https://claude.com/claude-code)