### PR TITLE
Respect ensure when managing xtrabackup backup package

### DIFF
--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -35,7 +35,7 @@ class mysql::backup::xtrabackup (
   String[1]                                     $backupmethod_package     = $mysql::params::xtrabackup_package_name,
   Array[String]                                 $excludedatabases = [],
 ) inherits mysql::params {
-  stdlib::ensure_packages($backupmethod_package)
+  stdlib::ensure_packages($backupmethod_package, { 'ensure' => $ensure })
 
   $backuppassword_unsensitive = if $backuppassword =~ Sensitive {
     $backuppassword.unwrap
@@ -174,8 +174,10 @@ class mysql::backup::xtrabackup (
     require => Package[$backupmethod_package],
   }
 
+  $backupdir_ensure = $ensure ? { 'absent' => 'absent', default => 'directory' }
+
   file { $backupdir:
-    ensure => 'directory',
+    ensure => $backupdir_ensure,
     mode   => $backupdirmode,
     owner  => $backupdirowner,
     group  => $backupdirgroup,

--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -35,7 +35,7 @@ class mysql::backup::xtrabackup (
   String[1]                                     $backupmethod_package     = $mysql::params::xtrabackup_package_name,
   Array[String]                                 $excludedatabases = [],
 ) inherits mysql::params {
-  stdlib::ensure_packages($backupmethod_package)
+  stdlib::ensure_packages($backupmethod_package, { 'ensure' => $ensure })
 
   $backuppassword_unsensitive = if $backuppassword =~ Sensitive {
     $backuppassword.unwrap
@@ -168,8 +168,10 @@ class mysql::backup::xtrabackup (
     require => Package[$backupmethod_package],
   }
 
+  $backupdir_ensure = $ensure ? { 'absent' => 'absent', default => 'directory' }
+
   file { $backupdir:
-    ensure => 'directory',
+    ensure => $backupdir_ensure,
     mode   => $backupdirmode,
     owner  => $backupdirowner,
     group  => $backupdirgroup,

--- a/spec/classes/mysql_backup_xtrabackup_spec.rb
+++ b/spec/classes/mysql_backup_xtrabackup_spec.rb
@@ -316,6 +316,55 @@ describe 'mysql::backup::xtrabackup' do
           )
         end
       end
+
+      package = if facts[:os]['family'] == 'RedHat'
+                  if Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '8') >= 0
+                    'percona-xtrabackup-24'
+                  else
+                    'percona-xtrabackup'
+                  end
+                elsif facts[:os]['name'] == 'Debian'
+                  'percona-xtrabackup-24'
+                elsif facts[:os]['name'] == 'Ubuntu'
+                  if Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '20') < 0 &&
+                     Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '16') >= 0
+                    'percona-xtrabackup'
+                  else
+                    'percona-xtrabackup-24'
+                  end
+                elsif facts[:os]['family'] == 'Suse'
+                  'xtrabackup'
+                else
+                  'percona-xtrabackup'
+                end
+
+      context 'with ensure => present' do
+        let(:params) do
+          { ensure: 'present' }.merge(default_params)
+        end
+
+        it 'installs the backup method package' do
+          expect(subject).to contain_package(package).with_ensure('installed')
+        end
+
+        it 'manages the backup directory' do
+          expect(subject).to contain_file('/tmp').with_ensure('directory')
+        end
+      end
+
+      context 'with ensure => absent' do
+        let(:params) do
+          { ensure: 'absent' }.merge(default_params)
+        end
+
+        it 'removes the backup method package' do
+          expect(subject).to contain_package(package).with_ensure('absent')
+        end
+
+        it 'removes the backup directory' do
+          expect(subject).to contain_file('/tmp').with_ensure('absent')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
Fixes `mysql::backup::xtrabackup` so that the backup method package and backup directory are removed when the class is declared with `ensure => absent`.

## Additional Context
- [x] Root cause and the steps to reproduce.
  - Root cause: `stdlib::ensure_packages($backupmethod_package)` was called without an options hash, defaulting the package to `ensure => present` regardless of the class `$ensure` parameter.
  - The $backupdir file resource was hardcoded to ensure => 'directory', which ignores the class's $ensure parameter.
  - Reproduce: Declare `mysql::server::backup` (with `backupmethod => 'xtrabackup'`) and `ensure => absent`, run `puppet apply`, and observe that the backup method package remains installed and still manages the backup directory.
- [x] Thought process behind the implementation.
  - The class already exposes an `$ensure` parameter (`Enum['present', 'absent']`) used for the other backup resources. Passing it through to `stdlib::ensure_packages` and file makes the package and directory lifecycle consistent with the rest of the backup resources without introducing a new parameter.
