### PR TITLE
*Breaking* Remove SSL settings from default_options

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -91,9 +91,6 @@ class mysql::params {
       $root_group              = 'root'
       $mysql_group             = 'mysql'
       $socket                  = '/var/lib/mysql/mysql.sock'
-      $ssl_ca                  = '/etc/mysql/cacert.pem'
-      $ssl_cert                = '/etc/mysql/server-cert.pem'
-      $ssl_key                 = '/etc/mysql/server-key.pem'
       $tmpdir                  = '/tmp'
       $managed_dirs            = undef
       # mysql::bindings
@@ -138,9 +135,6 @@ class mysql::params {
       $server_service_name = 'mysql'
       $xtrabackup_package_name = 'xtrabackup'
 
-      $ssl_ca              = '/etc/mysql/cacert.pem'
-      $ssl_cert            = '/etc/mysql/server-cert.pem'
-      $ssl_key             = '/etc/mysql/server-key.pem'
       $tmpdir              = '/tmp'
       $managed_dirs        = undef
       # mysql::bindings
@@ -182,9 +176,6 @@ class mysql::params {
       $root_group              = 'root'
       $mysql_group             = 'adm'
       $socket                  = '/var/run/mysqld/mysqld.sock'
-      $ssl_ca                  = '/etc/mysql/cacert.pem'
-      $ssl_cert                = '/etc/mysql/server-cert.pem'
-      $ssl_key                 = '/etc/mysql/server-key.pem'
       $tmpdir                  = '/tmp'
       $managed_dirs            = ['tmpdir','basedir','datadir','innodb_data_home_dir','innodb_log_group_home_dir','innodb_undo_directory','innodb_tmpdir']
 
@@ -243,9 +234,6 @@ class mysql::params {
       $mysql_group             = 'mysql'
       $server_service_name     = 'mysqld'
       $socket                  = '/var/lib/mysql/mysql.sock'
-      $ssl_ca                  = '/etc/mysql/cacert.pem'
-      $ssl_cert                = '/etc/mysql/server-cert.pem'
-      $ssl_key                 = '/etc/mysql/server-key.pem'
       $tmpdir                  = '/tmp'
       $managed_dirs            = undef
       # mysql::bindings
@@ -270,9 +258,6 @@ class mysql::params {
       $mysql_group         = 'mysql'
       $server_service_name = 'mysql'
       $socket              = '/run/mysqld/mysqld.sock'
-      $ssl_ca              = '/etc/mysql/cacert.pem'
-      $ssl_cert            = '/etc/mysql/server-cert.pem'
-      $ssl_key             = '/etc/mysql/server-key.pem'
       $tmpdir              = '/tmp'
       $managed_dirs        = undef
       # mysql::bindings
@@ -297,9 +282,6 @@ class mysql::params {
       $mysql_group         = 'mysql'
       $server_service_name = 'mysql-server'
       $socket              = '/var/db/mysql/mysql.sock'
-      $ssl_ca              = undef
-      $ssl_cert            = undef
-      $ssl_key             = undef
       $tmpdir              = '/tmp'
       $managed_dirs        = undef
       # mysql::bindings
@@ -327,9 +309,6 @@ class mysql::params {
       $mysql_group         = '_mysql'
       $server_service_name = 'mysqld'
       $socket              = '/var/run/mysql/mysql.sock'
-      $ssl_ca              = undef
-      $ssl_cert            = undef
-      $ssl_key             = undef
       $tmpdir              = '/tmp'
       $managed_dirs        = undef
       # mysql::bindings
@@ -358,9 +337,6 @@ class mysql::params {
           $mysql_group         = 'mysql'
           $server_service_name = 'mariadb'
           $socket              = '/run/mysqld/mysqld.sock'
-          $ssl_ca              = '/etc/mysql/cacert.pem'
-          $ssl_cert            = '/etc/mysql/server-cert.pem'
-          $ssl_key             = '/etc/mysql/server-key.pem'
           $tmpdir              = '/tmp'
           $managed_dirs        = undef
           $java_package_name   = undef
@@ -385,9 +361,6 @@ class mysql::params {
           $mysql_group         = 'mysql'
           $server_service_name = 'mysqld'
           $socket              = '/var/lib/mysql/mysql.sock'
-          $ssl_ca              = '/etc/mysql/cacert.pem'
-          $ssl_cert            = '/etc/mysql/server-cert.pem'
-          $ssl_key             = '/etc/mysql/server-key.pem'
           $tmpdir              = '/tmp'
           $managed_dirs        = undef
           # mysql::bindings
@@ -458,11 +431,6 @@ class mysql::params {
       'port'                  => '3306',
       'skip-external-locking' => true,
       'socket'                => $mysql::params::socket,
-      'ssl'                   => false,
-      'ssl-ca'                => $mysql::params::ssl_ca,
-      'ssl-cert'              => $mysql::params::ssl_cert,
-      'ssl-key'               => $mysql::params::ssl_key,
-      'ssl-disable'           => false,
       'thread_cache_size'     => '8',
       'thread_stack'          => '256K',
       'tmpdir'                => $mysql::params::tmpdir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -91,9 +91,6 @@ class mysql::params {
       $root_group              = 'root'
       $mysql_group             = 'mysql'
       $socket                  = '/var/lib/mysql/mysql.sock'
-      $ssl_ca                  = '/etc/mysql/cacert.pem'
-      $ssl_cert                = '/etc/mysql/server-cert.pem'
-      $ssl_key                 = '/etc/mysql/server-key.pem'
       $tmpdir                  = '/tmp'
       $managed_dirs            = undef
       # mysql::bindings
@@ -106,6 +103,7 @@ class mysql::params {
     'Suse': {
       case $facts['os']['name'] {
         'OpenSuSE': {
+          $provider = 'mariadb'
           $socket = '/var/run/mysql/mysql.sock'
           $log_error = '/var/log/mysql/mysqld.log'
           $pidfile = '/var/run/mysql/mysqld.pid'
@@ -117,6 +115,7 @@ class mysql::params {
           $basedir             = undef
         }
         'SLES','SLED': {
+          $provider = 'mariadb'
           $socket = '/run/mysql/mysql.sock'
           $log_error = '/var/log/mysqld.log'
           $pidfile = '/var/lib/mysql/mysqld.pid'
@@ -137,9 +136,6 @@ class mysql::params {
       $server_service_name = 'mysql'
       $xtrabackup_package_name = 'xtrabackup'
 
-      $ssl_ca              = '/etc/mysql/cacert.pem'
-      $ssl_cert            = '/etc/mysql/server-cert.pem'
-      $ssl_key             = '/etc/mysql/server-key.pem'
       $tmpdir              = '/tmp'
       $managed_dirs        = undef
       # mysql::bindings
@@ -181,9 +177,6 @@ class mysql::params {
       $root_group              = 'root'
       $mysql_group             = 'adm'
       $socket                  = '/var/run/mysqld/mysqld.sock'
-      $ssl_ca                  = '/etc/mysql/cacert.pem'
-      $ssl_cert                = '/etc/mysql/server-cert.pem'
-      $ssl_key                 = '/etc/mysql/server-key.pem'
       $tmpdir                  = '/tmp'
       $managed_dirs            = ['tmpdir','basedir','datadir','innodb_data_home_dir','innodb_log_group_home_dir','innodb_undo_directory','innodb_tmpdir']
 
@@ -227,6 +220,7 @@ class mysql::params {
     }
 
     'Archlinux': {
+      $provider                = 'mariadb'
       $daemon_dev_package_name = undef
       $client_dev_package_name = undef
       $includedir              = undef
@@ -241,9 +235,6 @@ class mysql::params {
       $mysql_group             = 'mysql'
       $server_service_name     = 'mysqld'
       $socket                  = '/var/lib/mysql/mysql.sock'
-      $ssl_ca                  = '/etc/mysql/cacert.pem'
-      $ssl_cert                = '/etc/mysql/server-cert.pem'
-      $ssl_key                 = '/etc/mysql/server-key.pem'
       $tmpdir                  = '/tmp'
       $managed_dirs            = undef
       # mysql::bindings
@@ -255,6 +246,7 @@ class mysql::params {
     }
 
     'Gentoo': {
+      $provider            = 'mysql'
       $client_package_name = 'virtual/mysql'
       $includedir          = undef
       $server_package_name = 'virtual/mysql'
@@ -267,9 +259,6 @@ class mysql::params {
       $mysql_group         = 'mysql'
       $server_service_name = 'mysql'
       $socket              = '/run/mysqld/mysqld.sock'
-      $ssl_ca              = '/etc/mysql/cacert.pem'
-      $ssl_cert            = '/etc/mysql/server-cert.pem'
-      $ssl_key             = '/etc/mysql/server-key.pem'
       $tmpdir              = '/tmp'
       $managed_dirs        = undef
       # mysql::bindings
@@ -281,6 +270,7 @@ class mysql::params {
     }
 
     'FreeBSD': {
+      $provider            = 'mysql'
       $client_package_name = 'databases/mysql57-client'
       $server_package_name = 'databases/mysql57-server'
       $basedir             = '/usr/local'
@@ -293,9 +283,6 @@ class mysql::params {
       $mysql_group         = 'mysql'
       $server_service_name = 'mysql-server'
       $socket              = '/var/db/mysql/mysql.sock'
-      $ssl_ca              = undef
-      $ssl_cert            = undef
-      $ssl_key             = undef
       $tmpdir              = '/tmp'
       $managed_dirs        = undef
       # mysql::bindings
@@ -310,6 +297,7 @@ class mysql::params {
     }
 
     'OpenBSD': {
+      $provider            = 'mariadb'
       $client_package_name = 'mariadb-client'
       $server_package_name = 'mariadb-server'
       $basedir             = '/usr/local'
@@ -322,9 +310,6 @@ class mysql::params {
       $mysql_group         = '_mysql'
       $server_service_name = 'mysqld'
       $socket              = '/var/run/mysql/mysql.sock'
-      $ssl_ca              = undef
-      $ssl_cert            = undef
-      $ssl_key             = undef
       $tmpdir              = '/tmp'
       $managed_dirs        = undef
       # mysql::bindings
@@ -341,6 +326,7 @@ class mysql::params {
     default: {
       case $facts['os']['name'] {
         'Alpine': {
+          $provider            = 'mariadb'
           $client_package_name = 'mariadb-client'
           $server_package_name = 'mariadb'
           $basedir             = '/usr'
@@ -352,9 +338,6 @@ class mysql::params {
           $mysql_group         = 'mysql'
           $server_service_name = 'mariadb'
           $socket              = '/run/mysqld/mysqld.sock'
-          $ssl_ca              = '/etc/mysql/cacert.pem'
-          $ssl_cert            = '/etc/mysql/server-cert.pem'
-          $ssl_key             = '/etc/mysql/server-key.pem'
           $tmpdir              = '/tmp'
           $managed_dirs        = undef
           $java_package_name   = undef
@@ -366,6 +349,7 @@ class mysql::params {
           $daemon_dev_package_name     = undef
         }
         'Amazon': {
+          $provider            = 'mysql'
           $client_package_name = 'mysql'
           $server_package_name = 'mysql-server'
           $basedir             = '/usr'
@@ -378,9 +362,6 @@ class mysql::params {
           $mysql_group         = 'mysql'
           $server_service_name = 'mysqld'
           $socket              = '/var/lib/mysql/mysql.sock'
-          $ssl_ca              = '/etc/mysql/cacert.pem'
-          $ssl_cert            = '/etc/mysql/server-cert.pem'
-          $ssl_key             = '/etc/mysql/server-key.pem'
           $tmpdir              = '/tmp'
           $managed_dirs        = undef
           # mysql::bindings
@@ -451,11 +432,6 @@ class mysql::params {
       'port'                  => '3306',
       'skip-external-locking' => true,
       'socket'                => $mysql::params::socket,
-      'ssl'                   => false,
-      'ssl-ca'                => $mysql::params::ssl_ca,
-      'ssl-cert'              => $mysql::params::ssl_cert,
-      'ssl-key'               => $mysql::params::ssl_key,
-      'ssl-disable'           => false,
       'thread_cache_size'     => '8',
       'thread_stack'          => '256K',
       'tmpdir'                => $mysql::params::tmpdir,

--- a/spec/classes/mycnf_template_spec.rb
+++ b/spec/classes/mycnf_template_spec.rb
@@ -47,28 +47,6 @@ describe 'mysql::server' do
         it { is_expected.to contain_file('mysql-config-file').with_content(%r{ssl = false}) }
       end
 
-      describe 'ssl set to false filters out ssl options' do
-        let(:params) { { override_options: { 'mysqld' => { 'ssl' => false, 'ssl-disable' => false, 'ssl-key' => '/etc/key.pem' } } } }
-
-        it { is_expected.to contain_file('mysql-config-file').with_content(%r{ssl = false}) }
-        it { is_expected.to contain_file('mysql-config-file').without_content(%r{ssl-key}) }
-      end
-
-      # ssl-disable (and ssl) are special cased within mysql.
-      describe 'possibility of disabling ssl completely' do
-        let(:params) { { override_options: { 'mysqld' => { 'ssl' => true, 'ssl-disable' => true } } } }
-
-        it { is_expected.to contain_file('mysql-config-file').without_content(%r{ssl = true}) }
-      end
-
-      describe 'ssl-disable filters other ssl options' do
-        let(:params) { { override_options: { 'mysqld' => { 'ssl' => true, 'ssl-disable' => true, 'ssl-key' => '/etc/key.pem' } } } }
-
-        it { is_expected.to contain_file('mysql-config-file').without_content(%r{ssl = true}) }
-        it { is_expected.to contain_file('mysql-config-file').without_content(%r{ssl-disable}) }
-        it { is_expected.to contain_file('mysql-config-file').without_content(%r{ssl-key}) }
-      end
-
       describe 'a non ssl option set to true' do
         let(:params) { { override_options: { 'mysqld' => { 'test' => true } } } }
 

--- a/templates/my.cnf.epp
+++ b/templates/my.cnf.epp
@@ -4,9 +4,7 @@
 <% if type($v[1]) =~ Type[Hash] { -%>
 [<%= $v[0] %>]
 <%sort($v[1].map |$key, $value| { [$key, $value] }).map |$vi| { -%>
-<%- if ($vi[0] == 'ssl-disable') or ($vi[0] =~ /^ssl/ and $v[1]['ssl-disable'] == true) or ($vi[0] =~ /^ssl-/ and $v[1]['ssl'] == false) { -%>
-<%- next -%>
-<%- } elsif $vi[1] == true or $vi[1] == '' { -%>
+<%- if $vi[1] == true or $vi[1] == '' { -%>
 <%= $vi[0] %>
 <%- } elsif type($vi[1]) =~ Type[Array] { -%>
 <%- $vi[1].each |$vii| { -%>

--- a/templates/my.cnf.epp
+++ b/templates/my.cnf.epp
@@ -4,9 +4,7 @@
 <% if type($v[1]) =~ Type[Hash] { -%>
 [<%= $v[0] %>]
 <%sort($v[1].map |$key, $value| { [$key, $value] }).map |$vi| { -%>
-<%- if ($vi[0] == 'ssl-disable') or ($vi[0] =~ /^ssl/ and $v[1]['ssl-disable'] == true) or ($vi[0] =~ /^ssl-/ and $v[1]['ssl'] == false) { -%>
-<%- next -%>
-<%- } elsif $vi[1] == true or $vi[1] == '' { -%>
+<%- if $vi[1] == true or $vi[1] == '' { -%>
 <%= $vi[0] -%>
 <%- } elsif type($vi[1]) =~ Type[Array] { -%>
 <%- $vi[1].each |$vii| { -%>


### PR DESCRIPTION
## Summary
:warning: This change is not backwards compatible, as it alters the default settings. Affected users may need to check the `server::override_options` setting and adjust it to suit their requirements.

Changes the `$default_options` in `params.pp` to relay on the default on the binaries of mysql and mariadb.

* MariaDB <= 11.4 had SSL disabled per default.
* MariaDB >= 11.4 enabled zero config ssl
  * See https://mariadb.org/mission-impossible-zero-configuration-ssl
* MySQL 8.4 brings selfsinged certs and fallsback to no ssl per default.

Removes undocumented `ssl-disable` handling in `templates/my.cnf.epp`. Users should set unwanted values to `undef` instead.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Closes #1670
Closes #1674

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (via pupept on RHEL9 with MariaDB 12.3)
