### PR TITLE
Quash my.cnf.epp template's extra-newline issues

### DIFF
--- a/manifests/backup/mysqldump.pp
+++ b/manifests/backup/mysqldump.pp
@@ -112,7 +112,6 @@ class mysql::backup::mysqldump (
     'include_routines' => $include_routines,
   }
 
-  # TODO: use EPP instead of ERB, as EPP can handle Data of Type Sensitive without further ado
   file { 'mysqlbackup.sh':
     ensure  => $ensure,
     path    => '/usr/local/sbin/mysqlbackup.sh',

--- a/manifests/backup/xtrabackup.pp
+++ b/manifests/backup/xtrabackup.pp
@@ -175,7 +175,6 @@ class mysql::backup::xtrabackup (
     group  => $backupdirgroup,
   }
 
-  # TODO: use EPP instead of ERB, as EPP can handle Data of Type Sensitive without further ado
   $parameters = {
     'innobackupex_args' => mysql::innobackupex_args($backupuser, $backupcompress, $backuppassword_unsensitive, $backupdatabases, $optional_args),
     'backuprotate' => $backuprotate,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -99,7 +99,7 @@ class mysql::server (
   Optional[Array[String[1]]]                                            $install_options         = undef,
   Variant[Boolean, String[1]]                                           $manage_config_file      = true,
   Mysql::Options                                                        $options                 = {},
-  Hash                                                                  $override_options        = {},
+  Mysql::OverrideOptions                                                $override_options        = {},
   Variant[Enum['present','absent'], Pattern[/(\d+)[\.](\d+)[\.](\d+)/]] $package_ensure          = 'present',
   Boolean                                                               $package_manage          = true,
   String[1]                                                             $package_name            = $mysql::params::server_package_name,

--- a/manifests/server/root_password.pp
+++ b/manifests/server/root_password.pp
@@ -44,7 +44,6 @@ class mysql::server::root_password {
   }
 
   if $mysql::server::create_root_my_cnf and $root_password_set {
-    # TODO: use EPP instead of ERB, as EPP can handle Data of Type Sensitive without further ado
     file { "${facts['root_home']}/.my.cnf":
       content => epp('mysql/my.cnf.pass.epp',$parameters),
       owner   => 'root',

--- a/spec/classes/mycnf_template_spec.rb
+++ b/spec/classes/mycnf_template_spec.rb
@@ -10,11 +10,44 @@ describe 'mysql::server' do
       end
 
       context 'normal entry' do
-        let(:params) { { override_options: { 'mysqld' => { 'socket' => '/var/lib/mysql/mysql.sock' } } } }
+        let(:params) do
+          {
+            'override_options' => {
+              'mysqld' => {
+                'socket' => '/var/lib/mysql/mysql.sock',
+              },
+              'mysqld-5.7' => {
+                'myisam-recover-options' => :undef,
+              },
+              'mysqld-5.6' => {
+                'myisam-recover-options' => :undef,
+              },
+              'mysqld-5.5' => :undef,
+            },
+          }
+        end
 
         it do
-          expect(subject).to contain_file('mysql-config-file').with(mode: '0644',
-                                                                    selinux_ignore_defaults: true).with_content(%r{socket = /var/lib/mysql/mysql.sock})
+          expect(subject).to contain_file('mysql-config-file')
+            .with_mode('0644')
+            .with_selinux_ignore_defaults(true)
+            .with_content(%r{socket = /var/lib/mysql/mysql.sock})
+        end
+        it 'allows undef values in key/value overrides to knock keys out of default_options' do
+          expect(subject).to contain_file('mysql-config-file')
+            .without_content(%r{myisam-recover-options})
+        end
+        it 'allows undef values in section overrides to knock sections out of default_options' do
+          expect(subject).to contain_file('mysql-config-file')
+            .without_content(%r{\[mysqld-5.5\]})
+        end
+        it 'contains no blank lines between entries within a section' do
+          expect(subject).to contain_file('mysql-config-file')
+            .without_content(%r{\w$\R(\R)+^\w})
+        end
+        it 'contains exactly one blank line between any two sections' do
+          expect(subject).to contain_file('mysql-config-file')
+            .without_content(%r{\w$\R\R(\R)+^\[})
         end
       end
 

--- a/templates/my.cnf.epp
+++ b/templates/my.cnf.epp
@@ -1,25 +1,38 @@
 ### MANAGED BY PUPPET ###
 
-<% sort($options.map |$key, $value| { [$key, $value] }).map |$v| { -%>
-<% if type($v[1]) =~ Type[Hash] { -%>
-[<%= $v[0] %>]
-<%sort($v[1].map |$key, $value| { [$key, $value] }).map |$vi| { -%>
-<%- if ($vi[0] == 'ssl-disable') or ($vi[0] =~ /^ssl/ and $v[1]['ssl-disable'] == true) or ($vi[0] =~ /^ssl-/ and $v[1]['ssl'] == false) { -%>
-<%- next -%>
-<%- } elsif $vi[1] == true or $vi[1] == '' { -%>
-<%= $vi[0] -%>
-<%- } elsif type($vi[1]) =~ Type[Array] { -%>
-<%- $vi[1].each |$vii| { -%>
-<%-$base = $vi[0]-%>
-<%= $base %> = <%= $vii %>
-<%- } -%>
-<%- } elsif !($vi[1] ==nil or $vi[1]=='' or $vi[1]==undef) { -%>
-<%-$base = $vi[0]-%>
-<%= $base %> = <%= $vi[1] -%>
-<% } %>
-<% } %>
-<% } %>
-<% } %>
-<% if $includedir and $includedir != '' { -%>
+<%- Array.new($options).sort.each |$section_and_contents| {
+      [$section, $contents] = $section_and_contents
+      unless $contents =~ Hash {
+        next
+      } else { -%>
+[<%= $section %>]
+<%-     Array.new($contents).sort.each |$key_and_value| {
+          [$key, $value] = $key_and_value
+          if
+            # Always discard `ssl-disable`; it's a module feature, not a valid config key, and
+            # we never include it even if it's set to `false`
+            ($key == 'ssl-disable')
+            # If `ssl-disable` is true, discard ALL ssl-related keys, including `ssl`
+            or ($key =~ /^ssl/ and $contents['ssl-disable'])
+            # If `ssl` is specifically `false` (not unset or `undef`), discard all
+            # ssl-related keys EXCEPT `ssl`
+            or ($key =~ /^ssl-/ and $contents['ssl'] == false)
+          {
+            next
+          } elsif $value in [true, ''] { -%>
+<%= $key %>
+<%-       } elsif $value =~ Array {
+            $value.each |$each_value| { -%>
+<%= $key %> = <%= $each_value %>
+<%-         }
+          } elsif $value !~ Undef { -%>
+<%= $key %> = <%= $value %>
+<%-       } -%>
+<%# No line suppression dash below so we get a blank line at the end of each section -%>
+<%-     } %>
+<%-   } -%>
+<%# No line suppression dash below so we get a second blank line before includedir -%>
+<%- } %>
+<%- unless $includedir.empty { -%>
 !includedir <%= $includedir %>
-<% } -%>
+<%- } -%>

--- a/types/overrideoptions.pp
+++ b/types/overrideoptions.pp
@@ -1,0 +1,6 @@
+# @summary A hash of options to merge with the default options.  Sections and keys can be knocked
+#   out of the final config file by setting their value to `undef`.
+type Mysql::OverrideOptions = Hash[
+  String,
+  Optional[Hash],
+]


### PR DESCRIPTION
## Summary
The my.cnf.epp template was not converted from ERB to EPP very well, with seemingly little attention paid to the template bracketry's newline suppression.  It inserts tons of random newlines into the body of the config file in weird random places, causing unnecessary diffs when upgrading from prior module versions and resulting in a weirdly sparse config layout that's more difficult to read.

The template logic was also obtuse and not especially easy to read or reason about, nor was it particularly efficient, producing a lot of values that would have been immediately discarded, prefering obtuse approaches, and failing to embrace the side-effects through which template rendering inherently works.  These should be somewhat better now.  Ruby and Puppet are related languages, but not identical; what makes sense in one will not always make sense in the other.

Also remove a few leftover TODO comments that all cite the aforementioned conversion as a thing that still needs to be done, despite being done already.

## Additional Context
The issue is that while the original ERB template did the sensible thing and added a newlines after every line it added to the output, the translated EPP template for some reason tries to add newlines at loop exit _instead of at line output._  Because not all iterations through a loop add template output, and exiting multiple loops at once (end of a section, end of all sections, etc.), will add newlines for each exited loop, this yields predictably abysmal results.  

Upgrading from a pre-v16.0.0 version of this module (prior to the template's conversion to EPP) to v16.3.0 of this module, with _no other changes of any kind,_ with an `override_options` hash that included the following:
```
mysqld => {
  'sql_mode' => 'NO_UNSIGNED_SUBTRACTION',
  'ssl'      => undef,
  'ssl-ca'   => "/etc/mysql_ssl/cool_cert_bundle.crt",
  'ssl-cert' => "/etc/mysql_ssl/cool_certificate.crt",
  'ssl-key'  => "/etc/mysql_ssl/cool_certificate.key",
'mysqld-5.5'  => {
  'query_cache_limit' => undef,
  'query_cache_size'  => undef,
},
'mysqld-5.6'  => {
  'query_cache_limit' => undef,
  'query_cache_size'  => undef,
},
```
...resulted in diffs that looked like this:
```
@@ -70,8 +74,10 @@
 slow_query_log_file = /data/log/mysql/slow-queries.log
 socket = /data/mysql.sock
 sql_mode = NO_UNSIGNED_SUBTRACTION
+
 ssl-ca = /etc/mysql_ssl/cool_cert_bundle.crt
 ssl-cert = /etc/mysql_ssl/cool_certificate.crt
+
 ssl-key = /etc/mysql_ssl/cool_certificate.key
 sync_binlog = 1
 sysdate_is_now = 1
@@ -83,26 +89,39 @@
 tmpdir = /data/tmp
 user = mysql
 
+
 [mysqld-5.0]
 myisam-recover = BACKUP
 
+
 [mysqld-5.1]
 myisam-recover = BACKUP
 
+
 [mysqld-5.5]
 myisam-recover = BACKUP
 
+
+
+
 [mysqld-5.6]
 myisam-recover-options = BACKUP
 
+
+
+
```
And to walk through this a little bit, this was: 
- line 77: `'ssl' => false` prints nothing, still adds a newline when we exit that iteration
- line 80: `'ssl-disable' => false` (from default_options in params.pp) prints nothing, still adds a newline when we exit that iteration
- line 92: (end of `mysqld` section): post-v16.x, ending any section adds one more newline
- line 96: (end of `mysqld-5.0` section): post-v16.x, ending any section adds a second newline
- line 100: (end of `mysqld-5.1` section): post-v16.x, ending any section adds a second newline
- line 104: `'query_cache_limit' => undef` prints nothing, still adds a newline when we exit that iteration
- line 105: `'query_cache_size'  => undef` prints nothing, still adds a newline when we exit that iteration
- line 106: (end of `mysqld-5.5` section): post-v16.x, ending any section adds a second newline
- line 111: `'query_cache_limit' => undef` prints nothing, still adds a newline when we exit that iteration
- line 112: `'query_cache_size'  => undef` prints nothing, still adds a newline when we exit that iteration
- line 113: (end of `mysqld-5.6` section): post-v16.x, ending any section adds a second newline

This approach to newlines is fundamentally broken.  Newlines should be added whenever we've just printed a line, and should _not be added unless we've added a line or done something significant like end a section_ (though in that case, ideally, we just get one extra, as previously).  This change returns to exactly that approach, exactly like the ERB template used to do; and in addition, adds unit tests to catch this if anyone screws it up again.  

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)