### PR TITLE
Remove Debian 10 from supported OS list

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -39,7 +39,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
         "11",
         "12"
       ]


### PR DESCRIPTION
Debian 10 (Buster) reached end-of-life in June 2024. The litmusimage/debian:10 test image has a systemd/Docker incompatibility that causes MariaDB to fail to start, breaking all acceptance tests on that platform.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)