### PR TITLE
Fix `mysql_*` providers for MariaDB >= 11.4

### DIFF
--- a/lib/puppet/provider/mysql.rb
+++ b/lib/puppet/provider/mysql.rb
@@ -37,34 +37,20 @@ class Puppet::Provider::Mysql < Puppet::Provider
     '/usr/mysql/5.7/lib64',
   ].join(':')
 
-  # rubocop:disable Style/HashSyntax
-  commands :mysql_client     => 'mysql'
-  commands :mariadb_client   => 'mariadb'
-  commands :mysqld_service   => 'mysqld'
-  commands :mariadbd_service => 'mariadbd'
-  commands :mysql_admin      => 'mysqladmin'
-  commands :mariadb_admin    => 'mariadb-admin'
-  # rubocop:enable Style/HashSyntax
+  COMMANDS = {
+    mysql_raw: ['mysql', 'mariadb'],
+    mysqld: ['mysqld', 'mariadbd'],
+    mysqladmin: ['mysqladmin', 'mariadb-admin'],
+  }.freeze
 
-  def self.mysql_raw(*args)
-    if newer_than('mariadb' => '11.0.0') && mysqld_version_string.scan(%r{mariadb}i)
-      return mariadb_client(*args)
-    end
-    mysql_client(*args)
-  end
+  COMMANDS.each_key do |method_name|
+    define_singleton_method(method_name) do |*args|
+      idx = COMMANDS[method_name].each_index.find(-> { 0 }) do |i|
+        respond_to?("#{method_name}#{i}") && command("#{method_name}#{i}")
+      end
 
-  def self.mysqld(*args)
-    if newer_than('mariadb' => '11.0.0') && mysqld_version_string.scan(%r{mariadb}i)
-      return mariadb_client(*args)
+      send("#{method_name}#{idx}", *args)
     end
-    mysqld_service(*args)
-  end
-
-  def self.mysqladmin(*args)
-    if newer_than('mariadb' => '11.0.0') && mysqld_version_string.scan(%r{mariadb}i)
-      return mariadb_client(*args)
-    end
-    mysql_admin(*args)
   end
 
   # Optional defaults file

--- a/lib/puppet/provider/mysql_database/mysql.rb
+++ b/lib/puppet/provider/mysql_database/mysql.rb
@@ -4,7 +4,10 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'mysql'))
 Puppet::Type.type(:mysql_database).provide(:mysql, parent: Puppet::Provider::Mysql) do
   desc 'Manages MySQL databases.'
 
-  commands mysql_raw: 'mysql'
+  superclass::COMMANDS[:mysql_raw].each_with_index do |binary_name, idx|
+    optional_commands "mysql_raw#{idx}": binary_name
+  end
+  confine true: -> { superclass::COMMANDS[:mysql_raw].any? { |binary_name| Puppet::Util.which(binary_name) } }
 
   def self.instances(managed_databases = nil)
     db_list = if managed_databases && !managed_databases.empty?

--- a/lib/puppet/provider/mysql_datadir/mysql.rb
+++ b/lib/puppet/provider/mysql_datadir/mysql.rb
@@ -34,7 +34,10 @@ Puppet::Type.type(:mysql_datadir).provide(:mysql, parent: Puppet::Provider::Mysq
     '/usr/mysql/5.7/bin',
   ].join(':')
 
-  commands mysqld: 'mysqld'
+  superclass::COMMANDS[:mysqld].each_with_index do |binary_name, idx|
+    optional_commands "mysqld#{idx}": binary_name
+  end
+  confine true: -> { superclass::COMMANDS[:mysqld].any? { |binary_name| Puppet::Util.which(binary_name) } }
   optional_commands mysql_install_db: 'mysql_install_db'
   # rubocop:disable Lint/UselessAssignment
   def create

--- a/lib/puppet/provider/mysql_grant/mysql.rb
+++ b/lib/puppet/provider/mysql_grant/mysql.rb
@@ -4,7 +4,10 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'mysql'))
 Puppet::Type.type(:mysql_grant).provide(:mysql, parent: Puppet::Provider::Mysql) do
   desc 'Set grants for users in MySQL.'
 
-  commands mysql_raw: 'mysql'
+  superclass::COMMANDS[:mysql_raw].each_with_index do |binary_name, idx|
+    optional_commands "mysql_raw#{idx}": binary_name
+  end
+  confine true: -> { superclass::COMMANDS[:mysql_raw].any? { |binary_name| Puppet::Util.which(binary_name) } }
 
   def self.instances(managed_users = nil)
     instance_configs = {}

--- a/lib/puppet/provider/mysql_plugin/mysql.rb
+++ b/lib/puppet/provider/mysql_plugin/mysql.rb
@@ -4,7 +4,10 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'mysql'))
 Puppet::Type.type(:mysql_plugin).provide(:mysql, parent: Puppet::Provider::Mysql) do
   desc 'Manages MySQL plugins.'
 
