### PR TITLE
Fix backup optional_args.

### DIFF
--- a/templates/mysqlbackup.sh.epp
+++ b/templates/mysqlbackup.sh.epp
@@ -56,7 +56,7 @@ ADDITIONAL_OPTIONS="$ADDITIONAL_OPTIONS --skip-routines"
 <% } -%>
 <% } -%>
 
-<%- if $optional_args and type($optional_args) =~ Type(Array) { -%>
+<%- if $optional_args and type($optional_args) =~ Type[Array] { -%>
 <% $optional_args.each |$arg| { -%>
 ADDITIONAL_OPTIONS="$ADDITIONAL_OPTIONS <%= $arg %>"
 <%- } -%>


### PR DESCRIPTION
See: https://github.com/puppetlabs/puppetlabs-mysql/pull/1665

## Summary
Fixes mysqlbackup optional args so that it actually interprets and implements the optional args. Current version does not.