### PR TITLE
fix: use mysql binary instead of params::provider for SQL import

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -124,7 +124,7 @@ define mysql::db (
 
     if $sql {
       exec { "${dbname}-import":
-        command     => "${import_cat_cmd} ${shell_join($sql)} | ${mysql::params::provider} ${dbname}",
+        command     => "${import_cat_cmd} ${shell_join($sql)} | mysql ${dbname}",
         logoutput   => true,
         environment => "HOME=${facts['root_home']}",
         refreshonly => ! $enforce_sql,

--- a/spec/defines/mysql_db_spec.rb
+++ b/spec/defines/mysql_db_spec.rb
@@ -39,7 +39,7 @@ describe 'mysql::db', type: :define do
         # ' if enforcing #refreshonly'
         expect(subject).to contain_exec('test_db-import').with_refreshonly(false)
         # 'if enforcing #command'
-        expect(subject).to contain_exec('test_db-import').with_command("cat /tmp/test.sql | mysql test_db")
+        expect(subject).to contain_exec('test_db-import').with_command('cat /tmp/test.sql | mysql test_db')
       end
 
       it 'imports sql script with custom command on creation' do
@@ -47,12 +47,12 @@ describe 'mysql::db', type: :define do
         # if enforcing #refreshonly
         expect(subject).to contain_exec('test_db-import').with_refreshonly(false)
         # if enforcing #command
-        expect(subject).to contain_exec('test_db-import').with_command("zcat /tmp/test.sql | mysql test_db")
+        expect(subject).to contain_exec('test_db-import').with_command('zcat /tmp/test.sql | mysql test_db')
       end
 
       it 'imports sql scripts when more than one is specified' do
         params['sql'] = ['/tmp/test.sql', '/tmp/test_2.sql']
-        expect(subject).to contain_exec('test_db-import').with_command("cat /tmp/test.sql /tmp/test_2.sql | mysql test_db")
+        expect(subject).to contain_exec('test_db-import').with_command('cat /tmp/test.sql /tmp/test_2.sql | mysql test_db')
       end
 
       it 'does not create database' do

--- a/spec/defines/mysql_db_spec.rb
+++ b/spec/defines/mysql_db_spec.rb
@@ -5,21 +5,6 @@ require 'spec_helper'
 describe 'mysql::db', type: :define do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      provider = if facts[:os]['family'] == 'RedHat'
-                   'mariadb'
-                 elsif facts[:os]['family'] == 'Suse'
-                   'mariadb'
-                 elsif facts[:os]['name'] == 'Debian'
-                   'mariadb'
-                 elsif facts[:os]['name'] == 'Ubuntu'
-                   if Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '20') < 0 &&
-                      Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '16') >= 0
-                     'mysql'
-                   else
-                     'mariadb'
-                   end
-                 end
-
       let(:facts) do
         facts.merge(root_home: '/root')
       end
@@ -54,7 +39,7 @@ describe 'mysql::db', type: :define do
         # ' if enforcing #refreshonly'
         expect(subject).to contain_exec('test_db-import').with_refreshonly(false)
         # 'if enforcing #command'
-        expect(subject).to contain_exec('test_db-import').with_command("cat /tmp/test.sql | #{provider} test_db")
+        expect(subject).to contain_exec('test_db-import').with_command("cat /tmp/test.sql | mysql test_db")
       end
 
       it 'imports sql script with custom command on creation' do
@@ -62,12 +47,12 @@ describe 'mysql::db', type: :define do
         # if enforcing #refreshonly
         expect(subject).to contain_exec('test_db-import').with_refreshonly(false)
         # if enforcing #command
-        expect(subject).to contain_exec('test_db-import').with_command("zcat /tmp/test.sql | #{provider} test_db")
+        expect(subject).to contain_exec('test_db-import').with_command("zcat /tmp/test.sql | mysql test_db")
       end
 
       it 'imports sql scripts when more than one is specified' do
         params['sql'] = ['/tmp/test.sql', '/tmp/test_2.sql']
-        expect(subject).to contain_exec('test_db-import').with_command("cat /tmp/test.sql /tmp/test_2.sql | #{provider} test_db")
+        expect(subject).to contain_exec('test_db-import').with_command("cat /tmp/test.sql /tmp/test_2.sql | mysql test_db")
       end
 
       it 'does not create database' do
@@ -126,7 +111,7 @@ describe 'mysql::db', type: :define do
       ].each do |path|
         it "succeeds when provided '#{path}' as a value to the 'sql' parameter" do
           params['sql'] = [path]
-          expect(subject).to contain_exec('test_db-import').with_command("cat #{path} | #{provider} test_db")
+          expect(subject).to contain_exec('test_db-import').with_command("cat #{path} | mysql test_db")
         end
       end
 


### PR DESCRIPTION
## Summary

- Reverts the `mysql::db` SQL import exec command to use the `mysql` binary directly instead of `${mysql::params::provider}`
- `$mysql::params::provider` is a package/service naming convention (resolves to `mariadb` on RHEL/CentOS/Rocky >= 7), not a CLI binary name — the `mariadb` binary doesn't exist on systems running MariaDB < 10.5
- The `mysql` binary is universally available on all MySQL and MariaDB installations (MariaDB provides it as a compatibility symlink)

## Root Cause

Commit `bb99a9b` changed the SQL import command in `manifests/db.pp` from hardcoded `mysql` to `${mysql::params::provider}`, which resolves to `mariadb` on RHEL-family >= 7. On these systems, the MariaDB packages ship the CLI binary as `mysql`, not `mariadb` (the `mariadb` binary name was only introduced in MariaDB 10.5+ and became primary in 11.0+).

This caused `sh: mariadb: command not found` errors on CentOS-8, Rocky-8, and RedHat-8 nightly acceptance tests:

```
Error: /Stage[main]/Main/Mysql::Db[spec2]/Exec[spec2-import]: Failed to call refresh: sh: mariadb: command not found
```

**Failing tests:**
- `spec/acceptance/01_mysql_db_spec.rb:53` — `mysql::db` with post-sql idempotency
- `spec/acceptance/01_mysql_db_spec.rb:57` — post-sql exit code/stdout check
- `spec/acceptance/types/mysql_grant_spec.rb:694` — grant spec table creation (cascading)
- `spec/acceptance/types/mysql_grant_spec.rb:698` — grant spec table check (cascading)

## Why `mysql` is correct

1. The `mysql` binary exists on **every** MySQL and MariaDB installation — MariaDB provides it as a symlink/wrapper
2. The Ruby provider (`lib/puppet/provider/mysql.rb:49-54`) already handles binary selection correctly — it only uses `mariadb` for MariaDB >= 11.0, defaulting to `mysql` otherwise
3. The `mysql_exec_path` parameter on `mysql::db` already allows users to customize the binary location if needed
4. `$mysql::params::provider` was designed for package/service name selection (e.g., `mariadb-server` package, `mariadb` service), not as a CLI binary name

## Test plan

- [ ] Verify nightly acceptance tests pass on CentOS-8, Rocky-8, RedHat-8 (previously failing with `mariadb: command not found`)
- [ ] Verify `mysql::db` with `sql` parameter works on Debian/Ubuntu (uses `mysql` provider, unaffected)
- [ ] Verify RedHat-9 acceptance tests remain passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)