### PR TITLE
Exclude Ubuntu 20.04 from acceptance test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,5 @@ jobs:
        contains(github.event.pull_request.labels.*.name, 'allowed-for-ci'))
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      flags: "--nightly --platform-exclude centos-7 --platform-exclude scientific-7 --platform-exclude oraclelinux-7 --platform-exclude almalinux-8 --platform-exclude debian-10 --arch-exclude arm"
+      flags: "--nightly --platform-exclude centos-7 --platform-exclude scientific-7 --platform-exclude oraclelinux-7 --platform-exclude almalinux-8 --platform-exclude debian-10 --platform-exclude ubuntu-2004 --arch-exclude arm"
     secrets: "inherit"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,5 +14,5 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      flags: "--nightly --platform-exclude centos-7 --platform-exclude scientific-7 --platform-exclude oraclelinux-7 --platform-exclude almalinux-8 --platform-exclude debian-10 --arch-exclude arm"
+      flags: "--nightly --platform-exclude centos-7 --platform-exclude scientific-7 --platform-exclude oraclelinux-7 --platform-exclude almalinux-8 --platform-exclude debian-10 --platform-exclude ubuntu-2004 --arch-exclude arm"
     secrets: "inherit"


### PR DESCRIPTION
Ubuntu 20.04 (Focal) reached end-of-life in April 2025. The litmusimage/ubuntu:20.04 Docker container has the same systemd incompatibility as debian:10 — when acceptance tests attempt to start MariaDB as a systemd service inside the container, the start operation times out:

  Error: Systemd start for mariadb failed!
  mariadb.service: Failed with result 'timeout'.
  Failed to start MariaDB 10.3.39 database server.

This is consistent with the previous exclusion of debian-10 for the same reason.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)