### PR TITLE
Fix arrow_alignment violation in mysqlbackup.pp

### DIFF
--- a/manifests/backup/mysqlbackup.pp
+++ b/manifests/backup/mysqlbackup.pp
@@ -41,7 +41,7 @@ class mysql::backup::mysqlbackup (
   mysql_user { "${backupuser}@localhost":
     ensure        => $ensure,
     password_hash => Deferred('mysql::password', [$backuppassword]),
-    require => Class['mysql::server::root_password'],
+    require       => Class['mysql::server::root_password'],
   }
 
   package { 'meb':


### PR DESCRIPTION
The `require` parameter in the `mysql_user` resource block was missing alignment spaces, causing puppet-lint's `arrow_alignment` check to fail:

    indentation of => is not properly aligned (expected in column 19,
    but found it in column 13) on line 44 (check: arrow_alignment)

All `=>` arrows within a resource block must align at the same column. The other two parameters in this block already have `=>` at column 19:

    ensure        => $ensure,
    password_hash => Deferred('mysql::password', [$backuppassword]),
    require => Class['mysql::server::root_password'],  ← col 13 (wrong)

Restored the correct spacing so all three arrows align at column 19:

    require       => Class['mysql::server::root_password'],

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)