### PR TITLE
Exclude Debian 10 from acceptance test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,5 @@ jobs:
        contains(github.event.pull_request.labels.*.name, 'allowed-for-ci'))
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      flags: "--nightly --platform-exclude centos-7 --platform-exclude scientific-7 --platform-exclude oraclelinux-7 --platform-exclude almalinux-8 --arch-exclude arm"
+      flags: "--nightly --platform-exclude centos-7 --platform-exclude scientific-7 --platform-exclude oraclelinux-7 --platform-exclude almalinux-8 --platform-exclude debian-10 --arch-exclude arm"
     secrets: "inherit"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,5 +14,5 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      flags: "--nightly --platform-exclude centos-7 --platform-exclude scientific-7 --platform-exclude oraclelinux-7 --platform-exclude almalinux-8 --arch-exclude arm"
+      flags: "--nightly --platform-exclude centos-7 --platform-exclude scientific-7 --platform-exclude oraclelinux-7 --platform-exclude almalinux-8 --platform-exclude debian-10 --arch-exclude arm"
     secrets: "inherit"


### PR DESCRIPTION
## Summary

Debian 10 (Buster) reached end-of-life in June 2024. The `litmusimage/debian:10` Docker container used for CI testing has a known incompatibility with systemd — when the acceptance tests attempt to start MariaDB as a systemd service inside the container, the start operation times out and fails:

```
Error: Systemd start for mariadb failed!
mariadb.service: Start operation timed out. Terminating.
mariadb.service: Failed with result 'timeout'.
Failed to start MariaDB 10.3.39 database server.
```

This causes all acceptance tests on Debian 10 to fail during setup — before any test examples run — producing noisy CI failures caused by the test environment rather than any issue with the module itself.

## Changes

Adds `--platform-exclude debian-10` to the `flags` parameter in both:
- `.github/workflows/ci.yml`
- `.github/workflows/nightly.yml`

This excludes Debian 10 from the acceptance test matrix generated by `matrix_from_metadata_v3`, preventing the platform from being provisioned and tested in CI.

## Why This Approach

The root cause is a Docker/systemd incompatibility in `litmusimage/debian:10` — Docker containers do not run a full init system by default, so systemd-managed services like MariaDB cannot start. This is an infrastructure limitation outside the module's control.

This is consistent with how other EOL platforms are already excluded in this repo — `centos-7`, `scientific-7`, `oraclelinux-7` and `almalinux-8` are all excluded using the same `--platform-exclude` mechanism.

The correct long-term fix would be to update `litmusimage/debian:10` in the `voxpupuli/litmusimage` repository, however given that Debian 10 is end-of-life and unlikely to receive further investment, excluding it from CI is the more pragmatic approach.

**This change does not affect the module's support for Debian 10 in production.** The module's Puppet code is unchanged and Debian 10 remains listed in `metadata.json` as a supported OS. Real Debian 10 servers with a proper init system are unaffected — the incompatibility is specific to the Docker test environment.

## Impact

- Debian 10 acceptance tests: excluded from CI (previously failing)
- All other OS acceptance tests: unaffected
- Module behaviour on Debian 10 in production: unaffected

## Related

- Preceded by: Allow zypper refresh to fail gracefully on SLES (merged)

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.