-  commands mysql_raw: 'mysql'
+  superclass::COMMANDS[:mysql_raw].each_with_index do |binary_name, idx|
+    optional_commands "mysql_raw#{idx}": binary_name
+  end
+  confine true: -> { superclass::COMMANDS[:mysql_raw].any? { |binary_name| Puppet::Util.which(binary_name) } }
 
   def self.instances
     mysql_caller('show plugins', 'regular').split("\n").map do |line|

--- a/lib/puppet/provider/mysql_user/mysql.rb
+++ b/lib/puppet/provider/mysql_user/mysql.rb
@@ -3,7 +3,11 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'mysql'))
 Puppet::Type.type(:mysql_user).provide(:mysql, parent: Puppet::Provider::Mysql) do
   desc 'manage users for a mysql database.'
-  commands mysql_raw: 'mysql'
+
+  superclass::COMMANDS[:mysql_raw].each_with_index do |binary_name, idx|
+    optional_commands "mysql_raw#{idx}": binary_name
+  end
+  confine true: -> { superclass::COMMANDS[:mysql_raw].any? { |binary_name| Puppet::Util.which(binary_name) } }
 
   # Build a property_hash containing all the discovered information about MySQL
   # users.

--- a/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_database/mysql_spec.rb
@@ -27,6 +27,7 @@ describe Puppet::Type.type(:mysql_database).provider(:mysql) do
   before :each do
     allow(Facter.fact(:value)).to receive(:root_home).and_return('/root')
     allow(Puppet::Util).to receive(:which).with('mysql').and_return('/usr/bin/mysql')
+    allow(Puppet::Util).to receive(:which).with('mariadb').and_return('/usr/bin/mariadb')
     allow(File).to receive(:file?).with('/root/.my.cnf').and_return(true)
     allow(provider.class).to receive(:mysql_caller).with('show databases', 'regular').and_return('new_database')
     allow(provider.class).to receive(:mysql_caller).with(["show variables like '%_database'", 'new_database'], 'regular').and_return("character_set_database latin1\ncollation_database latin1_swedish_ci\nskip_show_database OFF") # rubocop:disable Layout/LineLength

--- a/spec/unit/puppet/provider/mysql_plugin/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_plugin/mysql_spec.rb
@@ -18,6 +18,7 @@ describe Puppet::Type.type(:mysql_plugin).provider(:mysql) do
   before :each do
     allow(Facter).to receive(:value).with(:root_home).and_return('/root')
     allow(Puppet::Util).to receive(:which).with('mysql').and_return('/usr/bin/mysql')
+    allow(Puppet::Util).to receive(:which).with('mariadb').and_return('/usr/bin/mariadb')
     allow(File).to receive(:file?).with('/root/.my.cnf').and_return(true)
     allow(provider.class).to receive(:mysql_caller).with('show plugins', 'regular').and_return('auth_socket	ACTIVE	AUTHENTICATION	auth_socket.so	GPL')
   end

--- a/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
+++ b/spec/unit/puppet/provider/mysql_user/mysql_spec.rb
@@ -99,7 +99,7 @@ describe Puppet::Type.type(:mysql_user).provider(:mysql) do
     allow(Facter).to receive(:value).with(:mysql_version).and_return('5.6.24')
     provider.class.instance_variable_set(:@mysqld_version_string, '5.6.24')
     allow(Puppet::Util).to receive(:which).with('mysql').and_return('/usr/bin/mysql')
-    allow(Puppet::Util).to receive(:which).with('mysqld').and_return('/usr/sbin/mysqld')
+    allow(Puppet::Util).to receive(:which).with('mariadb').and_return('/usr/bin/mariadb')
     allow(File).to receive(:file?).with('/root/.my.cnf').and_return(true)
     allow(provider.class).to receive(:mysql_caller).with("SELECT CONCAT(User, '@',Host) AS User FROM mysql.user where HOST IS NOT NULL AND HOST != ''", 'regular').and_return('joe@localhost')
     allow(provider.class).to receive(:mysql_caller).with("SELECT MAX_USER_CONNECTIONS, MAX_CONNECTIONS, MAX_QUESTIONS, MAX_UPDATES, SSL_TYPE, SSL_CIPHER, X509_ISSUER, X509_SUBJECT, PASSWORD /*!50508 , PLUGIN */ FROM mysql.user WHERE CONCAT(user, '@', host) = 'joe@localhost'", 'regular').and_return('10	10	10	10					*6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4') # rubocop:disable Layout/LineLength


### PR DESCRIPTION
This PR is created to execute tests for the original PR (https://github.com/puppetlabs/puppetlabs-mysql/pull/1713)