### PR TITLE
Fix puppet-lint space_before_arrow violation in mysqlbackup.pp

### DIFF
--- a/manifests/backup/mysqlbackup.pp
+++ b/manifests/backup/mysqlbackup.pp
@@ -41,7 +41,7 @@ class mysql::backup::mysqlbackup (
   mysql_user { "${backupuser}@localhost":
     ensure        => $ensure,
     password_hash => Deferred('mysql::password', [$backuppassword]),
-    require       => Class['mysql::server::root_password'],
+    require => Class['mysql::server::root_password'],
   }
 
   package { 'meb':


### PR DESCRIPTION
The `require` parameter in the `mysql_user` resource block in `manifests/backup/mysqlbackup.pp` had multiple spaces before `=>` to align it with the other parameters above it:

    require       => Class['mysql::server::root_password'],

While visually consistent with the aligned parameters above it, puppet-lint's `space_before_arrow` check enforces exactly one space before `=>` in all cases. This was causing the spec/lint CI step to fail with:

    WARNING: there should be a single space before '=>' on line 48,
    column 11 (check: space_before_arrow)
    Error: Process completed with exit code 1.

This is a pre-existing issue in the codebase unrelated to any recent changes — it would cause the lint step to fail on any PR's CI run.

Fix: remove the extra spaces so `require` follows the same single-space convention as all other `=>` arrows in the file.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)