### PR TITLE
Squelch assorted test complaints

### DIFF
--- a/spec/acceptance/types/mysql_grant_spec.rb
+++ b/spec/acceptance/types/mysql_grant_spec.rb
@@ -282,7 +282,7 @@ describe 'mysql_grant' do
 
         exec { 'mysql-create-table':
           command     => '/usr/bin/#{mysql_cmd} -NBe "CREATE TABLE foo.bar (name VARCHAR(20))"',
-          environment => "HOME=${::root_home}",
+          environment => "HOME=${facts['root_home']}",
           unless      => '/usr/bin/#{mysql_cmd} -NBe "SELECT 1 FROM foo.bar LIMIT 1;"',
           require     => Mysql_database['foo'],
         }
@@ -334,12 +334,12 @@ describe 'mysql_grant' do
           user       => "web@${dbSubnet}",
           require    => Mysql_user["web@${dbSubnet}"],
         }
-        mysql_user { "web@${::networking['ip']}":
+        mysql_user { "web@${facts['networking']['ip']}":
           ensure => present,
         }
-        mysql_grant { "web@${::networking['ip']}/*.*":
-          user       => "web@${::networking['ip']}",
-          require    => Mysql_user["web@${::networking['ip']}"],
+        mysql_grant { "web@${facts['networking']['ip']}/*.*":
+          user       => "web@${facts['networking']['ip']}",
+          require    => Mysql_user["web@${facts['networking']['ip']}"],
         }
         mysql_user { 'web@localhost':
           ensure => present,

--- a/spec/classes/mysql_server_account_security_spec.rb
+++ b/spec/classes/mysql_server_account_security_spec.rb
@@ -16,8 +16,8 @@ describe 'mysql::server::account_security' do
         let(:facts) do
           override_facts(
             super(),
-            'root_home' => '/root',
-            'networking' => {
+            root_home: '/root',
+            networking: {
               'fqdn' => 'myhost.mydomain',
               'hostname' => 'myhost',
             },
@@ -55,8 +55,8 @@ describe 'mysql::server::account_security' do
         let(:facts) do
           override_facts(
             super(),
-            'root_home' => '/root',
-            'networking' => {
+            root_home: '/root',
+            networking: {
               'fqdn' => 'localhost',
               'hostname' => 'localhost',
             },
@@ -79,8 +79,8 @@ describe 'mysql::server::account_security' do
         let(:facts) do
           override_facts(
             super(),
-            'root_home' => '/root',
-            'networking' => {
+            root_home: '/root',
+            networking: {
               'fqdn' => 'localhost.localdomain',
               'hostname' => 'localhost',
             },

--- a/spec/unit/facter/mysql_server_id_spec.rb
+++ b/spec/unit/facter/mysql_server_id_spec.rb
@@ -14,7 +14,7 @@ describe Facter::Util::Fact.to_s do
       end
 
       it do
-        Facter.fact(:mysql_server_id).value.to_s.should == '241857808'
+        expect(Facter.fact(:mysql_server_id).value).to eq(241_857_808)
       end
     end
 
@@ -24,7 +24,7 @@ describe Facter::Util::Fact.to_s do
       end
 
       it do
-        Facter.fact(:mysql_server_id).value.to_s.should == '1'
+        expect(Facter.fact(:mysql_server_id).value).to eq(1)
       end
     end
 
@@ -34,7 +34,7 @@ describe Facter::Util::Fact.to_s do
       end
 
       it do
-        Facter.fact(:mysql_server_id).value.to_s.should == ''
+        expect(Facter.fact(:mysql_server_id).value).to eq(nil)
       end
     end
   end

--- a/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
@@ -25,7 +25,7 @@ describe Puppet::Type.type(:mysql_database).provider(:mysql) do
   end
 
   before :each do
-    allow(Facter.fact(:value)).to receive(:root_home).and_return('/root')
+    allow(Facter).to receive(:value).with(:root_home).and_return('/root')
     allow(Puppet::Util).to receive(:which).with('mysql').and_return('/usr/bin/mysql')
     allow(File).to receive(:file?).with('/root/.my.cnf').and_return(true)
     allow(provider.class).to receive(:mysql_caller).with('show databases', 'regular').and_return('new_database')


### PR DESCRIPTION
When running module tests locally, random issues with the test framework, some of which would have invalidated the tests they were part of, caused almost as many lines of error spam during a test run as a clean test run itself would have produced.  Fix these aggravating leftover issues and assorted deprecations so the tests are not as annoying to use.

## Summary
- Remove deprecated `should` syntax in favor of `expect` to squelch warnings like `Deprecation Warnings:  Using 'should' from rspec-expectations' old ':should' syntax without explicitly enabling the syntax is deprecated.`
- Fix a broken Facter mock so it no longer produces 45 lines of warnings like `WARNING: An expectation of ':root_home' was set on 'nil'. To allow expectations on 'nil'...` by attempting to mock methods that do not exist
- Top-level fact names are symbols; stop merging string names into the facts hash and merge symbols instead.  The string names do not merge with the symbols they replace, but they do take precedence over symbol names during retrieval; so all of the data attached to the existing symbol-named fact is effectively lost, and you get fun errors like `Could not retrieve fact networking.ip`
- Convert legacy facts-as-top-scope-variable references in acceptance tests, since these all go away as of Puppet 8.  These did not produce error output that I could see, since I can't run the acceptance tests in my environment, but came up while looking for the `root_home` culprit above.

## Checklist
- [x] 🟢 Spec tests.
