### PR TITLE
Remove inaccessible MariaDB repo from SLES CI setup

### DIFF
--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -8,19 +8,16 @@ class LitmusHelper
 end
 
 # TEMPORARY FIX for unregistered SLES CI systems with no repos configured.
-# Configures openSUSE Leap and MariaDB repos to enable package installation.
+# Configures openSUSE Leap repos to enable package installation.
 # DO NOT use in production - not enterprise-supported.
 def configure_sles_repos_once
   return if @sles_repos_configured || os[:family] != 'sles'
 
   sles_version = os[:release].to_i
   base_url = (sles_version == 12) ? 'http://download.opensuse.org/distribution/leap/42.3/repo' : 'http://download.opensuse.org/distribution/leap/15.6/repo'
-  mariadb_version = (sles_version == 12) ? '10.6' : '10.11'
 
   LitmusHelper.instance.run_shell("zypper --non-interactive --gpg-auto-import-keys ar #{base_url}/oss/ opensuse-leap-oss || true", expect_failures: true)
   LitmusHelper.instance.run_shell("zypper --non-interactive --gpg-auto-import-keys ar #{base_url}/non-oss/ opensuse-leap-non-oss || true", expect_failures: true)
-  LitmusHelper.instance.run_shell('rpm --import https://supplychain.mariadb.com/MariaDB-Server-GPG-KEY', expect_failures: true)
-  LitmusHelper.instance.run_shell("zypper --non-interactive --gpg-auto-import-keys ar https://rpm.mariadb.org/#{mariadb_version}/sles/#{sles_version}/x86_64 mariadb || true", expect_failures: true)
   LitmusHelper.instance.run_shell('zypper --non-interactive --gpg-auto-import-keys refresh', expect_failures: true)
   LitmusHelper.instance.apply_manifest("package { 'net-tools-deprecated': ensure => 'latest', }", expect_failures: false)
 


### PR DESCRIPTION
The `configure_sles_repos_once` function in `spec_helper_acceptance_local.rb` previously registered the official MariaDB RPM repository (rpm.mariadb.org) and imported its GPG key as part of SLES test setup.

However, this repository requires a paid subscription to access. In CI, the environment has no credentials for it, causing zypper to receive a 403 Permission Denied response when attempting to fetch repo metadata. This resulted in zypper exiting with code 106 (repository error) on every subsequent package install — including `mariadb` itself — even though the package is available from the openSUSE Leap repositories that are also configured by this function.

The MariaDB repo was effectively non-functional in CI: no packages were ever successfully sourced from it, and its presence was causing all SLES 15 acceptance tests to fail at the `include mysql::server` step.

Changes:
- Removed the `mariadb_version` variable (used only to construct the now-removed repo URL)
- Removed the MariaDB GPG key import line (`rpm --import https://supplychain.mariadb.com/MariaDB-Server-GPG-KEY`)
- Removed the zypper repo registration line for rpm.mariadb.org
- Updated the function comment to no longer reference MariaDB repos

The openSUSE Leap OSS/non-OSS repos remain configured and provide all required MariaDB packages for SLES CI testing.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)