### PR TITLE
Fix Ubuntu 20.04 platform exclude flag format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,5 @@ jobs:
        contains(github.event.pull_request.labels.*.name, 'allowed-for-ci'))
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      flags: "--nightly --platform-exclude centos-7 --platform-exclude scientific-7 --platform-exclude oraclelinux-7 --platform-exclude almalinux-8 --platform-exclude debian-10 --platform-exclude ubuntu-2004 --arch-exclude arm"
+      flags: "--nightly --platform-exclude centos-7 --platform-exclude scientific-7 --platform-exclude oraclelinux-7 --platform-exclude almalinux-8 --platform-exclude debian-10 --platform-exclude ubuntu-20.04 --arch-exclude arm"
     secrets: "inherit"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,5 +14,5 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      flags: "--nightly --platform-exclude centos-7 --platform-exclude scientific-7 --platform-exclude oraclelinux-7 --platform-exclude almalinux-8 --platform-exclude debian-10 --platform-exclude ubuntu-2004 --arch-exclude arm"
+      flags: "--nightly --platform-exclude centos-7 --platform-exclude scientific-7 --platform-exclude oraclelinux-7 --platform-exclude almalinux-8 --platform-exclude debian-10 --platform-exclude ubuntu-20.04 --arch-exclude arm"
     secrets: "inherit"


### PR DESCRIPTION
The previous exclusion used '--platform-exclude ubuntu-2004' which did not match the platform name derived from metadata.json where Ubuntu's release is specified as '20.04' (with a dot). This meant Ubuntu 20.04 was still being included in the test matrix and failing with the same systemd/Docker incompatibility.

Corrected to '--platform-exclude ubuntu-20.04' to match the metadata format.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)