### PR TITLE
Allow zypper refresh to fail gracefully on SLES

### DIFF
--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -21,7 +21,7 @@ def configure_sles_repos_once
   LitmusHelper.instance.run_shell("zypper --non-interactive --gpg-auto-import-keys ar #{base_url}/non-oss/ opensuse-leap-non-oss || true", expect_failures: true)
   LitmusHelper.instance.run_shell('rpm --import https://supplychain.mariadb.com/MariaDB-Server-GPG-KEY', expect_failures: true)
   LitmusHelper.instance.run_shell("zypper --non-interactive --gpg-auto-import-keys ar https://rpm.mariadb.org/#{mariadb_version}/sles/#{sles_version}/x86_64 mariadb || true", expect_failures: true)
-  LitmusHelper.instance.run_shell('zypper --non-interactive --gpg-auto-import-keys refresh', expect_failures: false)
+  LitmusHelper.instance.run_shell('zypper --non-interactive --gpg-auto-import-keys refresh', expect_failures: true)
   LitmusHelper.instance.apply_manifest("package { 'net-tools-deprecated': ensure => 'latest', }", expect_failures: false)
 
   @sles_repos_configured = true


### PR DESCRIPTION
The zypper refresh command on SLES was aborting the entire test setup when the MariaDB repository was inaccessible due to permission denial. Changing expect_failures to true allows the setup to continue using the openSUSE fallback repositories instead.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)